### PR TITLE
Refactoring OneTSP to allow DomDocument to be injected into parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,11 @@ A PHP library for parsing recipe data from HTML.
 Usage
 ------------------------------
 
-Put this library somewhere you can load it from your PHP code. Call `RecipeParser::parse()`, passing in the contents of an HTML file that includes a recipe and, optionally, the URL of the original page, which helps to identify specific parsers to use. The return value is a PHP object containing the recipe's data.
+Put this library somewhere you can load it from your PHP code. Call `RecipeParser::parse()`, passing in the DomDocument object representing the contents of an HTML file that includes a recipe and, optionally, the URL of the original page, which helps to identify specific parsers to use. The return value is a PHP object containing the recipe's data.
 
 ```
-$recipe = RecipeParser::parse($html, $url);
+$doc = RecipeParser_Text::getDomDocument($html);
+$recipe = RecipeParser::parse($doc, $url);
 print_r($recipe);
 ```
 Output:
@@ -126,8 +127,8 @@ Many of the customized parsers will rely heavily on the generalized parsers as s
 ```
 class RecipeParser_Parser_Bhgcom {
 
-    public function parse($html, $url) {
-        $recipe = RecipeParser_Parser_MicrodataSchema::parse($html, $url);
+    public function parse(DomDocument $doc, $url) {
+        $recipe = RecipeParser_Parser_MicrodataSchema::parse($doc, $url);
 
         ...snip...
 

--- a/bin/import_test_boilerplate
+++ b/bin/import_test_boilerplate
@@ -41,7 +41,9 @@ foreach ($argv as $file) {
         \$path = "$file_path";
         \$url  = "$url";
 
-        \$recipe = RecipeParser::parse(file_get_contents(\$path), \$url);
+        \$doc = RecipeParser_Text::getDomDocument(file_get_contents(\$path));
+        \$recipe = RecipeParser::parse(\$doc, \$url);
+
         if (isset(\$_SERVER['VERBOSE'])) print_r(\$recipe);
 
         \$this->assertEquals('', \$recipe->title);

--- a/bin/parse_recipe
+++ b/bin/parse_recipe
@@ -39,7 +39,8 @@ if ($recipe_url) {
 // Parse recipe into a struct
 try {
     $url = RecipeParser_Text::getRecipeUrlFromMetadata($html);
-    $recipe = RecipeParser::parse($html, $url);
+    $doc = RecipeParser_Text::getDomDocument($html);
+    $recipe = RecipeParser::parse($doc, $url);
 } catch (NoMatchingParserException $e) {
     echo "Error: No matching parser (" . $e->getMessage() . ")\n";
     exit(1);

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -10,6 +10,7 @@ set_include_path( '.'
                 );
 
 // Setup UTF-8 handling
-ini_set('default_charset', 'UTF-8');
-ini_set('mbstring.internal_encoding', 'UTF-8');
-ini_set('mbstring.detect_order', 'UTF-8');
+@ini_set('default_charset', 'UTF-8');
+@ini_set('mbstring.internal_encoding', 'UTF-8');
+@ini_set('mbstring.detect_order', 'UTF-8');
+@ini_set('date.timezone', 'UTC');

--- a/lib/RecipeParser.php
+++ b/lib/RecipeParser.php
@@ -77,16 +77,16 @@ class RecipeParser {
         }
     }
 
-
     /**
      * Parse recipe data from an HTML document, returning a data structure that
      * contains structured data about the recipe.
      *
-     * @param string HTML
-     * @param strin URL
+     * @param DomDocument $doc
+     * @param string $url
      * @return object RecipeParser_Recipe
      */
-    static public function parse($html, $url=null) {
+    static public function parse(DOMDocument $doc, $url=null) {
+        $html = $doc->saveHTML();
         $parser = null;
 
         // Search for a registered parser that matches the URL.
@@ -107,7 +107,7 @@ class RecipeParser {
 
         // Initialize the right parser and run it.
         $classname = 'RecipeParser_Parser_' . $parser;
-        $recipe = $classname::parse($html, $url);
+        $recipe = $classname::parse($doc, $url);
         $recipe->url = $url;
         
         return $recipe;

--- a/lib/RecipeParser/Parser/101cookbookscom.php
+++ b/lib/RecipeParser/Parser/101cookbookscom.php
@@ -2,15 +2,12 @@
 
 class RecipeParser_Parser_101cookbookscom {
 
-    static public function parse($html, $url) {
-        $recipe = RecipeParser_Parser_Microformat::parse($html, $url);
-
-        // Turn off libxml errors to prevent mismatched tag warnings.
-        libxml_use_internal_errors(true);
-        $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
-        $doc = new DOMDocument();
-        $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
+    static public function parse(DOMDocument $doc, $url) {
+        // Get all of the standard microformat stuff we can find.
+        $recipe = RecipeParser_Parser_Microformat::parse($doc, $url);
         $xpath = new DOMXPath($doc);
+
+        // OVERRIDES FOR 101COOKBOOKS.COM
 
         // Description
         $description = "";

--- a/lib/RecipeParser/Parser/12tomatoescom.php
+++ b/lib/RecipeParser/Parser/12tomatoescom.php
@@ -2,19 +2,12 @@
 
 class RecipeParser_Parser_12tomatoescom {
 
-    static public function parse($html, $url) {
-
+    static public function parse(DOMDocument $doc, $url) {
         // Get all of the standard microdata stuff we can find.
-        $recipe = RecipeParser_Parser_MicrodataSchema::parse($html, $url);
-
-        // Turn off libxml errors to prevent mismatched tag warnings.
-        libxml_use_internal_errors(true);
-        $doc = new DOMDocument();
-        $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
-        $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
+        $recipe = RecipeParser_Parser_MicrodataSchema::parse($doc, $url);
         $xpath = new DOMXPath($doc);
 
-        // ---- OVERRIDES
+        // OVERRIDES FOR 12TOMATOES.COM
 
         // Title
         $nodes = $xpath->query('//h3//strong');

--- a/lib/RecipeParser/Parser/Aboutcom.php
+++ b/lib/RecipeParser/Parser/Aboutcom.php
@@ -2,18 +2,10 @@
 
 class RecipeParser_Parser_Aboutcom {
 
-    static public function parse($html, $url) {
-
-        // Turn off libxml errors to prevent mismatched tag warnings.
-        libxml_use_internal_errors(true);
-
-        $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
-
-        $doc = new DOMDocument();
-        $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
+    static public function parse(DOMDocument $doc, $url) {
+        // Get all of the standard microdata stuff we can find.
+        $recipe = RecipeParser_Parser_MicrodataSchema::parse($doc, $url);
         $xpath = new DOMXPath($doc);
-
-        $recipe = RecipeParser_Parser_MicrodataSchema::parse($html, $url);
 
         // OVERRIDES FOR ABOUT.COM
 

--- a/lib/RecipeParser/Parser/Allrecipescom.php
+++ b/lib/RecipeParser/Parser/Allrecipescom.php
@@ -2,16 +2,12 @@
 
 class RecipeParser_Parser_Allrecipescom {
 
-    static public function parse($html, $url) {
+    static public function parse(DOMDocument $doc, $url) {
         // Get all of the standard microdata stuff we can find.
-        $recipe = RecipeParser_Parser_MicrodataSchema::parse($html, $url);
-
-        // Turn off libxml errors to prevent mismatched tag warnings.
-        libxml_use_internal_errors(true);
-        $doc = new DOMDocument();
-        $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
-        $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
+        $recipe = RecipeParser_Parser_MicrodataSchema::parse($doc, $url);
         $xpath = new DOMXPath($doc);
+
+        // OVERRIDES FOR ALLRECIPES.COM
 
         // --- Allrecipes allows for custom recipes that use a different
         // --- template than their standard content. This template is not currently

--- a/lib/RecipeParser/Parser/Americastestkitchencom.php
+++ b/lib/RecipeParser/Parser/Americastestkitchencom.php
@@ -2,19 +2,12 @@
 
 class RecipeParser_Parser_Americastestkitchencom {
 
-    static public function parse($html, $url) {
-
+    static public function parse(DOMDocument $doc, $url) {
         // Get all of the standard microdata stuff we can find.
-        $recipe = RecipeParser_Parser_MicrodataSchema::parse($html, $url);
-
-        // Turn off libxml errors to prevent mismatched tag warnings.
-        libxml_use_internal_errors(true);
-        $doc = new DOMDocument();
-        $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
-        $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
+        $recipe = RecipeParser_Parser_MicrodataSchema::parse($doc, $url);
         $xpath = new DOMXPath($doc);
 
-        // --- OVERRIDES
+        // OVERRIDES FOR AMERICASTESTKITCHEN.COM
 
         return $recipe;
     }

--- a/lib/RecipeParser/Parser/Bbccouk.php
+++ b/lib/RecipeParser/Parser/Bbccouk.php
@@ -2,16 +2,12 @@
 
 class RecipeParser_Parser_Bbccouk {
 
-    static public function parse($html, $url) {
-        // Get all of the standard hrecipe stuff we can find.
-        $recipe = RecipeParser_Parser_Microformat::parse($html, $url);
-
-        // Turn off libxml errors to prevent mismatched tag warnings.
-        libxml_use_internal_errors(true);
-        $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
-        $doc = new DOMDocument();
-        $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
+    static public function parse(DOMDocument $doc, $url) {
+        // Get all of the standard microformat stuff we can find.
+        $recipe = RecipeParser_Parser_Microformat::parse($doc, $url);
         $xpath = new DOMXPath($doc);
+
+        // OVERRIDES FOR BDCCO.UK
 
         // Multi-stage ingredients
         $nodes = $xpath->query('//dl[@id="stages"]/*');

--- a/lib/RecipeParser/Parser/Bbcgoodfoodcom.php
+++ b/lib/RecipeParser/Parser/Bbcgoodfoodcom.php
@@ -2,15 +2,12 @@
 
 class RecipeParser_Parser_Bbcgoodfoodcom {
 
-    static public function parse($html, $url) {
-        $recipe = RecipeParser_Parser_MicrodataSchema::parse($html, $url);
-
-        // Turn off libxml errors to prevent mismatched tag warnings.
-        libxml_use_internal_errors(true);
-        $doc = new DOMDocument();
-        $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
-        $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
+    static public function parse(DOMDocument $doc, $url) {
+        // Get all of the standard microdata stuff we can find.
+        $recipe = RecipeParser_Parser_MicrodataSchema::parse($doc, $url);
         $xpath = new DOMXPath($doc);
+
+        // OVERRIDES FOR BDCGOODFOOD.COM
 
         // Ingredients
         $recipe->resetIngredients();           

--- a/lib/RecipeParser/Parser/Bhgcom.php
+++ b/lib/RecipeParser/Parser/Bhgcom.php
@@ -2,14 +2,12 @@
 
 class RecipeParser_Parser_Bhgcom {
 
-    static public function parse($html, $url) {
-        $recipe = RecipeParser_Parser_MicrodataSchema::parse($html, $url);
-
-        libxml_use_internal_errors(true);
-        $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
-        $doc = new DOMDocument();
-        $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
+    static public function parse(DOMDocument $doc, $url) {
+        // Get all of the standard microdata stuff we can find.
+        $recipe = RecipeParser_Parser_MicrodataSchema::parse($doc, $url);
         $xpath = new DOMXPath($doc);
+
+        // OVERRIDES FOR BHG.COM
 
         // Notes -- Collect the non-standard cook times and baking temps,
         // and also any tips/notes that appear at the end of the recipe instructions.

--- a/lib/RecipeParser/Parser/Bigovencom.php
+++ b/lib/RecipeParser/Parser/Bigovencom.php
@@ -2,16 +2,12 @@
 
 class RecipeParser_Parser_Bigovencom {
 
-    static public function parse($html, $url) {
-        // Get all of the standard hrecipe stuff we can find.
-        $recipe = RecipeParser_Parser_Microformat::parse($html, $url);
-
-        // Turn off libxml errors to prevent mismatched tag warnings.
-        libxml_use_internal_errors(true);
-        $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
-        $doc = new DOMDocument();
-        $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
+    static public function parse(DOMDocument $doc, $url) {
+        // Get all of the standard microformat stuff we can find.
+        $recipe = RecipeParser_Parser_Microformat::parse($doc, $url);
         $xpath = new DOMXPath($doc);
+
+        // OVERRIDES FOR BIGOVEN.COM
 
         // Yield
         $nodes = $xpath->query('//*[@name="resizeTo"]');

--- a/lib/RecipeParser/Parser/Bonappetitcom.php
+++ b/lib/RecipeParser/Parser/Bonappetitcom.php
@@ -2,14 +2,12 @@
 
 class RecipeParser_Parser_Bonappetitcom {
 
-    static public function parse($html, $url) {
-        $recipe = RecipeParser_Parser_MicrodataSchema::parse($html, $url);
-
-        libxml_use_internal_errors(true);
-        $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
-        $doc = new DOMDocument();
-        $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
+    static public function parse(DOMDocument $doc, $url) {
+        // Get all of the standard microdata stuff we can find.
+        $recipe = RecipeParser_Parser_MicrodataSchema::parse($doc, $url);
         $xpath = new DOMXPath($doc);
+
+        // OVERRIDES FOR BONAPPETIT.COM
 
         // Ingredients
         $recipe->resetIngredients();

--- a/lib/RecipeParser/Parser/Bravotvcom.php
+++ b/lib/RecipeParser/Parser/Bravotvcom.php
@@ -2,15 +2,11 @@
 
 class RecipeParser_Parser_Bravotvcom {
 
-    static public function parse($html, $url) {
-
+    static public function parse(DOMDocument $doc, $url) {
         $recipe = new RecipeParser_Recipe();
-
-        libxml_use_internal_errors(true);
-        $doc = new DOMDocument();
-        $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
-        $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
         $xpath = new DOMXPath($doc);
+
+        // OVERRIDES FOR BRAVOTV.COM
 
         // Title
         $nodes = $xpath->query('//h3[@class = "title"]');

--- a/lib/RecipeParser/Parser/Chowcom.php
+++ b/lib/RecipeParser/Parser/Chowcom.php
@@ -2,16 +2,12 @@
 
 class RecipeParser_Parser_Chowcom {
 
-    static public function parse($html, $url) {
-        // Get all of the standard bits we can find.
-        $recipe = RecipeParser_Parser_MicrodataSchema::parse($html, $url);
-
-        // Turn off libxml errors to prevent mismatched tag warnings.
-        libxml_use_internal_errors(true);
-        $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
-        $doc = new DOMDocument();
-        $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
+    static public function parse(DOMDocument $doc, $url) {
+        // Get all of the standard microdata stuff we can find.
+        $recipe = RecipeParser_Parser_MicrodataSchema::parse($doc, $url);
         $xpath = new DOMXPath($doc);
+
+        // OVERRIDES FOR CHOW.COM
 
         // Titles include "recipe"
         if (preg_match("/ Recipe( - CHOW.com)?$/", $recipe->title)) {

--- a/lib/RecipeParser/Parser/Cookingchanneltvcom.php
+++ b/lib/RecipeParser/Parser/Cookingchanneltvcom.php
@@ -2,15 +2,11 @@
 
 class RecipeParser_Parser_Cookingchanneltvcom {
 
-    static public function parse($html, $url) {
+    static public function parse(DOMDocument $doc, $url) {
         $recipe = new RecipeParser_Recipe();
-
-        // Turn off libxml errors to prevent mismatched tag warnings.
-        libxml_use_internal_errors(true);
-        $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
-        $doc = new DOMDocument();
-        $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
         $xpath = new DOMXPath($doc);
+
+        // OVERRIDES FOR COOKINGCHANNELTV.COM
 
         // Title
         $nodes = $xpath->query('//*[@class="rTitle fn"]');

--- a/lib/RecipeParser/Parser/Cookingcom.php
+++ b/lib/RecipeParser/Parser/Cookingcom.php
@@ -2,14 +2,12 @@
 
 class RecipeParser_Parser_Cookingcom {
 
-    static public function parse($html, $url) {
-        $recipe = RecipeParser_Parser_MicrodataSchema::parse($html, $url);
-
-        libxml_use_internal_errors(true);
-        $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
-        $doc = new DOMDocument();
-        $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
+    static public function parse(DOMDocument $doc, $url) {
+        // Get all of the standard microdata stuff we can find.
+        $recipe = RecipeParser_Parser_MicrodataSchema::parse($doc, $url);
         $xpath = new DOMXPath($doc);
+
+        // OVERRIDES FOR COOKING.COM
 
         return $recipe;
     }

--- a/lib/RecipeParser/Parser/Cookscom.php
+++ b/lib/RecipeParser/Parser/Cookscom.php
@@ -2,15 +2,11 @@
 
 class RecipeParser_Parser_Cookscom {
 
-    static public function parse($html, $url) {
+    static public function parse(DOMDocument $doc, $url) {
         $recipe = new RecipeParser_Recipe();
-
-        // Turn off libxml errors to prevent mismatched tag warnings.
-        libxml_use_internal_errors(true);
-        $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
-        $doc = new DOMDocument();
-        $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
         $xpath = new DOMXPath($doc);
+
+        // OVERRIDES FOR COOKS.COM
 
         // Title
         $node_list = $doc->getElementsByTagName('title');

--- a/lib/RecipeParser/Parser/Cooksillustratedcom.php
+++ b/lib/RecipeParser/Parser/Cooksillustratedcom.php
@@ -2,15 +2,11 @@
 
 class RecipeParser_Parser_Cooksillustratedcom {
 
-    static public function parse($html, $url) {
-
+    static public function parse(DOMDocument $doc, $url) {
         $recipe = new RecipeParser_Recipe();
-
-        libxml_use_internal_errors(true);
-        $doc = new DOMDocument();
-        $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
-        $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
         $xpath = new DOMXPath($doc);
+
+        // OVERRIDES FOR COOKSILLUSTRATED.COM
 
         // Title
         $nodes = $xpath->query('//div[@id="rightCol"]/h1');

--- a/lib/RecipeParser/Parser/Eatingwellcom.php
+++ b/lib/RecipeParser/Parser/Eatingwellcom.php
@@ -2,15 +2,11 @@
 
 class RecipeParser_Parser_Eatingwellcom {
 
-    static public function parse($html, $url) {
+    static public function parse(DOMDocument $doc, $url) {
         $recipe = new RecipeParser_Recipe();
-
-        // Turn off libxml errors to prevent mismatched tag warnings.
-        libxml_use_internal_errors(true);
-        $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
-        $doc = new DOMDocument();
-        $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
         $xpath = new DOMXPath($doc);
+
+        // OVERRIDES FOR EATINGWELL.COM
 
         // Title
         $nodes = $xpath->query('//h1[@itemprop="name"]');

--- a/lib/RecipeParser/Parser/Elanaspantrycom.php
+++ b/lib/RecipeParser/Parser/Elanaspantrycom.php
@@ -2,14 +2,12 @@
 
 class RecipeParser_Parser_Elanaspantrycom {
 
-    static public function parse($html, $url) {
-        $recipe = RecipeParser_Parser_Microformat::parse($html, $url);
-
-        libxml_use_internal_errors(true);
-        $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
-        $doc = new DOMDocument();
-        $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
+    static public function parse(DOMDocument $doc, $url) {
+        // Get all of the standard microformat stuff we can find.
+        $recipe = RecipeParser_Parser_Microformat::parse($doc, $url);
         $xpath = new DOMXPath($doc);
+
+        // OVERRIDES FOR ELANASPANTRY.COM
 
         if (!$recipe->title) {
             $nodes = $xpath->query('//div[@class="box"]/strong');

--- a/lib/RecipeParser/Parser/Epicuriouscom.php
+++ b/lib/RecipeParser/Parser/Epicuriouscom.php
@@ -2,18 +2,12 @@
 
 class RecipeParser_Parser_Epicuriouscom {
 
-    static public function parse($html, $url) {
-        $recipe = RecipeParser_Parser_MicrodataSchema::parse($html, $url);
-
-        // Turn off libxml errors to prevent mismatched tag warnings.
-        libxml_use_internal_errors(true);
-        $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
-        $doc = new DOMDocument();
-        $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
+    static public function parse(DOMDocument $doc, $url) {
+        // Get all of the standard microdata stuff we can find.
+        $recipe = RecipeParser_Parser_MicrodataSchema::parse($doc, $url);
         $xpath = new DOMXPath($doc);
 
-
-        // OVERRIDES for epicurious
+        // OVERRIDES FOR EPICURIOUS.COM
 
         // Ingredients
         $recipe->resetIngredients();

--- a/lib/RecipeParser/Parser/Food52com.php
+++ b/lib/RecipeParser/Parser/Food52com.php
@@ -2,19 +2,12 @@
 
 class RecipeParser_Parser_Food52com {
 
-    static public function parse($html, $url) {
-
+    static public function parse(DOMDocument $doc, $url) {
         // Get all of the standard microdata stuff we can find.
-        $recipe = RecipeParser_Parser_MicrodataSchema::parse($html, $url);
-
-        // Turn off libxml errors to prevent mismatched tag warnings.
-        libxml_use_internal_errors(true);
-        $doc = new DOMDocument();
-        $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
-        $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
+        $recipe = RecipeParser_Parser_MicrodataSchema::parse($doc, $url);
         $xpath = new DOMXPath($doc);
 
-        // ---- OVERRIDES
+        // OVERRIDES FOR FOOD52.COM
 
         // Credits
         if ($recipe->credits) {

--- a/lib/RecipeParser/Parser/Foodandwinecom.php
+++ b/lib/RecipeParser/Parser/Foodandwinecom.php
@@ -2,15 +2,11 @@
 
 class RecipeParser_Parser_Foodandwinecom {
 
-    static public function parse($html, $url) {
-
+    static public function parse(DOMDocument $doc, $url) {
         $recipe = new RecipeParser_Recipe();
-
-        libxml_use_internal_errors(true);
-        $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
-        $doc = new DOMDocument();
-        $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
         $xpath = new DOMXPath($doc);
+
+        // OVERRIDES FOR FOODANDWINE.COM
 
         // Title
         $nodes = $xpath->query('//h1[@itemprop="name"]');

--- a/lib/RecipeParser/Parser/Foodcom.php
+++ b/lib/RecipeParser/Parser/Foodcom.php
@@ -2,15 +2,12 @@
 
 class RecipeParser_Parser_Foodcom {
 
-    static public function parse($html, $url) {
-        $recipe = RecipeParser_Parser_MicrodataSchema::parse($html, $url);
-
-        // Turn off libxml errors to prevent mismatched tag warnings.
-        libxml_use_internal_errors(true);
-        $doc = new DOMDocument();
-        $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
-        $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
+    static public function parse(DOMDocument $doc, $url) {
+        // Get all of the standard microdata stuff we can find.
+        $recipe = RecipeParser_Parser_MicrodataSchema::parse($doc, $url);
         $xpath = new DOMXPath($doc);
+
+        // OVERRIDES FOR FOOD.COM
 
         // Photo -- skip logo if it was used in place of photo
         if (strpos($recipe->photo_url, "FDC_Logo_vertical.png") !== false

--- a/lib/RecipeParser/Parser/Foodnetworkcom.php
+++ b/lib/RecipeParser/Parser/Foodnetworkcom.php
@@ -2,16 +2,12 @@
 
 class RecipeParser_Parser_Foodnetworkcom {
 
-    static public function parse($html, $url) {
+    static public function parse(DOMDocument $doc, $url) {
         // Get all of the standard microdata stuff we can find.
-        $recipe = RecipeParser_Parser_MicrodataSchema::parse($html, $url);
-
-        // Turn off libxml errors to prevent mismatched tag warnings.
-        libxml_use_internal_errors(true);
-        $doc = new DOMDocument();
-        $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
-        $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
+        $recipe = RecipeParser_Parser_MicrodataSchema::parse($doc, $url);
         $xpath = new DOMXPath($doc);
+
+        // OVERRIDES FOR FOODNETWORK.COM
 
         // Ingredients
         $recipe->resetIngredients();

--- a/lib/RecipeParser/Parser/Foodnetworkcouk.php
+++ b/lib/RecipeParser/Parser/Foodnetworkcouk.php
@@ -2,17 +2,12 @@
 
 class RecipeParser_Parser_Foodnetworkcouk {
 
-    static public function parse($html, $url) {
+    static public function parse(DOMDocument $doc, $url) {
         // Get all of the standard microdata stuff we can find.
-        $recipe = RecipeParser_Parser_MicrodataDataVocabulary::parse($html, $url);
-
-        // Turn off libxml errors to prevent mismatched tag warnings.
-        libxml_use_internal_errors(true);
-        $doc = new DOMDocument();
-        $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
-        $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
+        $recipe = RecipeParser_Parser_MicrodataDataVocabulary::parse($doc, $url);
         $xpath = new DOMXPath($doc);
 
+        // OVERRIDES FOR FOODNETWORKCO.UK
 
         // Ingredients
         $recipe->resetIngredients();

--- a/lib/RecipeParser/Parser/Kingarthurflourcom.php
+++ b/lib/RecipeParser/Parser/Kingarthurflourcom.php
@@ -2,15 +2,12 @@
 
 class RecipeParser_Parser_Kingarthurflourcom {
 
-    static public function parse($html, $url) {
-        $recipe = RecipeParser_Parser_MicrodataDataVocabulary::parse($html, $url);
-
-        // Turn off libxml errors to prevent mismatched tag warnings.
-        libxml_use_internal_errors(true);
-        $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
-        $doc = new DOMDocument();
-        $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
+    static public function parse(DOMDocument $doc, $url) {
+        // Get all of the standard microdata stuff we can find.
+        $recipe = RecipeParser_Parser_MicrodataDataVocabulary::parse($doc, $url);
         $xpath = new DOMXPath($doc);
+
+        // OVERRIDES FOR KINGARTHURFLOUR.COM
 
         // Ingredients
         $recipe->resetIngredients();

--- a/lib/RecipeParser/Parser/Marthastewartcom.php
+++ b/lib/RecipeParser/Parser/Marthastewartcom.php
@@ -2,14 +2,12 @@
 
 class RecipeParser_Parser_Marthastewartcom {
 
-    static public function parse($html, $url) {
-        $recipe = RecipeParser_Parser_MicrodataSchema::parse($html, $url);
-
-        libxml_use_internal_errors(true);
-        $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
-        $doc = new DOMDocument();
-        $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
+    static public function parse(DOMDocument $doc, $url) {
+        // Get all of the standard microdata stuff we can find.
+        $recipe = RecipeParser_Parser_MicrodataSchema::parse($doc, $url);
         $xpath = new DOMXPath($doc);
+
+        // OVERRIDES FOR MARTHASTEWART.COM
 
         // Yield
         $nodes = $xpath->query('//li[@class="credit"]');

--- a/lib/RecipeParser/Parser/MicrodataDataVocabulary.php
+++ b/lib/RecipeParser/Parser/MicrodataDataVocabulary.php
@@ -2,14 +2,8 @@
 
 class RecipeParser_Parser_MicrodataDataVocabulary {
 
-    static public function parse($html, $url) {
-
+    static public function parse(DOMDocument $doc, $url) {
         $recipe = new RecipeParser_Recipe();
-
-        libxml_use_internal_errors(true);
-        $doc = new DOMDocument();
-        $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
-        $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
         $xpath = new DOMXPath($doc);
 
         // Find the top-level node for Recipe microdata

--- a/lib/RecipeParser/Parser/MicrodataRdfDataVocabulary.php
+++ b/lib/RecipeParser/Parser/MicrodataRdfDataVocabulary.php
@@ -2,14 +2,8 @@
 
 class RecipeParser_Parser_MicrodataRdfDataVocabulary {
 
-    static public function parse($html, $url) {
-
+    static public function parse(DOMDocument $doc, $url) {
         $recipe = new RecipeParser_Recipe();
-
-        libxml_use_internal_errors(true);
-        $doc = new DOMDocument();
-        $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
-        $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
         $xpath = new DOMXPath($doc);
 
         // Title

--- a/lib/RecipeParser/Parser/MicrodataSchema.php
+++ b/lib/RecipeParser/Parser/MicrodataSchema.php
@@ -2,14 +2,8 @@
 
 class RecipeParser_Parser_MicrodataSchema {
 
-    static public function parse($html, $url) {
-
+    static public function parse(DOMDocument $doc, $url) {
         $recipe = new RecipeParser_Recipe();
-
-        libxml_use_internal_errors(true);
-        $doc = new DOMDocument();
-        $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
-        $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
         $xpath = new DOMXPath($doc);
 
         $microdata = null;

--- a/lib/RecipeParser/Parser/Microformat.php
+++ b/lib/RecipeParser/Parser/Microformat.php
@@ -2,13 +2,8 @@
 
 class RecipeParser_Parser_Microformat {
 
-    static public function parse($html, $url) {
+    static public function parse(DOMDocument $doc, $url) {
         $recipe = new RecipeParser_Recipe();
-
-        libxml_use_internal_errors(true);
-        $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
-        $doc = new DOMDocument();
-        $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
         $xpath = new DOMXPath($doc);
 
         $hrecipe = null;

--- a/lib/RecipeParser/Parser/Myrecipescom.php
+++ b/lib/RecipeParser/Parser/Myrecipescom.php
@@ -2,14 +2,12 @@
 
 class RecipeParser_Parser_Myrecipescom {
 
-    static public function parse($html, $url) {
-        $recipe = RecipeParser_Parser_MicrodataDataVocabulary::parse($html, $url);
-        
-        libxml_use_internal_errors(true);
-        $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
-        $doc = new DOMDocument();
-        $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
+    static public function parse(DOMDocument $doc, $url) {
+        // Get all of the standard microdata stuff we can find.
+        $recipe = RecipeParser_Parser_MicrodataDataVocabulary::parse($doc, $url);
         $xpath = new DOMXPath($doc);
+
+        // OVERRIDES FOR MYRECIPES.COM
 
         // Title missing?
         if (!$recipe->title) {

--- a/lib/RecipeParser/Parser/Nytimescom.php
+++ b/lib/RecipeParser/Parser/Nytimescom.php
@@ -2,21 +2,16 @@
 
 class RecipeParser_Parser_Nytimescom {
 
-    static public function parse($html, $url) {
+    static public function parse(DOMDocument $doc, $url) {
+        $recipe = new RecipeParser_Recipe();
+        $xpath = new DOMXPath($doc);
+
+        // OVERRIDES FOR NYTIMES.COM
 
         if (strpos($url, "www.nytimes.com/recipes/") !== false) {
-
             //
             // "RECIPES" SECTION
             //
-
-            $recipe = new RecipeParser_Recipe();
-
-            libxml_use_internal_errors(true);
-            $doc = new DOMDocument();
-            $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
-            $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
-            $xpath = new DOMXPath($doc);
 
             // Title
             $nodes = $xpath->query('//h1[@class="recipe-title recipeName"]');
@@ -70,18 +65,9 @@ class RecipeParser_Parser_Nytimescom {
             }
 
         } else {
-
             //
             // DINING SECTION RECIPES
             //
-
-            $recipe = new RecipeParser_Recipe();
-
-            libxml_use_internal_errors(true);
-            $doc = new DOMDocument();
-            $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
-            $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
-            $xpath = new DOMXPath($doc);
 
             // Title
             $nodes = $xpath->query('//div[@id = "article"]//h1');

--- a/lib/RecipeParser/Parser/Pillsburycom.php
+++ b/lib/RecipeParser/Parser/Pillsburycom.php
@@ -2,14 +2,12 @@
 
 class RecipeParser_Parser_Pillsburycom {
 
-    static public function parse($html, $url) {
-        $recipe = RecipeParser_Parser_MicrodataSchema::parse($html, $url);
-
-        libxml_use_internal_errors(true);
-        $doc = new DOMDocument();
-        $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
-        $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
+    static public function parse(DOMDocument $doc, $url) {
+        // Get all of the standard microdata stuff we can find.
+        $recipe = RecipeParser_Parser_MicrodataSchema::parse($doc, $url);
         $xpath = new DOMXPath($doc);
+
+        // OVERRIDES FOR PILLSBURY.COM
 
         // Times
         $nodes = $xpath->query('//*[@class="recipePartAttributes recipePartPrimaryAttributes"]//li');

--- a/lib/RecipeParser/Parser/Realsimplecom.php
+++ b/lib/RecipeParser/Parser/Realsimplecom.php
@@ -2,15 +2,11 @@
 
 class RecipeParser_Parser_Realsimplecom {
 
-    static public function parse($html, $url) {
+    static public function parse(DOMDocument $doc, $url) {
         $recipe = new RecipeParser_Recipe();
-
-        // Turn off libxml errors to prevent mismatched tag warnings.
-        libxml_use_internal_errors(true);
-        $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
-        $doc = new DOMDocument();
-        $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
         $xpath = new DOMXPath($doc);
+
+        // OVERRIDES FOR REALSIMPLE.COM
 
         // Title
         $nodes = $xpath->query('//*[@id="page-title"]');

--- a/lib/RecipeParser/Parser/Recipecom.php
+++ b/lib/RecipeParser/Parser/Recipecom.php
@@ -2,16 +2,12 @@
 
 class RecipeParser_Parser_Recipecom {
 
-    static public function parse($html, $url) {
-        $recipe = RecipeParser_Parser_MicrodataSchema::parse($html, $url);
-
-        libxml_use_internal_errors(true);
-        $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
-        $doc = new DOMDocument();
-        $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
+    static public function parse(DOMDocument $doc, $url) {
+        // Get all of the standard microdata stuff we can find.
+        $recipe = RecipeParser_Parser_MicrodataSchema::parse($doc, $url);
         $xpath = new DOMXPath($doc);
 
-        // Overrides for data that isn't captured by their implementation of Schema.org.
+        // OVERRIDES FOR RECIPE.COM
 
         // Instructions
         $recipe->resetInstructions();

--- a/lib/RecipeParser/Parser/Saveurcom.php
+++ b/lib/RecipeParser/Parser/Saveurcom.php
@@ -2,14 +2,12 @@
 
 class RecipeParser_Parser_Saveurcom {
 
-    static public function parse($html, $url) {
-        $recipe = RecipeParser_Parser_MicrodataDataVocabulary::parse($html, $url);
-        
-        libxml_use_internal_errors(true);
-        $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
-        $doc = new DOMDocument();
-        $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
+    static public function parse(DOMDocument $doc, $url) {
+        // Get all of the standard microdata stuff we can find.
+        $recipe = RecipeParser_Parser_MicrodataDataVocabulary::parse($doc, $url);
         $xpath = new DOMXPath($doc);
+
+        // OVERRIDES FOR SAVEUR.COM
 
         // Yield, Ingredients, Instructions
         $found_instructions = false;

--- a/lib/RecipeParser/Parser/Seriouseatscom.php
+++ b/lib/RecipeParser/Parser/Seriouseatscom.php
@@ -2,14 +2,12 @@
 
 class RecipeParser_Parser_Seriouseatscom {
 
-    static public function parse($html, $url) {
-        $recipe = RecipeParser_Parser_Microformat::parse($html, $url);
-
-        libxml_use_internal_errors(true);
-        $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
-        $doc = new DOMDocument();
-        $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
+    static public function parse(DOMDocument $doc, $url) {
+        // Get all of the standard microformat stuff we can find.
+        $recipe = RecipeParser_Parser_Microformat::parse($doc, $url);
         $xpath = new DOMXPath($doc);
+
+        // OVERRIDES FOR SERIOUSEATS.COM
 
         $hrecipe = $xpath->query('//*[@class="hrecipe"]');
         if ($hrecipe->length) {

--- a/lib/RecipeParser/Parser/Simplyrecipescom.php
+++ b/lib/RecipeParser/Parser/Simplyrecipescom.php
@@ -2,14 +2,12 @@
 
 class RecipeParser_Parser_Simplyrecipescom {
 
-    static public function parse($html, $url) {
-        $recipe = RecipeParser_Parser_MicrodataSchema::parse($html, $url);
-
-        libxml_use_internal_errors(true);
-        $doc = new DOMDocument();
-        $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
-        $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
+    static public function parse(DOMDocument $doc, $url) {
+        // Get all of the standard microdata stuff we can find.
+        $recipe = RecipeParser_Parser_MicrodataSchema::parse($doc, $url);
         $xpath = new DOMXPath($doc);
+
+        // OVERRIDES FOR SIMPLYRECIPES.COM
 
         // Ingredients
         $recipe->resetIngredients();

--- a/lib/RecipeParser/Parser/Skinnytastecom.php
+++ b/lib/RecipeParser/Parser/Skinnytastecom.php
@@ -2,15 +2,11 @@
 
 class RecipeParser_Parser_Skinnytastecom {
 
-    static public function parse($html, $url) {
+    static public function parse(DOMDocument $doc, $url) {
         $recipe = new RecipeParser_Recipe();
-
-        // Turn off libxml errors to prevent mismatched tag warnings.
-        libxml_use_internal_errors(true);
-        $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
-        $doc = new DOMDocument();
-        $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
         $xpath = new DOMXPath($doc);
+
+        // OVERRIDES FOR SKINNYTASTE.COM
 
         // Title
         $nodes = $xpath->query('//title');

--- a/lib/RecipeParser/Parser/Sparkpeoplecom.php
+++ b/lib/RecipeParser/Parser/Sparkpeoplecom.php
@@ -2,14 +2,12 @@
 
 class RecipeParser_Parser_Sparkpeoplecom {
 
-    static public function parse($html, $url) {
-        $recipe = RecipeParser_Parser_MicrodataSchema::parse($html, $url);
-
-        libxml_use_internal_errors(true);
-        $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
-        $doc = new DOMDocument();
-        $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
+    static public function parse(DOMDocument $doc, $url) {
+        // Get all of the standard microdata stuff we can find.
+        $recipe = RecipeParser_Parser_MicrodataSchema::parse($doc, $url);
         $xpath = new DOMXPath($doc);
+
+        // OVERRIDES FOR SPARKPEOPLE.COM
 
         // Yield
         $nodes = $xpath->query('//*[@class="prep_box"]');

--- a/lib/RecipeParser/Parser/Tasteofhomecom.php
+++ b/lib/RecipeParser/Parser/Tasteofhomecom.php
@@ -2,14 +2,12 @@
 
 class RecipeParser_Parser_Tasteofhomecom {
 
-    static public function parse($html, $url) {
-        $recipe = RecipeParser_Parser_MicrodataSchema::parse($html, $url);
-
-        libxml_use_internal_errors(true);
-        $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
-        $doc = new DOMDocument();
-        $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
+    static public function parse(DOMDocument $doc, $url) {
+        // Get all of the standard microdata stuff we can find.
+        $recipe = RecipeParser_Parser_MicrodataSchema::parse($doc, $url);
         $xpath = new DOMXPath($doc);
+
+        // OVERRIDES FOR TASTEOFHOME.COM
 
         // Notes
         $nodes = $xpath->query('//div[@class="rd_editornote margin_bottom"]');

--- a/lib/RecipeParser/Parser/Thedailymealcom.php
+++ b/lib/RecipeParser/Parser/Thedailymealcom.php
@@ -2,14 +2,12 @@
 
 class RecipeParser_Parser_Thedailymealcom {
 
-    static public function parse($html, $url) {
-        $recipe = RecipeParser_Parser_MicrodataDataVocabulary::parse($html, $url);
-
-        libxml_use_internal_errors(true);
-        $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
-        $doc = new DOMDocument();
-        $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
+    static public function parse(DOMDocument $doc, $url) {
+        // Get all of the standard microdata stuff we can find.
+        $recipe = RecipeParser_Parser_MicrodataDataVocabulary::parse($doc, $url);
         $xpath = new DOMXPath($doc);
+
+        // OVERRIDES FOR THEDAILYMEAL.COM
 
         //
         // Some of the ingredient lines in on The Daily Meal do not adhere to

--- a/lib/RecipeParser/Parser/Thekitchencom.php
+++ b/lib/RecipeParser/Parser/Thekitchencom.php
@@ -2,15 +2,11 @@
 
 class RecipeParser_Parser_Thekitchencom {
 
-    static public function parse($html, $url) {
+    static public function parse(DOMDocument $doc, $url) {
         $recipe = new RecipeParser_Recipe();
-
-        // Turn off libxml errors to prevent mismatched tag warnings.
-        libxml_use_internal_errors(true);
-        $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
-        $doc = new DOMDocument();
-        $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
         $xpath = new DOMXPath($doc);
+
+        // OVERRIDES FOR THEKITCHEN.COM
 
         // Title
         $nodes = $xpath->query('//*[@id="recipe"]/h3');

--- a/lib/RecipeParser/Text.php
+++ b/lib/RecipeParser/Text.php
@@ -64,6 +64,20 @@ ONETSP_TIME: $time
     }
 
     /**
+     * Strip HTML conditional comments. E.g. Remove <!--[if lt IE 9]> <![endif]-->
+     * and their contents.
+     *
+     * @param string HTML
+     * @return string Modified HTML
+     */
+    static public function stripConditionalComments($html) {
+        $pattern = '/<!--\s?\[if.*endif\]-->/is';
+        $replacement = '<!-- STRIPPED CONDITIONAL COMMENT -->';
+        $html = preg_replace($pattern, $replacement, $html);
+        return $html;
+    }
+
+    /**
      * Cleanup for clipped HTML prior to parsing with RecipeParser.
      *
      * @param string HTML
@@ -79,6 +93,7 @@ ONETSP_TIME: $time
         // Strip out script tags so they don't accidentally get executed if we ever display
         // clipped content to end-users.
         $html = RecipeParser_Text::stripTagAndContents('script', $html);
+        $html = RecipeParser_Text::stripConditionalComments($html);
 
         return $html;
     }
@@ -535,6 +550,18 @@ ONETSP_TIME: $time
         $title = implode("_", $parts);
 
         return $title;
+    }
+
+    public static function getDomDocument($html) {
+        libxml_use_internal_errors(true);
+
+        $doc = new DOMDocument();
+        $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
+        $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
+
+        libxml_use_internal_errors(false);
+
+        return $doc;
     }
 
 }

--- a/tests/RecipeParser_Parser_101cookbookscomTest.php
+++ b/tests/RecipeParser_Parser_101cookbookscomTest.php
@@ -8,7 +8,8 @@ class RecipeParser_Parser_101cookbookscom_Test extends PHPUnit_Framework_TestCas
         $path = "data/101cookbooks_com_glissade_chocolate_pudding_cookbooks_curl.html";
         $url  = "http://www.101cookbooks.com/archives/glissade-chocolate-pudding-recipe.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Glissade Chocolate Pudding', $recipe->title);
@@ -36,7 +37,8 @@ class RecipeParser_Parser_101cookbookscom_Test extends PHPUnit_Framework_TestCas
         $path = "data/101cookbooks_com_lemony_olive_oil_banana_bread_cookbooks_curl.html";
         $url  = "http://www.101cookbooks.com/archives/lemony-olive-oil-banana-bread-recipe.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Lemony Olive Oil Banana Bread', $recipe->title);
@@ -69,7 +71,8 @@ class RecipeParser_Parser_101cookbookscom_Test extends PHPUnit_Framework_TestCas
         $path = "data/101cookbooks_com_roasted_squash_chile_and_mozzarella_salad_curl.html";
         $url  = "http://www.101cookbooks.com/archives/roasted-squash-chile-and-mozzarella-salad-recipe.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Roasted Squash, Chile, and Mozzarella Salad', $recipe->title);
@@ -95,7 +98,8 @@ class RecipeParser_Parser_101cookbookscom_Test extends PHPUnit_Framework_TestCas
         $path = "data/101cookbooks_com_tofu_amaranth_salad_cookbooks_curl.html";
         $url  = "http://www.101cookbooks.com/archives/tofu-amaranth-salad-recipe.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Tofu Amaranth Salad', $recipe->title);

--- a/tests/RecipeParser_Parser_12tomatoescomTest.php
+++ b/tests/RecipeParser_Parser_12tomatoescomTest.php
@@ -9,7 +9,8 @@ class RecipeParser_Parser_12tomatoescomTest extends PHPUnit_Framework_TestCase {
         $path = "data/12tomatoes_com_filling_and_fruity_treat_cream_cheese_curl.html";
         $url  = "http://12tomatoes.com/2015/04/filling-and-fruity-treat-cream-cheese-cherry-coffee-cake.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Cream Cheese Cherry Cake', $recipe->title);
@@ -38,7 +39,8 @@ class RecipeParser_Parser_12tomatoescomTest extends PHPUnit_Framework_TestCase {
         $path = "data/12tomatoes_com_healthy_sugar_free_cookies_no_bake_curl.html";
         $url  = "http://12tomatoes.com/2015/04/healthy-sugarfree-cookies-nobake-chocolate-oat-cookies.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Sugar-Free Chocolate Oat Cookies', $recipe->title);
@@ -67,7 +69,8 @@ class RecipeParser_Parser_12tomatoescomTest extends PHPUnit_Framework_TestCase {
         $path = "data/12tomatoes_com_light_and_sweet_dessert_creamy_raspberry_curl.html";
         $url  = "http://12tomatoes.com/2015/04/light-and-sweet-dessert-creamy-raspberry-cheesecake-bars.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Raspberry Cheesecake Bars', $recipe->title);

--- a/tests/RecipeParser_Parser_AboutcomTest.php
+++ b/tests/RecipeParser_Parser_AboutcomTest.php
@@ -8,7 +8,8 @@ class RecipeParser_Parser_AboutcomTest extends PHPUnit_Framework_TestCase {
         $path = "data/baking_about_com_cinnamon_walnut_biscotti_curl.html";
         $url = "http://baking.about.com/od/cookies/r/cinnamonwalnutbiscotti.htm";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals("Cinnamon Walnut Biscotti", $recipe->title);
@@ -30,7 +31,8 @@ class RecipeParser_Parser_AboutcomTest extends PHPUnit_Framework_TestCase {
         $path = "data/baking_about_com_ultimate_chocolate_cake_for_ultimate_chocolate_curl.html";
         $url = "http://baking.about.com/od/valentines/r/ultimatechoccak.htm";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals("Ultimate Chocolate Cake", $recipe->title);
@@ -61,7 +63,8 @@ class RecipeParser_Parser_AboutcomTest extends PHPUnit_Framework_TestCase {
         $path = "data/frenchfood_about_com_chicken_and_sausage_cassoulet_curl.html";
         $url = "http://frenchfood.about.com/od/maindishes/r/cassoulet.htm";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals("Chicken and Sausage Cassoulet", $recipe->title);
@@ -80,7 +83,8 @@ class RecipeParser_Parser_AboutcomTest extends PHPUnit_Framework_TestCase {
         $path = "data/southernfood_about_com_cinnamon_pound_cake_curl.html";
         $url = "http://southernfood.about.com/od/spicecakerecipes/r/bln255.htm";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals("Cinnamon Pound Cake", $recipe->title);

--- a/tests/RecipeParser_Parser_AllrecipesTest.php
+++ b/tests/RecipeParser_Parser_AllrecipesTest.php
@@ -8,7 +8,8 @@ class RecipeParser_Parser_AllrecipesTest extends PHPUnit_Framework_TestCase {
         $path = "data/allrecipes_com_pumpkin_apple_streusel_muffins_all_com_curl.html";
         $url = "http://allrecipes.com/Recipe/Apple-Pumpkin-Muffins/Detail.aspx";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
@@ -30,7 +31,8 @@ class RecipeParser_Parser_AllrecipesTest extends PHPUnit_Framework_TestCase {
         $path = "data/allrecipes_com_spiced_pumpkin_seeds_all_com_curl.html";
         $url = "http://allrecipes.com/Recipe/Spiced-Pumpkin-Seeds/Detail.aspx";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
@@ -48,7 +50,8 @@ class RecipeParser_Parser_AllrecipesTest extends PHPUnit_Framework_TestCase {
         $path = "data/allrecipes_com_carrot_cake_viii_all_com_curl.html";
         $url = "http://allrecipes.com/Recipe/Carrot-Cake-VIII/Detail.aspx";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
@@ -63,7 +66,8 @@ class RecipeParser_Parser_AllrecipesTest extends PHPUnit_Framework_TestCase {
         $path = "data/allrecipes_com_potato_bacon_cheese_frittata_customized_by_curl.html";
         $url = "http://allrecipes.com/customrecipe/62636838/potato-bacon-cheese-frittata/detail.aspx";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
@@ -80,7 +84,8 @@ class RecipeParser_Parser_AllrecipesTest extends PHPUnit_Framework_TestCase {
         $path = "data/m_allrecipes_com_best_buckwheat_pancakes_all_com_curl.html";
         $url = "http://m.allrecipes.com/recipe/14096/best-buckwheat-pancakes/?internalSource=staff%20pick&referringContentType=home%20page&referringPosition=8";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
@@ -96,7 +101,8 @@ class RecipeParser_Parser_AllrecipesTest extends PHPUnit_Framework_TestCase {
         $path = "data/m_allrecipes_com_chef_johns_chicken_teriyaki_all_com_curl.html";
         $url = "http://m.allrecipes.com/recipe/237927/chef-johns-chicken-teriyaki/?internalSource=staff%20pick&referringContentType=home%20page";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
@@ -113,7 +119,8 @@ class RecipeParser_Parser_AllrecipesTest extends PHPUnit_Framework_TestCase {
         $path = "data/m_allrecipes_com_tiramisu_layer_cake_all_com_curl.html";
         $url = "http://m.allrecipes.com/recipe/25639/tiramisu-layer-cake/";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 

--- a/tests/RecipeParser_Parser_AmericastestkitchencomTest.php
+++ b/tests/RecipeParser_Parser_AmericastestkitchencomTest.php
@@ -8,7 +8,8 @@ class RecipeParser_Parser_AmericastestkitchencomTest extends PHPUnit_Framework_T
         $path = "data/americastestkitchen_com_thick_cut_sweet_potato_fries_america_s_test_kitchen_clipped.html";
         $url = "http://www.americastestkitchen.com/recipes/7775-thick-cut-sweet-potato-fries";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertGreaterThan(5, strlen($recipe->title));

--- a/tests/RecipeParser_Parser_BbccoukTest.php
+++ b/tests/RecipeParser_Parser_BbccoukTest.php
@@ -8,7 +8,8 @@ class RecipeParser_Parser_BbccoukTest extends PHPUnit_Framework_TestCase {
         $path = "data/bbc_co_uk_bbc_food_s_baked_pappardelle_with_curl.html";
         $url = "http://www.bbc.co.uk/food/recipes/baked_pappardelle_with_21046";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Baked pappardelle with pancetta and porcini', $recipe->title);
@@ -36,7 +37,8 @@ class RecipeParser_Parser_BbccoukTest extends PHPUnit_Framework_TestCase {
         $path = "data/bbc_co_uk_bbc_food_s_cherry_chocolate_pavlova_curl.html";
         $url = "http://www.bbc.co.uk/food/recipes/cherry_chocolate_pavlova_94685";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Cherry chocolate pavlova', $recipe->title);
@@ -68,7 +70,8 @@ class RecipeParser_Parser_BbccoukTest extends PHPUnit_Framework_TestCase {
         $path = "data/bbc_co_uk_bbc_food_s_saag_aloo_with_curl.html";
         $url = "http://www.bbc.co.uk/food/recipes/saag_aloo_with_roasted_95304";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Saag aloo with roasted gobi curry', $recipe->title);

--- a/tests/RecipeParser_Parser_BbcgoodfoodcomTest.php
+++ b/tests/RecipeParser_Parser_BbcgoodfoodcomTest.php
@@ -5,10 +5,11 @@ require_once '../bootstrap.php';
 class RecipeParser_Parser_BbcgoodfoodcomTest extends PHPUnit_Framework_TestCase {
 
     public function test_chicken_herb_rosti() {
-        $path_orig = "data/bbcgoodfood_com_chicken_amp_herb_r_sti_topped_pies_curl.html";
+        $path = "data/bbcgoodfood_com_chicken_amp_herb_r_sti_topped_pies_curl.html";
         $url = "http://www.bbcgoodfood.com/recipes/527632/chicken-and-herb-rstitopped-pies";
 
-        $recipe = RecipeParser::parse(file_get_contents($path_orig), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Chicken & herb rösti-topped pies', $recipe->title);
@@ -32,10 +33,11 @@ class RecipeParser_Parser_BbcgoodfoodcomTest extends PHPUnit_Framework_TestCase 
     }
 
     public function test_lemon_poppyseed() {
-        $path_orig = "data/bbcgoodfood_com_lemon_amp_poppyseed_cupcakes_bbc_good_curl.html";
+        $path = "data/bbcgoodfood_com_lemon_amp_poppyseed_cupcakes_bbc_good_curl.html";
         $url = "http://www.bbcgoodfood.com/recipes/470636/lemon-and-poppyseed-cupcakes";
 
-        $recipe = RecipeParser::parse(file_get_contents($path_orig), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Lemon & poppyseed cupcakes', $recipe->title);
@@ -61,10 +63,11 @@ class RecipeParser_Parser_BbcgoodfoodcomTest extends PHPUnit_Framework_TestCase 
     }
 
     public function test_ultimate_chocolate_cake() {
-        $path_orig = "data/bbcgoodfood_com_ultimate_chocolate_cake_bbc_good_food_curl.html";
+        $path = "data/bbcgoodfood_com_ultimate_chocolate_cake_bbc_good_food_curl.html";
         $url = "http://www.bbcgoodfood.com/recipes/3092/ultimate-chocolate-cake";
 
-        $recipe = RecipeParser::parse(file_get_contents($path_orig), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Ultimate chocolate cake', $recipe->title);
@@ -90,10 +93,11 @@ class RecipeParser_Parser_BbcgoodfoodcomTest extends PHPUnit_Framework_TestCase 
     }
 
     public function test_slow_cooked_chinese_beef() {
-        $path_orig = "data/bbcgoodfood_com_slow_cooked_chinese_beef_curl.html";
+        $path = "data/bbcgoodfood_com_slow_cooked_chinese_beef_curl.html";
         $url = "http://www.bbcgoodfood.com/recipes/96613/slowcooked-chinese-beef";
 
-        $recipe = RecipeParser::parse(file_get_contents($path_orig), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Slow-cooked Chinese beef', $recipe->title);

--- a/tests/RecipeParser_Parser_BhgcomTest.php
+++ b/tests/RecipeParser_Parser_BhgcomTest.php
@@ -5,10 +5,11 @@ require_once '../bootstrap.php';
 class RecipeParser_Parser_BhgcomTest extends PHPUnit_Framework_TestCase {
 
     public function test_eggnog_cheesecake() {
-        $path_orig = "data/bhg_com_bhgs_newest_eggnog_cheesecake_with_candied_curl.html";
+        $path = "data/bhg_com_bhgs_newest_eggnog_cheesecake_with_candied_curl.html";
         $url = "http://www.bhg.com/recipe/cheesecake/eggnog-cheesecake-with-candied-kumquats/";
 
-        $recipe = RecipeParser::parse(file_get_contents($path_orig), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Eggnog Cheesecake with Candied Kumquats', $recipe->title);
@@ -35,10 +36,11 @@ class RecipeParser_Parser_BhgcomTest extends PHPUnit_Framework_TestCase {
     }
 
     public function test_tomatillo_chicken_soup() {
-        $path_orig = "data/bhg_com_bhgs_newest_tomatillo_chicken_soup_curl.html";
+        $path = "data/bhg_com_bhgs_newest_tomatillo_chicken_soup_curl.html";
         $url = "http://www.bhg.com/recipe/chicken/tomatillo-chicken-soup/";
 
-        $recipe = RecipeParser::parse(file_get_contents($path_orig), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Tomatillo Chicken Soup', $recipe->title);

--- a/tests/RecipeParser_Parser_BigovencomTest.php
+++ b/tests/RecipeParser_Parser_BigovencomTest.php
@@ -8,7 +8,8 @@ class RecipeParser_Parser_BigovencomTest extends PHPUnit_Framework_TestCase {
         $path = "data/bigoven_com_banana_bread_bigoven_curl.html";
         $url = "http://www.bigoven.com/recipe/334322/Banana-Bread";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         
 
 

--- a/tests/RecipeParser_Parser_BonappetitcomTest.php
+++ b/tests/RecipeParser_Parser_BonappetitcomTest.php
@@ -8,7 +8,8 @@ class RecipeParser_Parser_BonappetitecomTest extends PHPUnit_Framework_TestCase 
         $path = "data/bonappetit_com_beet_and_fennel_soup_with_kefir_curl.html";
         $url = "http://www.bonappetit.com/recipes/quick-recipes/2011/01/beet_and_fennel_soup_with_kefir";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals("Beet and Fennel Soup with Kefir", $recipe->title);
@@ -28,7 +29,8 @@ class RecipeParser_Parser_BonappetitecomTest extends PHPUnit_Framework_TestCase 
         $path = "data/bonappetit_com_chai_spiced_hot_chocolate_bon_app_curl.html";
         $url = "http://www.bonappetit.com/recipes/quick-recipes/2010/02/chai_spiced_hot_chocolate";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals("Chai-Spiced Hot Chocolate", $recipe->title);
@@ -44,7 +46,8 @@ class RecipeParser_Parser_BonappetitecomTest extends PHPUnit_Framework_TestCase 
         $path = "data/bonappetit_com_flourless_chocolate_cake_with_caramel_sauce_curl.html";
         $url = "http://www.bonappetit.com/recipes/2002/10/flourless_chocolate_cake_with_caramel_sauce";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals("Flourless Chocolate Cake with Caramel Sauce", $recipe->title);
@@ -60,7 +63,8 @@ class RecipeParser_Parser_BonappetitecomTest extends PHPUnit_Framework_TestCase 
         $path = "data/bonappetit_com_special_sunday_roast_chicken_bon_app_curl.html";
         $url = "http://www.bonappetit.com/recipes/2009/02/special_sunday_roast_chicken";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals("Special Sunday Roast Chicken", $recipe->title);
@@ -74,7 +78,8 @@ class RecipeParser_Parser_BonappetitecomTest extends PHPUnit_Framework_TestCase 
         $path = "data/bonappetit_com_yogurt_with_granola_tropical_fruit_and_curl.html";
         $url = "http://www.bonappetit.com/recipes/quick-recipes/2008/07/yogurt_with_granola";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         // Should not have "Hungry for more" phrase in instructions
@@ -85,7 +90,8 @@ class RecipeParser_Parser_BonappetitecomTest extends PHPUnit_Framework_TestCase 
         $path = "data/bonappetit_com_harvest_pear_crisp_with_candied_ginger_curl.html";
         $url = "http://www.bonappetit.com/recipes/2009/11/harvest_pear_crisp_with_candied_ginger";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         // Watch for &ndash; in serving size

--- a/tests/RecipeParser_Parser_BravotvcomTest.php
+++ b/tests/RecipeParser_Parser_BravotvcomTest.php
@@ -19,7 +19,8 @@ class RecipeParser_Parser_BravotvcomTest extends PHPUnit_Framework_TestCase {
         $path = "data/bravotv_com_cornbread_topped_chilli_con_carne_finder_curl.html";
         $url = "http://www.bravotv.com/foodies/recipes/cornbread-topped-chilli-con-carne";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Cornbread-Topped Chilli Con Carne', $recipe->title);
@@ -44,7 +45,8 @@ class RecipeParser_Parser_BravotvcomTest extends PHPUnit_Framework_TestCase {
         $path = "data/bravotv_com_ground_lamb_scotch_egg_sweet_potato_curl.html";
         $url = "http://www.bravotv.com/foodies/recipes/ground-lamb-scotch-egg-sweet-potato-fries-and-tomato-tartnbsp";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Ground Lamb Scotch Egg, Sweet Potato Fries and Tomato Tart', $recipe->title);
@@ -72,7 +74,8 @@ class RecipeParser_Parser_BravotvcomTest extends PHPUnit_Framework_TestCase {
         $path = "data/bravotv_com_roast_grouper_with_gnocchi_peas_bacon_curl.html";
         $url = "http://www.bravotv.com/foodies/recipes/roast-grouper-with-gnocchi-peas-bacon-and-parsnip";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Roast Grouper with Gnocchi, Peas, Bacon, and Parsnip', $recipe->title);
@@ -93,7 +96,8 @@ class RecipeParser_Parser_BravotvcomTest extends PHPUnit_Framework_TestCase {
         $path = "data/bravotv_com_roasted_pork_chop_with_rosemary_thyme_curl.html";
         $url = "http://www.bravotv.com/foodies/recipes/roasted-pork-chop-with-rosemary-thyme-amp-garlic";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Roasted Pork Chop with Rosemary, Thyme & Garlic', $recipe->title);
@@ -113,7 +117,8 @@ class RecipeParser_Parser_BravotvcomTest extends PHPUnit_Framework_TestCase {
         $path = "data/bravotv_com_seared_colorado_sirloin_chanterelle_and_ruby_curl.html";
         $url = "http://www.bravotv.com/foodies/recipes/seared-colorado-sirloin-chanterelle-and-ruby-chard";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Seared Colorado Sirloin, Chanterelle and Ruby Chard', $recipe->title);
@@ -132,7 +137,8 @@ class RecipeParser_Parser_BravotvcomTest extends PHPUnit_Framework_TestCase {
         $path = "data/bravotv_com_sous_vide_chicken_mushrooms_yams_lobster_curl.html";
         $url = "http://www.bravotv.com/foodies/recipes/sous-vide-chicken-mushrooms-yams-lobster-sauce-amp-lobster-hash";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         // Only testing for instruction and ingredient sections

--- a/tests/RecipeParser_Parser_ChowcomTest.php
+++ b/tests/RecipeParser_Parser_ChowcomTest.php
@@ -8,7 +8,8 @@ class RecipeParser_Parser_ChowcomTest extends PHPUnit_Framework_TestCase {
         $path = "data/chow_com_herb_omelets_chow_com_curl.html";
         $url = "http://www.chow.com/recipes/28801-herb-omelets";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Herb Omelets', $recipe->title);
@@ -27,7 +28,8 @@ class RecipeParser_Parser_ChowcomTest extends PHPUnit_Framework_TestCase {
         $path = "data/chow_com_hungarian_chocolate_walnut_torte_chow_com_curl.html";
         $url = "http://www.chow.com/recipes/29536-hungarian-chocolate-walnut-torte";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Hungarian Chocolate-Walnut Torte', $recipe->title);
@@ -43,7 +45,8 @@ class RecipeParser_Parser_ChowcomTest extends PHPUnit_Framework_TestCase {
         $path = "data/chow_com_red_velvet_cake_chow_com_curl.html";
         $url = "http://www.chow.com/recipes/29310-red-velvet-cake";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Red Velvet Cake', $recipe->title);
@@ -61,7 +64,8 @@ class RecipeParser_Parser_ChowcomTest extends PHPUnit_Framework_TestCase {
         $path = "data/chow_com_roasted_sardines_with_smashed_potatoes_chow_curl.html";
         $url = "http://www.chow.com/recipes/29617-roasted-sardines-with-smashed-potatoes";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Roasted Sardines with Smashed Potatoes', $recipe->title);
@@ -79,7 +83,8 @@ class RecipeParser_Parser_ChowcomTest extends PHPUnit_Framework_TestCase {
         $path = "data/chow_com_white_peach_sangr_a_chow_com_curl.html";
         $url = "http://www.chow.com/recipes/29663-white-peach-sangria";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('White Peach Sangría', $recipe->title);

--- a/tests/RecipeParser_Parser_CookingchanneltvcomTest.php
+++ b/tests/RecipeParser_Parser_CookingchanneltvcomTest.php
@@ -5,10 +5,11 @@ require_once '../bootstrap.php';
 class RecipeParser_Parser__Cookingchanneltvcom_Test extends PHPUnit_Framework_TestCase {
 
     public function test_chocolate_cake() {
-        $path_orig = "data/cookingchanneltv_com_chocolate_chocolate_cake_cooking_channel_curl.html";
+        $path = "data/cookingchanneltv_com_chocolate_chocolate_cake_cooking_channel_curl.html";
         $url = "http://www.cookingchanneltv.com/recipes/emeril-lagasse/chocolate-chocolate-cake.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path_orig), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Chocolate, Chocolate Cake', $recipe->title);
@@ -30,10 +31,11 @@ class RecipeParser_Parser__Cookingchanneltvcom_Test extends PHPUnit_Framework_Te
     }
 
     public function test_pork_tenderloin() {
-        $path_orig = "data/cookingchanneltv_com_stuffed_pork_tenderloin_cooking_channel_curl.html";
+        $path = "data/cookingchanneltv_com_stuffed_pork_tenderloin_cooking_channel_curl.html";
         $url = "http://www.cookingchanneltv.com/recipes/pork-tenderloin.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path_orig), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Pork Tenderloin', $recipe->title);
@@ -54,10 +56,11 @@ class RecipeParser_Parser__Cookingchanneltvcom_Test extends PHPUnit_Framework_Te
     }
 
     public function test_chocolate_croissant() {
-        $path_orig = "data/cookingchanneltv_com_chocolate_croissant_bread_pudding_with_bourbon_curl.html";
+        $path = "data/cookingchanneltv_com_chocolate_croissant_bread_pudding_with_bourbon_curl.html";
         $url = "http://www.cookingchanneltv.com/recipes/michael-chiarello/chocolate-croissant-bread-pudding-with-bourbon-ice-cream-sauce.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path_orig), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Chocolate Croissant Bread Pudding with Bourbon Ice Cream Sauce', $recipe->title);
@@ -78,10 +81,11 @@ class RecipeParser_Parser__Cookingchanneltvcom_Test extends PHPUnit_Framework_Te
     }
 
     public function test_cream_puffs() {
-        $path_orig = "data/cookingchanneltv_com_chocolate_cream_puffs_cooking_channel_curl.html";
+        $path = "data/cookingchanneltv_com_chocolate_cream_puffs_cooking_channel_curl.html";
         $url = "http://www.cookingchanneltv.com/recipes/chocolate-cream-puffs.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path_orig), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Chocolate Cream Puffs', $recipe->title);

--- a/tests/RecipeParser_Parser_Cookingcom.php
+++ b/tests/RecipeParser_Parser_Cookingcom.php
@@ -8,7 +8,8 @@ class RecipeParser_Parser_Cookingcom_Test extends PHPUnit_Framework_TestCase {
         $path = "data/cooking_com_big_oatmeal_raisin_chews_cooking_com_curl.html";
         $url  = "http://www.cooking.com/recipes-and-more/recipes/big-oatmeal-raisin-chews-recipe-5114.aspx";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Big Oatmeal Raisin Chews', $recipe->title);
@@ -33,7 +34,8 @@ class RecipeParser_Parser_Cookingcom_Test extends PHPUnit_Framework_TestCase {
         $path = "data/cooking_com_raisin_cinnamon_apple_bread_cooking_com_curl.html";
         $url  = "http://www.cooking.com/recipes-and-more/recipes/raisin-cinnamon-apple-bread-recipe-355.aspx";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Raisin-Cinnamon Apple Bread', $recipe->title);
@@ -60,7 +62,8 @@ class RecipeParser_Parser_Cookingcom_Test extends PHPUnit_Framework_TestCase {
         $path = "data/cooking_com_wild_maine_blueberry_cobbler_cooking_com_curl.html";
         $url  = "http://www.cooking.com/recipes-and-more/recipes/wild-maine-blueberry-cobbler-recipe-2278.aspx";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Wild Maine Blueberry Cobbler', $recipe->title);

--- a/tests/RecipeParser_Parser_CookscomTest.php
+++ b/tests/RecipeParser_Parser_CookscomTest.php
@@ -8,7 +8,8 @@ class RecipeParser_Parser_CookscomTest extends PHPUnit_Framework_TestCase {
         $path = "data/cooks_com_nilla_wafers_and_no_bake_jello_curl.html";
         $url = "http://www.cooks.com/rec/doc/0,2213,158182-232201,00.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals("Nilla Wafers And No-Bake Jello Cheesecake", $recipe->title);
@@ -23,7 +24,8 @@ class RecipeParser_Parser_CookscomTest extends PHPUnit_Framework_TestCase {
         $path = "data/cooks_com_baklava_greek_version_cooks_com_curl.html";
         $url = "http://www.cooks.com/rec/view/0,1918,148188-224203,00.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals("Baklava - Greek Version", $recipe->title);
@@ -37,7 +39,8 @@ class RecipeParser_Parser_CookscomTest extends PHPUnit_Framework_TestCase {
         $path = "data/cooks_com_kathys_quiche_cooks_com_curl.html";
         $url = "http://www.cooks.com/rec/view/0,1826,148162-235202,00.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals("Kathy's Quiche", $recipe->title);
@@ -52,7 +55,8 @@ class RecipeParser_Parser_CookscomTest extends PHPUnit_Framework_TestCase {
         $path = "data/cooks_com_lemon_crumb_bars_cooks_com_curl.html";
         $url = "http://www.cooks.com/rec/view/0,1910,150169-234207,00.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
         
         $this->assertEquals("Lemon Crumb Bars", $recipe->title);

--- a/tests/RecipeParser_Parser_CooksillustratedcomTest.php
+++ b/tests/RecipeParser_Parser_CooksillustratedcomTest.php
@@ -10,7 +10,8 @@ class RecipeParser_Parser_CooksillustratedcomTest extends PHPUnit_Framework_Test
         $path = "data/cooksillustrated_com_key_lime_bars_cooks_illustrated_chrome_12_0_orig.html";
         $url = "http://www.cooksillustrated.com/recipes/detail.asp?docid=7683";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Key Lime Bars', $recipe->title);
@@ -44,7 +45,8 @@ class RecipeParser_Parser_CooksillustratedcomTest extends PHPUnit_Framework_Test
         $path = "data/cooksillustrated_com_perfect_chocolate_chip_cookies_cooks_illustrated_chrome_12_0_orig.html";
         $url = "http://www.cooksillustrated.com/recipes/detail.asp?docid=19364";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Perfect Chocolate Chip Cookies', $recipe->title);

--- a/tests/RecipeParser_Parser_EatingwellcomTest.php
+++ b/tests/RecipeParser_Parser_EatingwellcomTest.php
@@ -5,10 +5,11 @@ require_once '../bootstrap.php';
 class RecipeParser_Parser_EatingwellcomTest extends PHPUnit_Framework_TestCase {
 
     public function test_apple_cranberry_cake() {
-        $path_orig = "data/eatingwell_com_apple_cranberry_upside_down_cake_curl.html";
+        $path = "data/eatingwell_com_apple_cranberry_upside_down_cake_curl.html";
         $url = "http://www.eatingwell.com/recipes/apple_cranberry_upside_down_cake.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path_orig), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Apple-Cranberry Upside-Down Cake', $recipe->title);
@@ -32,10 +33,11 @@ class RecipeParser_Parser_EatingwellcomTest extends PHPUnit_Framework_TestCase {
     }
 
     public function test_chocolate_pumpkin_bundt() {
-        $path_orig = "data/eatingwell_com_glazed_chocolate_pumpkin_bundt_cake_curl.html";
+        $path = "data/eatingwell_com_glazed_chocolate_pumpkin_bundt_cake_curl.html";
         $url = "http://www.eatingwell.com/recipes/glazed_chocolate_pumpkin_bundt_cake.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path_orig), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Glazed Chocolate-Pumpkin Bundt Cake', $recipe->title);
@@ -59,10 +61,11 @@ class RecipeParser_Parser_EatingwellcomTest extends PHPUnit_Framework_TestCase {
     }
 
     public function test_scandinavian_pickled_herring_bites() {
-        $path_orig = "data/eatingwell_com_scandinavian_pickled_herring_bites_curl.html";
+        $path = "data/eatingwell_com_scandinavian_pickled_herring_bites_curl.html";
         $url = "http://www.eatingwell.com/recipes/pickled_herring_bites.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path_orig), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Scandinavian Pickled Herring Bites', $recipe->title);

--- a/tests/RecipeParser_Parser_ElanaspantrycomTest.php
+++ b/tests/RecipeParser_Parser_ElanaspantrycomTest.php
@@ -9,7 +9,8 @@ class RecipeParser_Parser_Elanaspantrycom_Test extends PHPUnit_Framework_TestCas
         $path = "data/elanaspantry_com_cranberry_coconut_power_bars_paleo_power_bars_curl.html";
         $url  = "http://www.elanaspantry.com/cranberry-coconut-power-bars/";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Paleo Power Bars', $recipe->title);
@@ -33,7 +34,8 @@ class RecipeParser_Parser_Elanaspantrycom_Test extends PHPUnit_Framework_TestCas
         $path = "data/elanaspantry_com_gluten_free_and_nut_free_coconut_cupcakes_curl.html";
         $url  = "http://www.elanaspantry.com/coconut-cupcakes-key-lime-icing/";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Coconut Cupcakes with Key Lime Icing', $recipe->title);
@@ -60,7 +62,8 @@ class RecipeParser_Parser_Elanaspantrycom_Test extends PHPUnit_Framework_TestCas
         $path = "data/elanaspantry_com_pumpkin_cranberry_upside_down_cake_gluten_free_dessert_curl.html";
         $url  = "http://www.elanaspantry.com/pumpkin-cranberry-upside-down-cake/";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Pumpkin Cranberry Upside-Down Cake', $recipe->title);
@@ -84,7 +87,8 @@ class RecipeParser_Parser_Elanaspantrycom_Test extends PHPUnit_Framework_TestCas
         $path = "data/elanaspantry_com_paleo_samoas_gluten_free_girl_scout_samoa_cookies_curl.html";
         $url  = "http://www.elanaspantry.com/paleo-samoas/";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Paleo Samoas', $recipe->title);

--- a/tests/RecipeParser_Parser_EpicuriouscomTest.php
+++ b/tests/RecipeParser_Parser_EpicuriouscomTest.php
@@ -8,7 +8,8 @@ class RecipeParser_Parser_EpicuriouscomTest extends PHPUnit_Framework_TestCase {
         $path = "data/epicurious_com_chocolate_cake_with_caramel_milk_chocolate_curl.html";
         $url = "http://www.epicurious.com/recipes/food/views/Chocolate-Cake-with-Caramel-Milk-Chocolate-Frosting-107944";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals("Chocolate Cake with Caramel-Milk Chocolate Frosting", $recipe->title);
@@ -36,7 +37,8 @@ class RecipeParser_Parser_EpicuriouscomTest extends PHPUnit_Framework_TestCase {
         $path = "data/epicurious_com_chocolate_crunch_layer_cake_with_milk_curl.html";
         $url = "http://www.epicurious.com/recipes/food/views/Chocolate-Crunch-Layer-Cake-with-Milk-Chocolate-Frosting-103151";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals("Chocolate Crunch Layer Cake with Milk Chocolate Frosting", $recipe->title);
@@ -58,7 +60,8 @@ class RecipeParser_Parser_EpicuriouscomTest extends PHPUnit_Framework_TestCase {
         $path = "data/epicurious_com_lemon_ros_eacute_bellini_epicurious_com_curl.html";
         $url = "http://www.epicurious.com/recipes/food/views/Lemon-Rose-Bellini-362450";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals("Lemon Rosé Bellini", $recipe->title);
@@ -73,7 +76,8 @@ class RecipeParser_Parser_EpicuriouscomTest extends PHPUnit_Framework_TestCase {
         $path = "data/epicurious_com_ziti_with_roasted_zucchini_epicurious_com_curl.html";
         $url = "http://www.epicurious.com/recipes/food/views/Ziti-with-Roasted-Zucchini-361191";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals("Ziti with Roasted Zucchini", $recipe->title);

--- a/tests/RecipeParser_Parser_Food52comTest.php
+++ b/tests/RecipeParser_Parser_Food52comTest.php
@@ -8,7 +8,8 @@ class RecipeParser_Parser_Food52comTest extends PHPUnit_Framework_TestCase {
         $path = "data/food52_com_banana_cake_with_penuche_frosting_on_curl.html";
         $url  = "http://food52.com/recipes/20123-banana-cake-with-penuche-frosting";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Banana Cake with Penuche Frosting', $recipe->title);
@@ -36,7 +37,8 @@ class RecipeParser_Parser_Food52comTest extends PHPUnit_Framework_TestCase {
         $path = "data/food52_com_brown_butter_apple_tart_on_food_curl.html";
         $url  = "http://food52.com/recipes/33370-brown-butter-apple-tart";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Brown Butter Apple Tart', $recipe->title);
@@ -63,7 +65,8 @@ class RecipeParser_Parser_Food52comTest extends PHPUnit_Framework_TestCase {
         $path = "data/food52_com_challah_bread_pudding_with_raspberries_on_curl.html";
         $url  = "http://food52.com/recipes/33952-challah-bread-pudding-with-raspberries";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Challah Bread Pudding with Raspberries', $recipe->title);

--- a/tests/RecipeParser_Parser_FoodandwinecomTest.php
+++ b/tests/RecipeParser_Parser_FoodandwinecomTest.php
@@ -8,7 +8,8 @@ class RecipeParser_Parser_FoodandwinecomTest extends PHPUnit_Framework_TestCase 
         $path = "data/foodandwine_com_carrot_sheet_cake_with_cream_cheese_curl.html";
         $url = "http://www.foodandwine.com/recipes/carrot-sheet-cake-with-cream-cheese-frosting";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Carrot Sheet Cake with Cream Cheese Frosting', $recipe->title);
@@ -38,7 +39,8 @@ class RecipeParser_Parser_FoodandwinecomTest extends PHPUnit_Framework_TestCase 
         $path = "data/foodandwine_com_chicken_wild_mushroom_and_roasted_garlic_curl.html";
         $url = "http://www.foodandwine.com/recipes/chicken-wild-mushroom-and-roasted-garlic-saute";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Chicken, Wild Mushroom and Roasted-Garlic Sauté', $recipe->title);
@@ -65,7 +67,8 @@ class RecipeParser_Parser_FoodandwinecomTest extends PHPUnit_Framework_TestCase 
         $path = "data/foodandwine_com_hanger_steak_with_shallots_and_mushrooms_curl.html";
         $url = "http://www.foodandwine.com/recipes/hanger-steak-with-shallots-and-mushrooms";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals("", $recipe->photo_url);  // Don't clip F&W thumbnail when photo is missing.
@@ -75,7 +78,8 @@ class RecipeParser_Parser_FoodandwinecomTest extends PHPUnit_Framework_TestCase 
         $path = "data/foodandwine_com_cocoa_carrot_cake_with_cocoa_crumble_curl.html";
         $url = "http://www.foodandwine.com/recipes/cocoa-carrot-cake-with-cocoa-crumble";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Cocoa-Carrot Cake with Cocoa Crumble', $recipe->title);

--- a/tests/RecipeParser_Parser_FoodcomTest.php
+++ b/tests/RecipeParser_Parser_FoodcomTest.php
@@ -8,7 +8,8 @@ class RecipeParser_Parser_FoodcomTest extends PHPUnit_Framework_TestCase {
         $path = "data/food_com_halloween_eyeball_cookies_food_com_curl.html";
         $url = "http://www.food.com/recipe/halloween-eyeball-cookies-143344";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals("Halloween Eyeball Cookies", $recipe->title);
@@ -27,7 +28,8 @@ class RecipeParser_Parser_FoodcomTest extends PHPUnit_Framework_TestCase {
         $path = "data/food_com_braised_lamb_shanks_with_guinness_and_curl.html";
         $url = "http://www.food.com/recipe/braised-lamb-shanks-with-guinness-barley-222337";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals("Braised Lamb Shanks With Guinness & Barley", $recipe->title);
@@ -46,7 +48,8 @@ class RecipeParser_Parser_FoodcomTest extends PHPUnit_Framework_TestCase {
         $path = "data/food_com_carrot_cheesecake_food_com_curl.html";
         $url = "http://www.food.com/recipe/carrot-cheesecake-362026"; 
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals("Carrot Cheesecake", $recipe->title);

--- a/tests/RecipeParser_Parser_FoodnetworkcomTest.php
+++ b/tests/RecipeParser_Parser_FoodnetworkcomTest.php
@@ -8,7 +8,8 @@ class RecipeParser_Parser_FoodnetworkcomTest extends PHPUnit_Framework_TestCase 
         $path = "data/foodnetwork_com_aaron_mccargo_jrs_steak_fajita_chili_curl.html";
         $url = "http://www.foodnetwork.com/recipes/aaron-mccargo-jr/aaron-mccargo-jrs-steak-fajita-chili-recipe.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals("Aaron McCargo, Jr.'s Steak Fajita Chili", $recipe->title);
@@ -26,7 +27,8 @@ class RecipeParser_Parser_FoodnetworkcomTest extends PHPUnit_Framework_TestCase 
         $path = "data/foodnetwork_com_beattys_chocolate_cake_ina_garten_food_curl.html";
         $url = "http://www.foodnetwork.com/recipes/ina-garten/beattys-chocolate-cake-recipe.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals("Beatty's Chocolate Cake", $recipe->title);
@@ -50,7 +52,8 @@ class RecipeParser_Parser_FoodnetworkcomTest extends PHPUnit_Framework_TestCase 
         $path = "data/foodnetwork_com_braised_short_ribs_with_mushrooms_food_curl.html";
         $url = "http://www.foodnetwork.com/recipes/food-network-kitchens/braised-short-ribs-with-mushrooms-recipe.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals("Braised Short Ribs with Mushrooms", $recipe->title);
@@ -71,7 +74,8 @@ class RecipeParser_Parser_FoodnetworkcomTest extends PHPUnit_Framework_TestCase 
         $path = "data/foodnetwork_com_chocolate_cake_emeril_lagasse_food_network_curl.html";
         $url = "http://www.foodnetwork.com/recipes/emeril-lagasse/chocolate-cake-recipe.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals("Chocolate Cake", $recipe->title);
@@ -92,7 +96,8 @@ class RecipeParser_Parser_FoodnetworkcomTest extends PHPUnit_Framework_TestCase 
         $path = "data/foodnetwork_com_big_blue_burgers_rachael_ray_food_curl.html";
         $url = "http://www.foodnetwork.com/recipes/rachael-ray/big-blue-burgers-recipe.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals("Big Blue Burgers", $recipe->title);
@@ -114,7 +119,8 @@ class RecipeParser_Parser_FoodnetworkcomTest extends PHPUnit_Framework_TestCase 
         $path = "data/foodnetwork_com_six_layer_chocolate_cake_paula_deen_curl.html";
         $url = "http://www.foodnetwork.com/recipes/paula-deen/six-layer-chocolate-cake-recipe.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         // Testing only for format of multi-step ingredients
@@ -134,7 +140,8 @@ class RecipeParser_Parser_FoodnetworkcomTest extends PHPUnit_Framework_TestCase 
         $path = "data/foodnetwork_com_cream_scones_with_currants_food_network_curl.html";
         $url = "http://www.foodnetwork.com/recipes/food-network-kitchens/cream-scones-with-currants-recipe.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('8 scones', $recipe->yield);
@@ -147,7 +154,8 @@ class RecipeParser_Parser_FoodnetworkcomTest extends PHPUnit_Framework_TestCase 
         $path = "data/foodnetwork_com_roasted_pepper_pasta_salad_food_network_curl.html";
         $url = "http://www.foodnetwork.com/recipes/food-network-kitchens/roasted-pepper-pasta-salad-recipe.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals(4, count($recipe->instructions[0]['list']));
@@ -158,7 +166,8 @@ class RecipeParser_Parser_FoodnetworkcomTest extends PHPUnit_Framework_TestCase 
         $path = "data/foodnetwork_com_bubble_tea_food_network_kitchen_food_curl.html";
         $url = "http://www.foodnetwork.com/recipes/food-network-kitchens/bubble-tea-recipe.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals("Bubble Tea", $recipe->title);
@@ -178,7 +187,8 @@ class RecipeParser_Parser_FoodnetworkcomTest extends PHPUnit_Framework_TestCase 
         $path = "data/foodnetwork_com_mini_upside_down_cakes_food_network_curl.html";
         $url = "http://www.foodnetwork.com/recipes/food-network-kitchens/mini-upside-down-cakes-recipe.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals("Mini Upside-Down Cakes", $recipe->title);
@@ -195,7 +205,8 @@ class RecipeParser_Parser_FoodnetworkcomTest extends PHPUnit_Framework_TestCase 
         $path = "data/foodnetwork_com_scallop_ceviche_food_network_kitchen_food_curl.html";
         $url = "http://www.foodnetwork.com/recipes/food-network-kitchens/scallop-ceviche-recipe.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals("Scallop Ceviche", $recipe->title);
@@ -212,7 +223,8 @@ class RecipeParser_Parser_FoodnetworkcomTest extends PHPUnit_Framework_TestCase 
         $path = "data/foodnetwork_com_roast_bacon_ina_garten_food_network_curl.html";
         $url = "http://www.foodnetwork.com/recipes/ina-garten/roast-bacon-recipe.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals(2, count($recipe->instructions[0]['list']));

--- a/tests/RecipeParser_Parser_FoodnetworkcoukTest.php
+++ b/tests/RecipeParser_Parser_FoodnetworkcoukTest.php
@@ -8,7 +8,8 @@ class RecipeParser_Parser_Foodnetworkcouk_Test extends PHPUnit_Framework_TestCas
         $path = "data/foodnetwork_co_uk_herb_marinated_pork_fillet_by_ina_curl.html";
         $url  = "http://www.foodnetwork.co.uk/recipes/herb-marinated-pork-tenderloins.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Herb-marinated Pork Fillet', $recipe->title);
@@ -34,7 +35,8 @@ class RecipeParser_Parser_Foodnetworkcouk_Test extends PHPUnit_Framework_TestCas
         $path = "data/foodnetwork_co_uk_jonathans_pepperpot_by_jonathan_phang_food_curl.html";
         $url  = "http://www.foodnetwork.co.uk/recipes/jonathans-pepperpot.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Jonathan\'s Pepperpot', $recipe->title);
@@ -60,7 +62,8 @@ class RecipeParser_Parser_Foodnetworkcouk_Test extends PHPUnit_Framework_TestCas
         $path = "data/foodnetwork_co_uk_lemon_yoghurt_cake_by_ina_garten_curl.html";
         $url  = "http://www.foodnetwork.co.uk/recipes/lemon-yoghurt-cake.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Lemon Yoghurt Cake', $recipe->title);

--- a/tests/RecipeParser_Parser_KingarthurflourcomTest.php
+++ b/tests/RecipeParser_Parser_KingarthurflourcomTest.php
@@ -5,10 +5,11 @@ require_once '../bootstrap.php';
 class Import_Kingarthurflourcom_Test extends PHPUnit_Framework_TestCase {
 
     public function test_cream_pie() {
-        $path_orig = "data/kingarthurflour_com_cream_pie.html";
+        $path = "data/kingarthurflour_com_cream_pie.html";
         $url = "http://www.kingarthurflour.com/recipes/chocolate-cream-pie-recipe";
 
-        $recipe = RecipeParser::parse(file_get_contents($path_orig), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Chocolate Cream Pie', $recipe->title);
@@ -40,10 +41,11 @@ class Import_Kingarthurflourcom_Test extends PHPUnit_Framework_TestCase {
     }
 
     public function test_golden_vanilla_cake() {
-        $path_orig = "data/kingarthurflour_com_golden_vanilla_cake.html";
+        $path = "data/kingarthurflour_com_golden_vanilla_cake.html";
         $url = "http://www.kingarthurflour.com/recipes/golden-vanilla-cake-recipe";
 
-        $recipe = RecipeParser::parse(file_get_contents($path_orig), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Golden Vanilla Cake', $recipe->title);
@@ -59,10 +61,11 @@ class Import_Kingarthurflourcom_Test extends PHPUnit_Framework_TestCase {
     }
 
     public function test_pretzels() {
-        $path_orig = "data/kingarthurflour_com_pretzels.html";
+        $path = "data/kingarthurflour_com_pretzels.html";
         $url = "http://www.kingarthurflour.com/recipes/hot-buttered-soft-pretzels-recipe";
 
-        $recipe = RecipeParser::parse(file_get_contents($path_orig), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Hot Buttered Soft Pretzels', $recipe->title);

--- a/tests/RecipeParser_Parser_MarthastewartcomTest.php
+++ b/tests/RecipeParser_Parser_MarthastewartcomTest.php
@@ -8,7 +8,8 @@ class RecipeParser_Parser_MarthastewartcomTest extends PHPUnit_Framework_TestCas
         $path = "data/marthastewart_com_emerils_pork_and_chorizo_burgers_with_curl.html";
         $url = "http://www.marthastewart.com/284367/emerils-pork-and-chorizo-burgers-with-gr?czone=food%2Fbest-grilling-recipes%2Fgrilling-recipes";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals(15, $recipe->time['prep']);
@@ -28,7 +29,8 @@ class RecipeParser_Parser_MarthastewartcomTest extends PHPUnit_Framework_TestCas
         $path = "data/marthastewart_com_sauteed_cajun_shrimp_martha_stewart_curl.html";
         $url = "http://www.marthastewart.com/255277/sauteed-cajun-shrimp?czone=food%2Fdinner-tonight-center%2Fdinner-tonight-main-courses";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals(20, $recipe->time['prep']);
@@ -46,7 +48,8 @@ class RecipeParser_Parser_MarthastewartcomTest extends PHPUnit_Framework_TestCas
         $path = "data/marthastewart_com_strawberry_tart_martha_stewart_curl.html";
         $url = "http://www.marthastewart.com/340929/strawberry-tart?czone=food%2Fproduce-guide-cnt%2Fspring-produce-recipes";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals(30, $recipe->time['prep']);

--- a/tests/RecipeParser_Parser_MicrodataDataVocabularyTest.php
+++ b/tests/RecipeParser_Parser_MicrodataDataVocabularyTest.php
@@ -8,7 +8,8 @@ class RecipeParser_Parser_MicrodataDataVocabularyTest extends PHPUnit_Framework_
         $path = "data/datavocabulary_spec.html";
         $url = "http://data-vocabulary.example.com/recipes/spec";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals("Grandma's Holiday Apple Pie", $recipe->title);
@@ -43,7 +44,8 @@ class RecipeParser_Parser_MicrodataDataVocabularyTest extends PHPUnit_Framework_
     public function test_schema_spec_class_instruction() {
         $path = "data/datavocabulary_spec_class_instruction.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path));
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals(1, count($recipe->instructions));
@@ -56,7 +58,8 @@ class RecipeParser_Parser_MicrodataDataVocabularyTest extends PHPUnit_Framework_
     public function test_datavocabulary_spec_instructions_li() {
         $path = "data/datavocabulary_spec_instructions_li.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path));
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals(1, count($recipe->instructions));

--- a/tests/RecipeParser_Parser_MicrodataRdfDataVocabularyTest.php
+++ b/tests/RecipeParser_Parser_MicrodataRdfDataVocabularyTest.php
@@ -8,7 +8,8 @@ class RecipeParser_Parser_MicrodataRdfDataVocabularyTest extends PHPUnit_Framewo
         $path = "data/rdf_datavocabulary_spec.html";
         $url = "http://rdf.data-vocabulary.example.com/recipes/spec";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals("Grandma's Holiday Apple Pie", $recipe->title);
@@ -41,7 +42,8 @@ class RecipeParser_Parser_MicrodataRdfDataVocabularyTest extends PHPUnit_Framewo
         $path = "data/rdf_datavocabulary_spec_property_instruction.html";
         $url = "http://rdf.data-vocabulary.example.com/recipes/spec";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals(1, count($recipe->instructions));
@@ -55,7 +57,8 @@ class RecipeParser_Parser_MicrodataRdfDataVocabularyTest extends PHPUnit_Framewo
         $path = "data/rdf_datavocabulary_spec_sub_nodes.html";
         $url = "http://rdf.data-vocabulary.example.com/recipes/spec";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals(1, count($recipe->instructions));

--- a/tests/RecipeParser_Parser_MicrodataSchemaTest.php
+++ b/tests/RecipeParser_Parser_MicrodataSchemaTest.php
@@ -8,7 +8,8 @@ class RecipeParser_Parser_MicrodataSchemaTest extends PHPUnit_Framework_TestCase
         $path = "data/schema_spec.html";
         $url = "http://schema.example.com/schema-spec";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals("Mom's World Famous Banana Bread", $recipe->title);
@@ -36,7 +37,8 @@ class RecipeParser_Parser_MicrodataSchemaTest extends PHPUnit_Framework_TestCase
         $path = "data/schema_spec_publisher.html";
         $url = "http://schema.example.com/schema-spec";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
     }
@@ -45,7 +47,8 @@ class RecipeParser_Parser_MicrodataSchemaTest extends PHPUnit_Framework_TestCase
         $path = "data/schema_spec_class_instruction.html";
         $url = "http://schema.example.com/schema-spec";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals(1, count($recipe->instructions));
@@ -59,7 +62,8 @@ class RecipeParser_Parser_MicrodataSchemaTest extends PHPUnit_Framework_TestCase
         $path = "data/schema_spec_recipeinstructions_li.html";
         $url = "http://schema.example.com/schema-spec";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals(1, count($recipe->instructions));
@@ -73,7 +77,8 @@ class RecipeParser_Parser_MicrodataSchemaTest extends PHPUnit_Framework_TestCase
         $path = "data/schema_spec_yield_as_content.html";
         $url = "http://schema.example.com/schema-spec";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('12 servings', $recipe->yield);
@@ -83,7 +88,8 @@ class RecipeParser_Parser_MicrodataSchemaTest extends PHPUnit_Framework_TestCase
         $path = "data/bettycrocker_com_banana_cake_with_fudge_frosting_curl.html";
         $url = "http://www.bettycrocker.com/recipes/banana-cake-with-fudge-frosting/ec14f90a-4ed3-4ef7-8f69-d9d5aadcebc3";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Banana Cake with Fudge Frosting', $recipe->title);
@@ -111,7 +117,8 @@ class RecipeParser_Parser_MicrodataSchemaTest extends PHPUnit_Framework_TestCase
         $path = "data/bettycrocker_com_blueberry_banana_oat_bread_curl.html";
         $url = "http://www.bettycrocker.com/recipes/blueberry-banana-oat-bread/886c41eb-a229-4ab5-ac74-41b68c4ce0ac";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Blueberry-Banana-Oat Bread', $recipe->title);
@@ -137,7 +144,8 @@ class RecipeParser_Parser_MicrodataSchemaTest extends PHPUnit_Framework_TestCase
         $path = "data/bettycrocker_com_coffee_toffee_cake_with_caramel_frosting_curl.html";
         $url = "http://www.bettycrocker.com/recipes/coffee-toffee-cake-with-caramel-frosting/557b8338-f603-4cc4-95e0-ec44089964bd";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Coffee-Toffee Cake with Caramel Frosting', $recipe->title);
@@ -163,7 +171,8 @@ class RecipeParser_Parser_MicrodataSchemaTest extends PHPUnit_Framework_TestCase
         $path = "data/wholefoodsmarket_com_mushroom_kale_noodle_kugel_whole_foods_curl.html";
         $url = "http://www.wholefoodsmarket.com/recipes/3112";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Mushroom Kale Noodle Kugel', $recipe->title);

--- a/tests/RecipeParser_Parser_MicroformatExamplesTest.php
+++ b/tests/RecipeParser_Parser_MicroformatExamplesTest.php
@@ -8,7 +8,8 @@ class RecipeParser_Parser_MicroformatExamplesTest extends PHPUnit_Framework_Test
         $path = "data/cookingchanneltv_com_matt_s_lemon_blueberry_muffins_s_cooking_curl.html";
         $url = "http://www.cookingchanneltv.com/recipes/matts-lemon-blueberry-muffins-recipe/index.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path));
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals("Matt's Lemon Blueberry Muffins", $recipe->title);

--- a/tests/RecipeParser_Parser_MicroformatTest.php
+++ b/tests/RecipeParser_Parser_MicroformatTest.php
@@ -8,7 +8,8 @@ class RecipeParser_Parser_MicroformatSpecTest extends PHPUnit_Framework_TestCase
         $path = "data/microformat_spec.html";
         $url = "http://microformat.example.com/recipes/spec";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals("Grandma's Holiday Apple Pie", $recipe->title);
@@ -43,7 +44,8 @@ class RecipeParser_Parser_MicroformatSpecTest extends PHPUnit_Framework_TestCase
         $path = "data/microformat_spec_class_instruction.html";
         $url = "http://microformat.example.com/recipes/spec";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals(1, count($recipe->instructions));
@@ -57,7 +59,8 @@ class RecipeParser_Parser_MicroformatSpecTest extends PHPUnit_Framework_TestCase
         $path = "data/microformat_spec_instructions_li.html";
         $url = "http://microformat.example.com/recipes/spec";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals(1, count($recipe->instructions));

--- a/tests/RecipeParser_Parser_MyrecipescomTest.php
+++ b/tests/RecipeParser_Parser_MyrecipescomTest.php
@@ -8,7 +8,8 @@ class RecipeParser_Parser_MyrecipescomTest extends PHPUnit_Framework_TestCase {
         $path = "data/myrecipes_com_blueberry_and_blackberry_galette_with_cornmeal_curl.html";
         $url = "http://www.myrecipes.com/recipe/blueberry-blackberry-galette-with-cornmeal-crust-10000001816371/";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals("Blueberry and Blackberry Galette with Cornmeal Crust", $recipe->title);
@@ -33,7 +34,8 @@ class RecipeParser_Parser_MyrecipescomTest extends PHPUnit_Framework_TestCase {
         $path = "data/myrecipes_com_simple_clam_chowder_my_com_curl.html";
         $url = "http://www.myrecipes.com/recipe/simple-clam-chowder-10000001696572/";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals("Simple Clam Chowder", $recipe->title);
@@ -46,7 +48,8 @@ class RecipeParser_Parser_MyrecipescomTest extends PHPUnit_Framework_TestCase {
         $path = "data/myrecipes_com_king_ranch_chicken_casserole_my_com_curl.html";
         $url = "http://www.myrecipes.com/recipe/king-ranch-chicken-casserole-10000001704091/";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals("King Ranch Chicken Casserole", $recipe->title);
@@ -61,7 +64,8 @@ class RecipeParser_Parser_MyrecipescomTest extends PHPUnit_Framework_TestCase {
         $path = "data/myrecipes_com_charred_lemon_chicken_piccata_my_com_curl.html";
         $url = "http://www.myrecipes.com/recipe/charred-lemon-chicken-piccata";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals("Charred Lemon Chicken Piccata", $recipe->title);
@@ -76,7 +80,8 @@ class RecipeParser_Parser_MyrecipescomTest extends PHPUnit_Framework_TestCase {
         $path = "data/myrecipes_com_creamy_broccoli_cheese_soup_my_com_curl.html";
         $url = "http://www.myrecipes.com/recipe/creamy-broccoli-cheese-soup";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals("Creamy Broccoli-Cheese Soup", $recipe->title);

--- a/tests/RecipeParser_Parser_NytimescomTest.php
+++ b/tests/RecipeParser_Parser_NytimescomTest.php
@@ -12,7 +12,8 @@ class RecipeParser_Parser_NytimescomRecipesTest extends PHPUnit_Framework_TestCa
         $path = "data/nytimes_com_blackberry_jam_cake_with_caramel_icing_curl.html";
         $url = "http://www.nytimes.com/recipes/7801/Blackberry-Jam-Cake-With-Caramel-Icing.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Blackberry Jam Cake With Caramel Icing', $recipe->title);
@@ -37,7 +38,8 @@ class RecipeParser_Parser_NytimescomRecipesTest extends PHPUnit_Framework_TestCa
         $path = "data/nytimes_com_fudge_frosting_the_new_york_times_curl.html";
         $url = "http://www.nytimes.com/recipes/9953/Fudge-Frosting.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Fudge Frosting', $recipe->title);
@@ -62,7 +64,8 @@ class RecipeParser_Parser_NytimescomRecipesTest extends PHPUnit_Framework_TestCa
         $path = "data/nytimes_com_lemon_cake_with_coconut_icing_the_curl.html";
         $url = "http://www.nytimes.com/recipes/7800/Lemon-Cake-With-Coconut-Icing.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Lemon Cake With Coconut Icing', $recipe->title);
@@ -89,7 +92,8 @@ class RecipeParser_Parser_NytimescomRecipesTest extends PHPUnit_Framework_TestCa
         $path = "data/nytimes_com_service_cake_with_victory_icing_the_curl.html";
         $url = "http://www.nytimes.com/recipes/7357/Service-Cake-With-Victory-Icing.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Service Cake With Victory Icing', $recipe->title);
@@ -119,7 +123,8 @@ class RecipeParser_Parser_NytimescomRecipesTest extends PHPUnit_Framework_TestCa
         $path = "data/nytimes_com_blood_orange_olive_oil_cake_nytimes_curl.html";
         $url = "http://www.nytimes.com/2009/03/18/dining/181arex.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals(0, $recipe->time['prep']);
@@ -143,7 +148,8 @@ class RecipeParser_Parser_NytimescomRecipesTest extends PHPUnit_Framework_TestCa
         $path = "data/nytimes_com_braised_sauerkraut_with_lots_of_pork_curl.html";
         $url = "http://www.nytimes.com/2011/02/16/dining/16apperex.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals(0, $recipe->time['prep']);
@@ -164,7 +170,8 @@ class RecipeParser_Parser_NytimescomRecipesTest extends PHPUnit_Framework_TestCa
         $path = "data/nytimes_com_clay_pot_pork_nytimes_com_curl.html";
         $url = "http://www.nytimes.com/2011/03/30/dining/30braiserex1.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals(0, $recipe->time['prep']);
@@ -185,7 +192,8 @@ class RecipeParser_Parser_NytimescomRecipesTest extends PHPUnit_Framework_TestCa
         $path = "data/nytimes_com_lentils_and_rice_with_or_without_curl.html";
         $url = "http://www.nytimes.com/2011/01/02/weekinreview/02recipes-2.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals(0, $recipe->time['prep']);
@@ -208,7 +216,8 @@ class RecipeParser_Parser_NytimescomRecipesTest extends PHPUnit_Framework_TestCa
         $path = "data/nytimes_com_rhubarb_upside_down_cake_nytimes_com_curl.html";
         $url = "http://www.nytimes.com/2011/05/25/dining/rhubarb-upside-down-cake-recipe.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals(0, $recipe->time['prep']);
@@ -233,7 +242,8 @@ class RecipeParser_Parser_NytimescomRecipesTest extends PHPUnit_Framework_TestCa
         $path = "data/nytimes_com_yellow_layer_cake_with_chocolate_frosting_curl.html";
         $url = "http://www.nytimes.com/2008/05/28/dining/281frex.html?ref=dining";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals(0, $recipe->time['prep']);

--- a/tests/RecipeParser_Parser_PillsburycomTest.php
+++ b/tests/RecipeParser_Parser_PillsburycomTest.php
@@ -5,10 +5,11 @@ require_once '../bootstrap.php';
 class RecipeParser_Parser_PillsburycomTest extends PHPUnit_Framework_TestCase {
 
     public function test_banana_crumb_cake() {
-        $path_orig = "data/pillsbury_com_banana_crumb_cake_from_pillsbury_com_curl.html";
+        $path = "data/pillsbury_com_banana_crumb_cake_from_pillsbury_com_curl.html";
         $url = "http://www.pillsbury.com/recipes/banana-crumb-cake/0ddbc221-0c55-47ea-aaab-7439b4aac4a6/";
 
-        $recipe = RecipeParser::parse(file_get_contents($path_orig), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Banana Crumb Cake', $recipe->title);
@@ -35,10 +36,11 @@ class RecipeParser_Parser_PillsburycomTest extends PHPUnit_Framework_TestCase {
     }
 
     public function test_cookie_pizza() {
-        $path_orig = "data/pillsbury_com_rocky_road_cookie_pizza_cookie_dough_curl.html";
+        $path = "data/pillsbury_com_rocky_road_cookie_pizza_cookie_dough_curl.html";
         $url = "http://www.pillsbury.com/recipes/rocky-road-cookie-pizza-cookie-dough-tub/8e79226f-937e-49c3-84a8-5bd55fa94d00/";
 
-        $recipe = RecipeParser::parse(file_get_contents($path_orig), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Rocky Road Cookie Pizza (cookie dough tub)', $recipe->title);
@@ -63,10 +65,11 @@ class RecipeParser_Parser_PillsburycomTest extends PHPUnit_Framework_TestCase {
     }
 
     public function test_white_wedding_cake() {
-        $path_orig = "data/pillsbury_com_white_wedding_cake_with_raspberry_filling_curl.html";
+        $path = "data/pillsbury_com_white_wedding_cake_with_raspberry_filling_curl.html";
         $url = "http://www.pillsbury.com/recipes/white-wedding-cake-with-raspberry-filling/552ae7a5-c451-43fa-9ddc-12b24dbce825/";
 
-        $recipe = RecipeParser::parse(file_get_contents($path_orig), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('White Wedding Cake with Raspberry Filling', $recipe->title);

--- a/tests/RecipeParser_Parser_RealsimplecomTest.php
+++ b/tests/RecipeParser_Parser_RealsimplecomTest.php
@@ -8,7 +8,8 @@ class RecipeParser_Parser_RealsimplecomTest extends PHPUnit_Framework_TestCase {
         $path = "data/realsimple_com_paprika_spiced_pork_chops_with_spinach_curl.html";
         $url = "http://www.realsimple.com/food-recipes/browse-all-recipes/paprika-spiced-pork-chops-recipe-00000000029765/index.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Paprika-Spiced Pork Chops With Spinach Sauté', $recipe->title);
@@ -32,7 +33,8 @@ class RecipeParser_Parser_RealsimplecomTest extends PHPUnit_Framework_TestCase {
         $path = "data/realsimple_com_yellow_cake_with_vanilla_frosting_and_curl.html";
         $url = "http://www.realsimple.com/food-recipes/browse-all-recipes/yellow-cake-vanilla-frosting-00000000057748/index.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Yellow Cake With Vanilla Frosting and White Chocolate Chips', $recipe->title);

--- a/tests/RecipeParser_Parser_RecipecomTest.php
+++ b/tests/RecipeParser_Parser_RecipecomTest.php
@@ -8,7 +8,8 @@ class RecipeParser_Parser_RecipecomTest extends PHPUnit_Framework_TestCase {
         $path = "data/recipe_com_quot_healthified_quot_chicken_tortilla_casserole_curl.html";
         $url = "http://www.recipe.com/healthified-chicken-tortilla-casserole/";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('"Healthified" Chicken Tortilla Casserole', $recipe->title);
@@ -34,7 +35,8 @@ class RecipeParser_Parser_RecipecomTest extends PHPUnit_Framework_TestCase {
         $path = "data/recipe_com_hot_dog_hamburger_secret_sauce_com_curl.html";
         $url = "http://www.recipe.com/hot-dog-hamburger-secret-sauce/";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Hot Dog-Hamburger Secret Sauce', $recipe->title);
@@ -61,7 +63,8 @@ class RecipeParser_Parser_RecipecomTest extends PHPUnit_Framework_TestCase {
         $path = "data/recipe_com_one_bowl_chocolate_cake_com_curl.html";
         $url = "http://www.recipe.com/one-bowl-chocolate-cake/";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('One-Bowl Chocolate Cake', $recipe->title);

--- a/tests/RecipeParser_Parser_SaveurcomTest.php
+++ b/tests/RecipeParser_Parser_SaveurcomTest.php
@@ -9,7 +9,8 @@ class RecipeParser_Parser_SaveurcomTest extends PHPUnit_Framework_TestCase {
         $path = "data/saveur_com_mitzis_chicken_fingers_curl.html";
         $url  = "http://www.saveur.com/article/Recipes/Mitzis-Chicken-Fingers";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Mitzi\'s Chicken Fingers', $recipe->title);
@@ -39,7 +40,8 @@ class RecipeParser_Parser_SaveurcomTest extends PHPUnit_Framework_TestCase {
         $path = "data/saveur_com_sponsored_curl.html";
         $url  = "http://www.saveur.com/article/Recipes/sponsored-Recipe-Ghirardellis-Chocolate-Chip-Bundt-Cake";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Ghirardelli\'s® Chocolate Chip Bundt Cake', $recipe->title);
@@ -68,7 +70,8 @@ class RecipeParser_Parser_SaveurcomTest extends PHPUnit_Framework_TestCase {
         $path = "data/saveur_com_strawberry_loaf_bread_curl.html";
         $url  = "http://www.saveur.com/article/Recipes/Strawberry-Loaf-Bread";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Strawberry Bread', $recipe->title);
@@ -98,7 +101,8 @@ class RecipeParser_Parser_SaveurcomTest extends PHPUnit_Framework_TestCase {
         $path = "data/saveur_com_strawberry_tart_curl.html";
         $url  = "http://www.saveur.com/article/Recipes/Strawberry-Tart";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Strawberry Tart', $recipe->title);
@@ -125,7 +129,8 @@ class RecipeParser_Parser_SaveurcomTest extends PHPUnit_Framework_TestCase {
         $path = "data/saveur_com_thomas_kellers_coconut_cake_curl.html";
         $url  = "http://www.saveur.com/article/recipes/thomas-kellers-coconut-cake";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Thomas Keller\'s Coconut Cake', $recipe->title);

--- a/tests/RecipeParser_Parser_SeriouseatscomTest.php
+++ b/tests/RecipeParser_Parser_SeriouseatscomTest.php
@@ -5,10 +5,11 @@ require_once '../bootstrap.php';
 class RecipeParser_Parser_SeriouseatscomTest extends PHPUnit_Framework_TestCase {
 
     public function test_banana_split_whoopie_pies() {
-        $path_orig = "data/seriouseats_com_banana_split_s_more_whoopie_pies_serious_curl.html";
+        $path = "data/seriouseats_com_banana_split_s_more_whoopie_pies_serious_curl.html";
         $url = "http://www.seriouseats.com/recipes/2011/08/banana-split-smore-whoopie-pies-recipe.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path_orig), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Banana Split S\'more Whoopie Pies', $recipe->title);
@@ -35,10 +36,11 @@ class RecipeParser_Parser_SeriouseatscomTest extends PHPUnit_Framework_TestCase 
     }
 
     public function test_sauted_andouille() {
-        $path_orig = "data/seriouseats_com_dinner_tonight_saut_ed_andouille_and_greens_curl.html";
+        $path = "data/seriouseats_com_dinner_tonight_saut_ed_andouille_and_greens_curl.html";
         $url = "http://www.seriouseats.com/recipes/2011/08/sauteed-andouille-and-greens-with-grits-recipe.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path_orig), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Sautéed Andouille and Greens With Grits', $recipe->title);
@@ -61,9 +63,10 @@ class RecipeParser_Parser_SeriouseatscomTest extends PHPUnit_Framework_TestCase 
     }
 
     public function test_aleppo_rubbed_pork_ribs() {
-        $path_orig = "data/seriouseats_com_sunday_supper_aleppo_rubbed_pork_ribs_serious_curl.html";
+        $path = "data/seriouseats_com_sunday_supper_aleppo_rubbed_pork_ribs_serious_curl.html";
         $url = "http://www.seriouseats.com/recipes/2011/08/aleppo-rubbed-pork-ribs.html";
-        $recipe = RecipeParser::parse(file_get_contents($path_orig), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         
 
 
@@ -86,10 +89,11 @@ class RecipeParser_Parser_SeriouseatscomTest extends PHPUnit_Framework_TestCase 
     }
 
     public function test_sunday_brunch_oysters_rockefeller() {
-        $path_orig = "data/seriouseats_com_oysters_rockefeller_serious_eats_s_curl.html";
+        $path = "data/seriouseats_com_oysters_rockefeller_serious_eats_s_curl.html";
         $url = "http://www.seriouseats.com/recipes/2011/08/oysters-rockefeller-sunday-brunch-seafood-appetizer.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path_orig), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         
 
 

--- a/tests/RecipeParser_Parser_SimplyrecipescomTest.php
+++ b/tests/RecipeParser_Parser_SimplyrecipescomTest.php
@@ -8,7 +8,8 @@ class RecipeParser_Parser_SimplyrecipescomTest extends PHPUnit_Framework_TestCas
         $path = "data/simplyrecipes_com_apple_cranberry_pie_simply_s_curl.html";
         $url = "http://simplyrecipes.com/recipes/apple_cranberry_pie/";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Apple Cranberry Pie', $recipe->title);
@@ -40,7 +41,8 @@ class RecipeParser_Parser_SimplyrecipescomTest extends PHPUnit_Framework_TestCas
         $path = "data/simplyrecipes_com_chicken_curry_salad_simply_s_curl.html";
         $url = "http://simplyrecipes.com/recipes/chicken_curry_salad/";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Chicken Curry Salad', $recipe->title);
@@ -58,7 +60,8 @@ class RecipeParser_Parser_SimplyrecipescomTest extends PHPUnit_Framework_TestCas
         $path = "data/simplyrecipes_com_chile_relleno_casserole_simply_s_curl.html";
         $url = "http://simplyrecipes.com/recipes/chile_relleno_casserole/";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Chile Relleno Casserole', $recipe->title);
@@ -81,7 +84,8 @@ class RecipeParser_Parser_SimplyrecipescomTest extends PHPUnit_Framework_TestCas
         $path = "data/simplyrecipes_com_grilled_tri_tip_steak_with_bell_pepper_curl.html";
         $url = "http://simplyrecipes.com/recipes/grilled_tri-tip_steak_with_bell_pepper_salsa/";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Grilled Tri-Tip Steak with Bell Pepper Salsa', $recipe->title);

--- a/tests/RecipeParser_Parser_SkinnytastecomTest.php
+++ b/tests/RecipeParser_Parser_SkinnytastecomTest.php
@@ -9,7 +9,8 @@ class RecipeParser_Parser_Skinnytastecom_Test extends PHPUnit_Framework_TestCase
         $path = "data/skinnytaste_com_baked_empanadas_skinnytaste_curl.html";
         $url  = "http://www.skinnytaste.com/2009/01/baked-empanadas-3-pts.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Baked Empanadas', $recipe->title);
@@ -30,7 +31,8 @@ class RecipeParser_Parser_Skinnytastecom_Test extends PHPUnit_Framework_TestCase
         $path = "data/skinnytaste_com_homemade_skinny_chocolate_cake_skinnytaste_curl.html";
         $url  = "http://www.skinnytaste.com/2012/02/homemade-skinny-chocolate-cake.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Homemade Skinny Chocolate Cake', $recipe->title);
@@ -51,7 +53,8 @@ class RecipeParser_Parser_Skinnytastecom_Test extends PHPUnit_Framework_TestCase
         $path = "data/skinnytaste_com_pink_lemonade_confetti_cupcakes_skinnytaste_curl.html";
         $url  = "http://www.skinnytaste.com/2011/07/pink-lemonade-confetti-cupcakes.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Pink Lemonade Confetti Cupcakes', $recipe->title);
@@ -73,7 +76,8 @@ class RecipeParser_Parser_Skinnytastecom_Test extends PHPUnit_Framework_TestCase
         $path = "data/skinnytaste_com_red_white_and_blueberry_trifle_skinnytaste_curl.html";
         $url  = "http://www.skinnytaste.com/2011/06/red-white-and-blueberry-trifle.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Red, White and Blueberry Trifle', $recipe->title);
@@ -97,7 +101,8 @@ class RecipeParser_Parser_Skinnytastecom_Test extends PHPUnit_Framework_TestCase
         $path = "data/skinnytaste_com_shrimp_salad_on_cucumber_slices_skinnytaste_curl.html";
         $url  = "http://www.skinnytaste.com/2010/08/shrimp-salad-on-cucumber-slices.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Shrimp Salad on Cucumber Slices', $recipe->title);
@@ -119,7 +124,8 @@ class RecipeParser_Parser_Skinnytastecom_Test extends PHPUnit_Framework_TestCase
         $path = "data/skinnytaste_com_skinny_coconut_cupcakes_skinnytaste_curl.html";
         $url  = "http://www.skinnytaste.com/2012/03/skinny-coconut-cupcakes.html";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Skinny Coconut Cupcakes', $recipe->title);

--- a/tests/RecipeParser_Parser_SparkpeoplecomTest.php
+++ b/tests/RecipeParser_Parser_SparkpeoplecomTest.php
@@ -8,7 +8,8 @@ class RecipeParser_Parser__Sparkpeoplecom_Test extends PHPUnit_Framework_TestCas
         $path = "data/recipes_sparkpeople_com_carrot_pumpkin_bars_by_andrewmom_sparks_curl.html";
         $url = "http://recipes.sparkpeople.com/recipe-detail.asp?recipe=157762";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Carrot Pumpkin Bars', $recipe->title);
@@ -41,7 +42,8 @@ class RecipeParser_Parser__Sparkpeoplecom_Test extends PHPUnit_Framework_TestCas
         $path = "data/recipes_sparkpeople_com_mini_cheesecakes_by_sparks_curl.html";
         $url = "http://recipes.sparkpeople.com/recipe-detail.asp?recipe=63";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Mini Cheesecakes', $recipe->title);
@@ -67,7 +69,8 @@ class RecipeParser_Parser__Sparkpeoplecom_Test extends PHPUnit_Framework_TestCas
         $path = "data/recipes_sparkpeople_com_no_bake_graham_cracker_cheesycake_by_curl.html";
         $url = "http://recipes.sparkpeople.com/recipe-detail.asp?recipe=384073";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('No Bake Graham Cracker Cheesycake', $recipe->title);
@@ -90,7 +93,8 @@ class RecipeParser_Parser__Sparkpeoplecom_Test extends PHPUnit_Framework_TestCas
         $path = "data/recipes_sparkpeople_com_skillet_lasagna_by_veggiekitty_sparks_curl.html";
         $url = "http://recipes.sparkpeople.com/recipe-detail.asp?recipe=20856";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Skillet Lasagna', $recipe->title);

--- a/tests/RecipeParser_Parser_TasteofhomecomTest.php
+++ b/tests/RecipeParser_Parser_TasteofhomecomTest.php
@@ -8,7 +8,8 @@ class RecipeParser_Parser_TasteofhomecomTest extends PHPUnit_Framework_TestCase 
         $path = "data/tasteofhome_com_almond_cheddar_appetizers_curl.html";
         $url = "http://www.tasteofhome.com/Recipes/Almond-Cheddar-Appetizers";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Almond Cheddar Appetizers', $recipe->title);
@@ -33,7 +34,8 @@ class RecipeParser_Parser_TasteofhomecomTest extends PHPUnit_Framework_TestCase 
         $path = "data/tasteofhome_com_artichoke_chicken_curl.html";
         $url = "http://www.tasteofhome.com/Recipes/Artichoke-Chicken";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Artichoke Chicken', $recipe->title);
@@ -52,7 +54,8 @@ class RecipeParser_Parser_TasteofhomecomTest extends PHPUnit_Framework_TestCase 
         $path = "data/tasteofhome_com_lemon_berry_shortcake_curl.html";
         $url = "http://www.tasteofhome.com/Recipes/Lemon-Berry-Shortcake";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Lemon-Berry Shortcake', $recipe->title);

--- a/tests/RecipeParser_Parser_ThedailymealcomTest.php
+++ b/tests/RecipeParser_Parser_ThedailymealcomTest.php
@@ -7,7 +7,8 @@ class RecipeParser_Parser_ThedailymealcomTest extends PHPUnit_Framework_TestCase
         $path = "data/thedailymeal_com_roast_capon_the_daily_meal_curl.html";
         $url  = "http://www.thedailymeal.com/roast-capon";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Roast Capon', $recipe->title);
@@ -31,7 +32,8 @@ class RecipeParser_Parser_ThedailymealcomTest extends PHPUnit_Framework_TestCase
         $path = "data/thedailymeal_com_whiskey_the_daily_meal_curl.html";
         $url  = "http://www.thedailymeal.com/whiskey-30";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Whiskey 3.0', $recipe->title);

--- a/tests/RecipeParser_Parser_ThekitchencomTest.php
+++ b/tests/RecipeParser_Parser_ThekitchencomTest.php
@@ -8,7 +8,8 @@ class RecipeParser_Parser_Thekitchencom_Test extends PHPUnit_Framework_TestCase 
         $path = "data/thekitchn_com_olive_oil_and_whiskey_carrot_cake_curl.html";
         $url  = "http://www.thekitchn.com/recipe-olive-oil-and-whisky-carrot-cake-recipes-from-the-kitchn-195594";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Olive Oil and Whisky Carrot Cake', $recipe->title);
@@ -37,7 +38,8 @@ class RecipeParser_Parser_Thekitchencom_Test extends PHPUnit_Framework_TestCase 
         $path = "data/thekitchn_com_one_pot_pasta_e_fagioli_italian_curl.html";
         $url  = "http://www.thekitchn.com/cozy-winter-recipe-onepot-past-135992";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('One-Pot Pasta e Fagioli (Italian Bean and Pasta Stew)', $recipe->title);
@@ -62,7 +64,8 @@ class RecipeParser_Parser_Thekitchencom_Test extends PHPUnit_Framework_TestCase 
         $path = "data/thekitchn_com_tart_cherry_crumble_from_the_kitchn_curl.html";
         $url  = "http://www.thekitchn.com/recipe-cherry-cobbler-recipes-from-the-kitchn-195824";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Tart Cherry Crumble', $recipe->title);

--- a/tests/RecipeParser_Parser_ThepioneerwomancomTest.php
+++ b/tests/RecipeParser_Parser_ThepioneerwomancomTest.php
@@ -8,7 +8,8 @@ class RecipeParser_Parser_ThepioneerwomancomTest extends PHPUnit_Framework_TestC
         $path = "data/thepioneerwoman_com_petite_vanilla_bean_scones_the_pioneer_curl.html";
         $url = "http://thepioneerwoman.com/cooking/2010/04/petite-vanilla-bean-scones/";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Petite Vanilla Bean Scones', $recipe->title);
@@ -39,7 +40,8 @@ class RecipeParser_Parser_ThepioneerwomancomTest extends PHPUnit_Framework_TestC
         $path = "data/thepioneerwoman_com_ravioli_three_ways_the_pioneer_woman_curl.html";
         $url = "http://thepioneerwoman.com/cooking/2011/09/ravioli-three-ways/";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Ravioli, Three Ways', $recipe->title);
@@ -65,7 +67,8 @@ class RecipeParser_Parser_ThepioneerwomancomTest extends PHPUnit_Framework_TestC
         $path = "data/thepioneerwoman_com_sweet_cinnamon_scones_the_pioneer_woman_curl.html";
         $url = "http://thepioneerwoman.com/cooking/2011/03/sweet-cinnamon-scones/";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Sweet Cinnamon Scones', $recipe->title);

--- a/tests/RecipeParser_Parser_YummlycomTest.php
+++ b/tests/RecipeParser_Parser_YummlycomTest.php
@@ -9,7 +9,8 @@ class RecipeParser_Parser_Yummlycom_Test extends PHPUnit_Framework_TestCase {
         $path = "data/yummly_com_egg_in_a_frame_toad_in_curl.html";
         $url  = "http://www.yummly.com/recipe/Egg-in-a-Frame-_Toad-in-a-Hole_-568587?columns=4";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Egg in a Frame (Toad in a Hole)', $recipe->title);
@@ -38,7 +39,8 @@ class RecipeParser_Parser_Yummlycom_Test extends PHPUnit_Framework_TestCase {
         $path = "data/yummly_com_maples_inn_blueberry_stuffed_french_toast_curl.html";
         $url  = "http://www.yummly.com/recipe/Maples-Inn-Blueberry-Stuffed-French-Toast-568585?columns=4";
 
-        $recipe = RecipeParser::parse(file_get_contents($path), $url);
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
         if (isset($_SERVER['VERBOSE'])) print_r($recipe);
 
         $this->assertEquals('Maples Inn Blueberry Stuffed French Toast', $recipe->title);

--- a/tests/RecipeParser_Test.php
+++ b/tests/RecipeParser_Test.php
@@ -33,9 +33,9 @@ class RecipeParser_Test extends PHPUnit_Framework_TestCase {
      * @expectedException NoMatchingParserException
      */
     function test_parser_no_matching_parser_exception() {
-        $html = "";
         $url = "http://www.example.com/";
-        $recipe = RecipeParser::parse($html, $url);
+        $doc = new DOMDocument();
+        $recipe = RecipeParser::parse($doc, $url);
     }
 
 }


### PR DESCRIPTION
# CHANGE SUMMARY

Injecting DomDocument into the parser so that creation of the DomDocument can vary independent of the parsers (i.e. use all alternate HTML5 parsing library).
- Extracted the creation of a DomDocument into RecipeParser_Text::getDomDocument(). This version uses the native PHP DomDocument (backed by libxml2). However, a client of the library can generate a DomDocument using an alternate html parsing library such as https://github.com/Masterminds/html5-php
- Modified all the parsers to accept a DomDocument instead of just the HTML string
- Updated all the unit tests to create a DomDocument and pass it into the parser
- Fixed a couple environment settings in the bootstrap process that were causing warnings for PHP 5.6 + 
- Updated the README.md to reflect the new parser interface and usage 

# RELEASE NOTES
Will need to run composer update recipeintoreality/RecipeParser to pull down the new changes

# TESTING
All unit tests are passing (except for a 3 which were already broken prior to this change)