### PR TITLE
CORE-1132: add mobile site check to myrecipes tester and fix title scraping logic for mobile

### DIFF
--- a/lib/RecipeParser/Parser/Myrecipescom.php
+++ b/lib/RecipeParser/Parser/Myrecipescom.php
@@ -1,6 +1,20 @@
 <?php
 
 class RecipeParser_Parser_Myrecipescom {
+    
+    static public function has_ingredients($recipe) {
+        if ($recipe->ingredients && array_key_exists("list", $recipe->ingredients[0])) {
+            return count($recipe->ingredients);
+        }
+        return false;
+    }
+    
+    static public function title_is_first_ingredient($recipe) {
+        if (self::has_ingredients($recipe)) {
+            return $recipe->title == $recipe->ingredients[0]["list"][0];
+        }
+        return false;
+    }
 
     static public function parse(DOMDocument $doc, $url) {
         // Get all of the standard microdata stuff we can find.
@@ -10,10 +24,9 @@ class RecipeParser_Parser_Myrecipescom {
         // OVERRIDES FOR MYRECIPES.COM
 
         // Title missing?
-        if (!$recipe->title) {
+        if (!$recipe->title || self::title_is_first_ingredient($recipe)) {
             $nodes = $xpath->query('//meta[@property="og:title"]');
             if ($nodes->length) {
-
                 $line = $nodes->item(0)->getAttribute("content");
                 $line = RecipeParser_Text::formatTitle($line);
                 $recipe->title = $line;

--- a/tests/RecipeParser_Parser_MyrecipescomTest.php
+++ b/tests/RecipeParser_Parser_MyrecipescomTest.php
@@ -32,7 +32,7 @@ class RecipeParser_Parser_MyrecipescomTest extends PHPUnit_Framework_TestCase {
 
     public function test_clam_chowder() {
         $path = "data/myrecipes_com_simple_clam_chowder_my_com_curl.html";
-        $url = "http://www.myrecipes.com/recipe/simple-clam-chowder-10000001696572/";
+        $url = "http://www.myrecipes.com/m/recipe/simple-clam-chowder/";
 
         $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
         $recipe = RecipeParser::parse($doc, $url);


### PR DESCRIPTION
# Change Summary
MyRecipes is not properly marking up their titles. The existing parser just uses the content of the first item tagged as a "name", leading it to save the first ingredient as the title.

Now, we do a test to see whether the first ingredient is the same as the title and if so, fall back to scraping the meta title.
# Release Notes
None.
# Testing
Tested by switching one of the MyRecipes unit tests to the mobile version. Parsed correctly.