### PR TITLE
Core 1103: fix Hungry Couple scraping issue

### DIFF
--- a/lib/RecipeParser/Parser/Hungrycouplenyccom.php
+++ b/lib/RecipeParser/Parser/Hungrycouplenyccom.php
@@ -2,17 +2,12 @@
 
 class RecipeParser_Parser_Hungrycouplenyccom {
     
-    static public function parse($html, $url) {
-        $recipe = RecipeParser_Parser_Microformat::parse($html, $url);
-
-        libxml_use_internal_errors(true);
-        $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
-        $doc = new DOMDocument();
-        $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
+    static public function parse(DOMDocument $doc, $url) {
+        $recipe = RecipeParser_Parser_Microformat::parse($doc, $url);
         $xpath = new DOMXPath($doc);
         
         // Title
-        $nodes = $xpath->query('.//*[@itemprop="name"]', $microdata);
+        $nodes = $xpath->query('.//*[@itemprop="name"]');
         if ($nodes->length) {
             $value = $nodes->item(0)->nodeValue;
             $value = RecipeParser_Text::formatTitle($value);

--- a/lib/RecipeParser/Parser/Hungrycouplenyccom.php
+++ b/lib/RecipeParser/Parser/Hungrycouplenyccom.php
@@ -1,0 +1,24 @@
+<?php
+
+class RecipeParser_Parser_Hungrycouplenyccom {
+    
+    static public function parse($html, $url) {
+        $recipe = RecipeParser_Parser_Microformat::parse($html, $url);
+
+        libxml_use_internal_errors(true);
+        $html = mb_convert_encoding($html, 'HTML-ENTITIES', "UTF-8");
+        $doc = new DOMDocument();
+        $doc->loadHTML('<?xml encoding="UTF-8">' . $html);
+        $xpath = new DOMXPath($doc);
+        
+        // Title
+        $nodes = $xpath->query('.//*[@itemprop="name"]', $microdata);
+        if ($nodes->length) {
+            $value = $nodes->item(0)->nodeValue;
+            $value = RecipeParser_Text::formatTitle($value);
+            $recipe->title = $value;
+        }
+        
+        return $recipe;
+    }
+}

--- a/lib/RecipeParser/Parser/Myrecipescom.php
+++ b/lib/RecipeParser/Parser/Myrecipescom.php
@@ -1,6 +1,20 @@
 <?php
 
 class RecipeParser_Parser_Myrecipescom {
+    
+    static public function has_ingredients($recipe) {
+        if ($recipe->ingredients && array_key_exists("list", $recipe->ingredients[0])) {
+            return count($recipe->ingredients);
+        }
+        return false;
+    }
+    
+    static public function title_is_first_ingredient($recipe) {
+        if (self::has_ingredients($recipe)) {
+            return $recipe->title == $recipe->ingredients[0]["list"][0];
+        }
+        return false;
+    }
 
     static public function parse(DOMDocument $doc, $url) {
         // Get all of the standard microdata stuff we can find.
@@ -10,10 +24,9 @@ class RecipeParser_Parser_Myrecipescom {
         // OVERRIDES FOR MYRECIPES.COM
 
         // Title missing?
-        if (!$recipe->title) {
+        if (!$recipe->title || self::title_is_first_ingredient($recipe)) {
             $nodes = $xpath->query('//meta[@property="og:title"]');
             if ($nodes->length) {
-
                 $line = $nodes->item(0)->getAttribute("content");
                 $line = RecipeParser_Text::formatTitle($line);
                 $recipe->title = $line;

--- a/lib/RecipeParser/Parser/parsers.ini
+++ b/lib/RecipeParser/Parser/parsers.ini
@@ -153,3 +153,7 @@ parser = "Thedailymealcom"
 [The Kitchn]
 pattern = "thekitchn.com"
 parser = "Thekitchencom"
+
+[Hungry Couple NYC]
+pattern = "hungrycouplenyc.com"
+parser = "Hungrycouplenyccom"

--- a/tests/RecipeParser_HungrycouplenyccomTest.php
+++ b/tests/RecipeParser_HungrycouplenyccomTest.php
@@ -1,0 +1,23 @@
+<?php
+
+require_once '../bootstrap.php';
+
+class RecipeParser_Parser_HungrycouplenyccomTest extends PHPUnit_Framework_TestCase {
+
+    public function test_crispy_potato_and_hummus_balls() {
+        $path = "data/hungrycouplenyc_com_hungry_couple_crispy_potato_and_hummus_curl.html";
+        $url = "http://www.hungrycouplenyc.com/2016/01/crispy-potato-and-hummus-balls.html";
+
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
+        if (isset($_SERVER['VERBOSE'])) print_r($recipe);
+        
+        $this->assertEquals("Crispy Potato and Hummus Balls", $recipe->title);
+        $this->assertEquals(2, count($recipe->ingredients));
+        $this->assertEquals("Breading", $recipe->ingredients[1]['name']);
+        $this->assertEquals(5, count($recipe->ingredients[0]['list']));
+        $this->assertEquals(3, count($recipe->ingredients[1]['list']));
+        $this->assertEquals("1/4 Cup Sabra Classic Hummus", $recipe->ingredients[0]['list'][1]);
+        $this->assertEquals("Hungry Couple", $recipe->credits);
+    }
+}

--- a/tests/RecipeParser_Parser_MyrecipescomTest.php
+++ b/tests/RecipeParser_Parser_MyrecipescomTest.php
@@ -32,7 +32,7 @@ class RecipeParser_Parser_MyrecipescomTest extends PHPUnit_Framework_TestCase {
 
     public function test_clam_chowder() {
         $path = "data/myrecipes_com_simple_clam_chowder_my_com_curl.html";
-        $url = "http://www.myrecipes.com/recipe/simple-clam-chowder-10000001696572/";
+        $url = "http://www.myrecipes.com/m/recipe/simple-clam-chowder/";
 
         $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
         $recipe = RecipeParser::parse($doc, $url);

--- a/tests/data/hungrycouplenyc_com_hungry_couple_crispy_potato_and_hummus_curl.html
+++ b/tests/data/hungrycouplenyc_com_hungry_couple_crispy_potato_and_hummus_curl.html
@@ -1,0 +1,2935 @@
+<!--
+ONETSP_URL: http://www.hungrycouplenyc.com/2016/01/crispy-potato-and-hummus-balls.html
+ONETSP_USER_AGENT: curl
+ONETSP_TIME: Fri, 15 Jan 2016 17:59:07 +0000
+-->
+
+<!DOCTYPE html>
+<html class='v2' dir='ltr' xmlns='http://www.w3.org/1999/xhtml' xmlns:b='http://www.google.com/2005/gml/b' xmlns:data='http://www.google.com/2005/gml/data' xmlns:expr='http://www.google.com/2005/gml/expr'>
+<head>
+<meta content='f1430b4141135b862eea7d6b2cf395a6' name='p:domain_verify'/>
+<meta content='IE=EmulateIE7' http-equiv='X-UA-Compatible'/>
+<meta content='width=1100' name='viewport'/>
+<meta content='text/html; charset=UTF-8' http-equiv='Content-Type'/>
+<!-- STRIPPED SCRIPT TAG -->
+<meta content='blogger' name='generator'/>
+<link href='http://www.hungrycouplenyc.com/favicon.ico' rel='icon' type='image/x-icon'/>
+<link href='http://www.hungrycouplenyc.com/2016/01/crispy-potato-and-hummus-balls.html' rel='canonical'/>
+<link rel="alternate" type="application/atom+xml" title="   Hungry Couple - Atom" href="http://www.hungrycouplenyc.com/feeds/posts/default" />
+<link rel="alternate" type="application/rss+xml" title="   Hungry Couple - RSS" href="http://www.hungrycouplenyc.com/feeds/posts/default?alt=rss" />
+<link rel="service.post" type="application/atom+xml" title="   Hungry Couple - Atom" href="https://www.blogger.com/feeds/8274369273568143862/posts/default" />
+
+<link rel="alternate" type="application/atom+xml" title="   Hungry Couple - Atom" href="http://www.hungrycouplenyc.com/feeds/662289017799682219/comments/default" />
+<!-- STRIPPED CONDITIONAL COMMENT -->
+<link href='http://4.bp.blogspot.com/-eLa65gducOc/VpbD3AhaehI/AAAAAAAAZVI/0kvPdDCG6eI/s1600/aIMG_2170f%2BVertical%2B690.jpg' rel='image_src'/>
+<meta content='Recipe for a mashed potato and hummus appetizer, breaded and crisped in the oven.' name='description'/>
+<!-- STRIPPED CONDITIONAL COMMENT -->
+<title>   Hungry Couple: Crispy Potato and Hummus Balls</title>
+<!-- STRIPPED SCRIPT TAG -->
+<style type="text/css">
+.wf-inactive .header h1, .wf-rocksalt-n4-loading .header h1, .wf-rocksalt-n4-inactive .header h1 {
+  font-family: cursive;
+}
+.wf-inactive .tabs-inner .widget li a, .wf-droidsans-n4-loading .tabs-inner .widget li a, .wf-droidsans-n4-inactive .tabs-inner .widget li a {
+  font-family: sans-serif;
+}
+.wf-inactive h3.post-title, .wf-rocksalt-n4-loading h3.post-title, .wf-rocksalt-n4-inactive h3.post-title, .wf-inactive .comments h4, .wf-rocksalt-n4-loading .comments h4, .wf-rocksalt-n4-inactive .comments h4 {
+  font-family: cursive;
+}
+</style>
+<link type='text/css' rel='stylesheet' href='https://www.blogger.com/static/v1/widgets/2973171168-css_bundle_v2.css' />
+<link type='text/css' rel='stylesheet' href='//www.google.com/uds/css/gsearch.css' />
+<link type='text/css' rel='stylesheet' href='https://www.blogger.com/dyn-css/authorization.css?targetBlogID=8274369273568143862&zx=073902f4-6ec6-4b6d-b642-d89868c4c293' />
+<style id='page-skin-1' type='text/css'><!--
+/*
+-----------------------------------------------
+Blogger Template Style
+Name:     Simple
+Designer: Josh Peterson
+URL:      www.noaesthetic.com
+----------------------------------------------- */
+/* Variable definitions
+====================
+<Variable name="keycolor" description="Main Color" type="color" default="#66bbdd"/>
+<Group description="Page Text" selector="body">
+<Variable name="body.font" description="Font" type="font"
+default="normal normal 12px Arial, Tahoma, Helvetica, FreeSans, sans-serif"/>
+<Variable name="body.text.color" description="Text Color" type="color" default="#222222"/>
+</Group>
+<Group description="Backgrounds" selector=".body-fauxcolumns-outer">
+<Variable name="body.background.color" description="Outer Background" type="color" default="#66bbdd"/>
+<Variable name="content.background.color" description="Main Background" type="color" default="#ffffff"/>
+<Variable name="header.background.color" description="Header Background" type="color" default="transparent"/>
+</Group>
+<Group description="Links" selector=".main-outer">
+<Variable name="link.color" description="Link Color" type="color" default="#2288bb"/>
+<Variable name="link.visited.color" description="Visited Color" type="color" default="#888888"/>
+<Variable name="link.hover.color" description="Hover Color" type="color" default="#33aaff"/>
+</Group>
+<Group description="Blog Title" selector=".header h1">
+<Variable name="header.font" description="Font" type="font"
+default="normal normal 60px Arial, Tahoma, Helvetica, FreeSans, sans-serif"/>
+<Variable name="header.text.color" description="Title Color" type="color" default="#3399bb" />
+</Group>
+<Group description="Blog Description" selector=".header .description">
+<Variable name="description.text.color" description="Description Color" type="color"
+default="#777777" />
+</Group>
+<Group description="Tabs Text" selector=".tabs-inner .widget li a">
+<Variable name="tabs.font" description="Font" type="font"
+default="normal normal 14px Arial, Tahoma, Helvetica, FreeSans, sans-serif"/>
+<Variable name="tabs.text.color" description="Text Color" type="color" default="#999999"/>
+<Variable name="tabs.selected.text.color" description="Selected Color" type="color" default="#000000"/>
+</Group>
+<Group description="Tabs Background" selector=".tabs-outer .PageList">
+<Variable name="tabs.background.color" description="Background Color" type="color" default="#f5f5f5"/>
+<Variable name="tabs.selected.background.color" description="Selected Color" type="color" default="#eeeeee"/>
+</Group>
+<Group description="Post Title" selector="h3.post-title, .comments h4">
+<Variable name="post.title.font" description="Font" type="font"
+default="normal normal 22px Arial, Tahoma, Helvetica, FreeSans, sans-serif"/>
+</Group>
+<Group description="Date Header" selector=".date-header">
+<Variable name="date.header.color" description="Text Color" type="color"
+default="#444444"/>
+<Variable name="date.header.background.color" description="Background Color" type="color"
+default="transparent"/>
+<Variable name="date.header.font" description="Text Font" type="font"
+default="normal bold 11px Arial, Tahoma, Helvetica, FreeSans, sans-serif"/>
+<Variable name="date.header.padding" description="Date Header Padding" type="string" default="inherit"/>
+<Variable name="date.header.letterspacing" description="Date Header Letter Spacing" type="string" default="inherit"/>
+<Variable name="date.header.margin" description="Date Header Margin" type="string" default="inherit"/>
+</Group>
+<Group description="Post Footer" selector=".post-footer">
+<Variable name="post.footer.text.color" description="Text Color" type="color" default="#666666"/>
+<Variable name="post.footer.background.color" description="Background Color" type="color"
+default="#f9f9f9"/>
+<Variable name="post.footer.border.color" description="Shadow Color" type="color" default="#eeeeee"/>
+</Group>
+<Group description="Gadgets" selector="h2">
+<Variable name="widget.title.font" description="Title Font" type="font"
+default="normal bold 11px Arial, Tahoma, Helvetica, FreeSans, sans-serif"/>
+<Variable name="widget.title.text.color" description="Title Color" type="color" default="#000000"/>
+<Variable name="widget.alternate.text.color" description="Alternate Color" type="color" default="#999999"/>
+</Group>
+<Group description="Images" selector=".main-inner">
+<Variable name="image.background.color" description="Background Color" type="color" default="#ffffff"/>
+<Variable name="image.border.color" description="Border Color" type="color" default="#eeeeee"/>
+<Variable name="image.text.color" description="Caption Text Color" type="color" default="#444444"/>
+</Group>
+<Group description="Accents" selector=".content-inner">
+<Variable name="body.rule.color" description="Separator Line Color" type="color" default="#eeeeee"/>
+<Variable name="tabs.border.color" description="Tabs Border Color" type="color" default="#eeeeee"/>
+</Group>
+<Variable name="body.background" description="Body Background" type="background"
+color="transparent" default="$(color) none repeat scroll top left"/>
+<Variable name="body.background.override" description="Body Background Override" type="string" default=""/>
+<Variable name="body.background.gradient.cap" description="Body Gradient Cap" type="url"
+default="url(//www.blogblog.com/1kt/simple/gradients_light.png)"/>
+<Variable name="body.background.gradient.tile" description="Body Gradient Tile" type="url"
+default="url(//www.blogblog.com/1kt/simple/body_gradient_tile_light.png)"/>
+<Variable name="content.background.color.selector" description="Content Background Color Selector" type="string" default=".content-inner"/>
+<Variable name="content.padding" description="Content Padding" type="length" default="10px" min="0" max="100px"/>
+<Variable name="content.padding.horizontal" description="Content Horizontal Padding" type="length" default="10px" min="0" max="100px"/>
+<Variable name="content.shadow.spread" description="Content Shadow Spread" type="length" default="40px" min="0" max="100px"/>
+<Variable name="content.shadow.spread.webkit" description="Content Shadow Spread (WebKit)" type="length" default="5px" min="0" max="100px"/>
+<Variable name="content.shadow.spread.ie" description="Content Shadow Spread (IE)" type="length" default="10px" min="0" max="100px"/>
+<Variable name="main.border.width" description="Main Border Width" type="length" default="0" min="0" max="10px"/>
+<Variable name="header.background.gradient" description="Header Gradient" type="url" default="none"/>
+<Variable name="header.shadow.offset.left" description="Header Shadow Offset Left" type="length" default="-1px" min="-50px" max="50px"/>
+<Variable name="header.shadow.offset.top" description="Header Shadow Offset Top" type="length" default="-1px" min="-50px" max="50px"/>
+<Variable name="header.shadow.spread" description="Header Shadow Spread" type="length" default="1px" min="0" max="100px"/>
+<Variable name="header.padding" description="Header Padding" type="length" default="30px" min="0" max="100px"/>
+<Variable name="header.border.size" description="Header Border Size" type="length" default="1px" min="0" max="10px"/>
+<Variable name="header.bottom.border.size" description="Header Bottom Border Size" type="length" default="1px" min="0" max="10px"/>
+<Variable name="header.border.horizontalsize" description="Header Horizontal Border Size" type="length" default="0" min="0" max="10px"/>
+<Variable name="description.text.size" description="Description Text Size" type="string" default="140%"/>
+<Variable name="tabs.margin.top" description="Tabs Margin Top" type="length" default="0" min="0" max="100px"/>
+<Variable name="tabs.margin.side" description="Tabs Side Margin" type="length" default="30px" min="0" max="100px"/>
+<Variable name="tabs.background.gradient" description="Tabs Background Gradient" type="url"
+default="url(//www.blogblog.com/1kt/simple/gradients_light.png)"/>
+<Variable name="tabs.border.width" description="Tabs Border Width" type="length" default="1px" min="0" max="10px"/>
+<Variable name="tabs.bevel.border.width" description="Tabs Bevel Border Width" type="length" default="1px" min="0" max="10px"/>
+<Variable name="post.margin.bottom" description="Post Bottom Margin" type="length" default="25px" min="0" max="100px"/>
+<Variable name="image.border.small.size" description="Image Border Small Size" type="length" default="2px" min="0" max="10px"/>
+<Variable name="image.border.large.size" description="Image Border Large Size" type="length" default="5px" min="0" max="10px"/>
+<Variable name="page.width.selector" description="Page Width Selector" type="string" default=".region-inner"/>
+<Variable name="page.width" description="Page Width" type="string" default="auto"/>
+<Variable name="main.section.margin" description="Main Section Margin" type="length" default="15px" min="0" max="100px"/>
+<Variable name="main.padding" description="Main Padding" type="length" default="15px" min="0" max="100px"/>
+<Variable name="main.padding.top" description="Main Padding Top" type="length" default="30px" min="0" max="100px"/>
+<Variable name="main.padding.bottom" description="Main Padding Bottom" type="length" default="30px" min="0" max="100px"/>
+<Variable name="paging.background"
+color="transparent"
+description="Background of blog paging area" type="background"
+default="transparent none no-repeat scroll top center"/>
+<Variable name="footer.bevel" description="Bevel border length of footer" type="length" default="0" min="0" max="10px"/>
+<Variable name="mobile.background.overlay" description="Mobile Background Overlay" type="string"
+default="transparent none repeat scroll top left"/>
+<Variable name="mobile.background.size" description="Mobile Background Size" type="string" default="auto"/>
+<Variable name="mobile.button.color" description="Mobile Button Color" type="color" default="#ffffff" />
+<Variable name="startSide" description="Side where text starts in blog language" type="automatic" default="left"/>
+<Variable name="endSide" description="Side where text ends in blog language" type="automatic" default="right"/>
+*/
+/* Content
+----------------------------------------------- */
+body {
+font: normal normal 13px Georgia, Utopia, 'Palatino Linotype', Palatino, serif;
+color: #444444;
+background: transparent none no-repeat scroll center center;
+padding: 0 40px 40px 40px;
+}
+html body .region-inner {
+min-width: 0;
+max-width: 100%;
+width: auto;
+}
+h2 {
+font-size: 22px;
+}
+a:link {
+text-decoration:none;
+color: #999999;
+}
+a:visited {
+text-decoration:none;
+color: #444444;
+}
+a:hover {
+text-decoration:underline;
+color: #cfe7d1;
+}
+.body-fauxcolumn-outer .fauxcolumn-inner {
+background: transparent none repeat scroll top left;
+_background-image: none;
+}
+.body-fauxcolumn-outer .cap-top {
+position: absolute;
+z-index: 1;
+height: 400px;
+width: 100%;
+background: transparent none no-repeat scroll center center;
+}
+.body-fauxcolumn-outer .cap-top .cap-left {
+width: 100%;
+background: transparent none repeat-x scroll top left;
+_background-image: none;
+}
+.content-outer {
+-moz-box-shadow: 0 0 40px rgba(0, 0, 0, .15);
+-webkit-box-shadow: 0 0 5px rgba(0, 0, 0, .15);
+-goog-ms-box-shadow: 0 0 10px #333333;
+box-shadow: 0 0 40px rgba(0, 0, 0, .15);
+margin-bottom: 1px;
+}
+.content-inner {
+padding: 10px 10px;
+}
+.content-inner {
+background-color: transparent;
+}
+/* Header
+----------------------------------------------- */
+.header-outer {
+background: transparent none repeat-x scroll 0 -400px;
+_background-image: none;
+}
+.Header h1 {
+font: normal normal 66px Rock Salt;
+color: #93c47d;
+text-shadow: -1px -1px 1px rgba(0, 0, 0, .2);
+}
+.Header h1 a {
+color: #93c47d;
+}
+.Header .description {
+font-size: 140%;
+color: transparent;
+}
+.header-inner .Header .titlewrapper {
+padding: 22px 30px;
+}
+.header-inner .Header .descriptionwrapper {
+padding: 0 30px;
+}
+/* Tabs
+----------------------------------------------- */
+.tabs-inner .section:first-child {
+border-top: 1px solid transparent;
+}
+.tabs-inner .section:first-child ul {
+margin-top: -1px;
+border-top: 1px solid transparent;
+border-left: 0 solid transparent;
+border-right: 0 solid transparent;
+}
+.tabs-inner .widget ul {
+background: #b6d7a8 url(//www.blogblog.com/1kt/simple/gradients_light.png) repeat-x scroll 0 -800px;
+_background-image: none;
+border-bottom: 1px solid transparent;
+margin-top: 0;
+margin-left: -30px;
+margin-right: -30px;
+}
+.tabs-inner .widget li a {
+display: inline-block;
+padding: .6em 1em;
+font: normal normal 17px Droid Sans;
+color: #444444;
+border-left: 1px solid transparent;
+border-right: 1px solid transparent;
+}
+.tabs-inner .widget li:first-child a {
+border-left: none;
+}
+.tabs-inner .widget li.selected a, .tabs-inner .widget li a:hover {
+color: #d9ead3;
+background-color: #93c47d;
+text-decoration: none;
+}
+/* Columns
+----------------------------------------------- */
+.main-outer {
+border-top: 0 solid #eeeeee;
+}
+.fauxcolumn-left-outer .fauxcolumn-inner {
+border-right: 1px solid #eeeeee;
+}
+.fauxcolumn-right-outer .fauxcolumn-inner {
+border-left: 1px solid #eeeeee;
+}
+/* Headings
+----------------------------------------------- */
+div.widget > h2,
+div.widget h2.title {
+margin: 0 0 1em 0;
+font: normal bold 11px Arial, Tahoma, Helvetica, FreeSans, sans-serif;
+color: #444444;
+}
+/* Widgets
+----------------------------------------------- */
+.widget .zippy {
+color: #666666;
+text-shadow: 2px 2px 1px rgba(0, 0, 0, .1);
+}
+.widget .popular-posts ul {
+list-style: none;
+}
+/* Posts
+----------------------------------------------- */
+h2.date-header {
+font: normal bold 11px Arial, Tahoma, Helvetica, FreeSans, sans-serif;
+}
+.date-header span {
+background-color: #ffffff;
+color: #999999;
+padding: inherit;
+letter-spacing: inherit;
+margin: inherit;
+}
+.main-inner {
+padding-top: 30px;
+padding-bottom: 30px;
+}
+.main-inner .column-center-inner {
+padding: 0 15px;
+}
+.main-inner .column-center-inner .section {
+margin: 0 15px;
+}
+.post {
+margin: 0 0 25px 0;
+}
+h3.post-title, .comments h4 {
+font: normal normal 22px Rock Salt;
+margin: .75em 0 0;
+}
+.post-body {
+font-size: 110%;
+line-height: 1.4;
+position: relative;
+}
+.post-body img, .post-body .tr-caption-container, .Profile img, .Image img,
+.BlogList .item-thumbnail img {
+padding: 2px;
+background: #ffffff;
+border: 1px solid #cccccc;
+-moz-box-shadow: 1px 1px 5px rgba(0, 0, 0, .1);
+-webkit-box-shadow: 1px 1px 5px rgba(0, 0, 0, .1);
+box-shadow: 1px 1px 5px rgba(0, 0, 0, .1);
+}
+.post-body img, .post-body .tr-caption-container {
+padding: 5px;
+}
+.post-body .tr-caption-container {
+color: #444444;
+}
+.post-body .tr-caption-container img {
+padding: 0;
+background: transparent;
+border: none;
+-moz-box-shadow: 0 0 0 rgba(0, 0, 0, .1);
+-webkit-box-shadow: 0 0 0 rgba(0, 0, 0, .1);
+box-shadow: 0 0 0 rgba(0, 0, 0, .1);
+}
+.post-header {
+margin: 0 0 1.5em;
+line-height: 1.6;
+font-size: 90%;
+}
+.post-footer {
+margin: 20px -2px 0;
+padding: 5px 10px;
+color: #666666;
+background-color: #ffffff;
+border-bottom: 1px solid #ffffff;
+line-height: 1.6;
+font-size: 90%;
+}
+#comments .comment-author {
+padding-top: 1.5em;
+border-top: 1px solid #eeeeee;
+background-position: 0 1.5em;
+}
+#comments .comment-author:first-child {
+padding-top: 0;
+border-top: none;
+}
+.avatar-image-container {
+margin: .2em 0 0;
+}
+#comments .avatar-image-container img {
+border: 1px solid #cccccc;
+}
+/* Comments
+----------------------------------------------- */
+.comments .comments-content .icon.blog-author {
+background-repeat: no-repeat;
+background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABIAAAASCAYAAABWzo5XAAAAAXNSR0IArs4c6QAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEgAACxIB0t1+/AAAAAd0SU1FB9sLFwMeCjjhcOMAAAD+SURBVDjLtZSvTgNBEIe/WRRnm3U8RC1neQdsm1zSBIU9VVF1FkUguQQsD9ITmD7ECZIJSE4OZo9stoVjC/zc7ky+zH9hXwVwDpTAWWLrgS3QAe8AZgaAJI5zYAmc8r0G4AHYHQKVwII8PZrZFsBFkeRCABYiMh9BRUhnSkPTNCtVXYXURi1FpBDgArj8QU1eVXUzfnjv7yP7kwu1mYrkWlU33vs1QNu2qU8pwN0UpKoqokjWwCztrMuBhEhmh8bD5UDqur75asbcX0BGUB9/HAMB+r32hznJgXy2v0sGLBcyAJ1EK3LFcbo1s91JeLwAbwGYu7TP/3ZGfnXYPgAVNngtqatUNgAAAABJRU5ErkJggg==);
+}
+.comments .comments-content .loadmore a {
+border-top: 1px solid #666666;
+border-bottom: 1px solid #666666;
+}
+.comments .comment-thread.inline-thread {
+background-color: #ffffff;
+}
+.comments .continue {
+border-top: 2px solid #666666;
+}
+/* Accents
+---------------------------------------------- */
+.section-columns td.columns-cell {
+border-left: 1px solid #eeeeee;
+}
+.blog-pager {
+background: transparent none no-repeat scroll top center;
+}
+.blog-pager-older-link, .home-link,
+.blog-pager-newer-link {
+background-color: transparent;
+padding: 5px;
+}
+.footer-outer {
+border-top: 0 dashed #bbbbbb;
+}
+/* Mobile
+----------------------------------------------- */
+body.mobile  {
+background-size: auto;
+}
+.mobile .body-fauxcolumn-outer {
+background: transparent none repeat scroll top left;
+}
+.mobile .body-fauxcolumn-outer .cap-top {
+background-size: 100% auto;
+}
+.mobile .content-outer {
+-webkit-box-shadow: 0 0 3px rgba(0, 0, 0, .15);
+box-shadow: 0 0 3px rgba(0, 0, 0, .15);
+}
+.mobile .tabs-inner .widget ul {
+margin-left: 0;
+margin-right: 0;
+}
+.mobile .post {
+margin: 0;
+}
+.mobile .main-inner .column-center-inner .section {
+margin: 0;
+}
+.mobile .date-header span {
+padding: 0.1em 10px;
+margin: 0 -10px;
+}
+.mobile h3.post-title {
+margin: 0;
+}
+.mobile .blog-pager {
+background: transparent none no-repeat scroll top center;
+}
+.mobile .footer-outer {
+border-top: none;
+}
+.mobile .main-inner, .mobile .footer-inner {
+background-color: transparent;
+}
+.mobile-index-contents {
+color: #444444;
+}
+.mobile-link-button {
+background-color: #999999;
+}
+.mobile-link-button a:link, .mobile-link-button a:visited {
+color: #ffffff;
+}
+.mobile .tabs-inner .section:first-child {
+border-top: none;
+}
+.mobile .tabs-inner .PageList .widget-content {
+background-color: #93c47d;
+color: #d9ead3;
+border-top: 1px solid transparent;
+border-bottom: 1px solid transparent;
+}
+.mobile .tabs-inner .PageList .widget-content .pagelist-arrow {
+border-left: 1px solid transparent;
+}
+
+--></style>
+<style id='template-skin-1' type='text/css'><!--
+body {
+min-width: 1165px;
+}
+.content-outer, .content-fauxcolumn-outer, .region-inner {
+min-width: 1165px;
+max-width: 1165px;
+_width: 1165px;
+}
+.main-inner .columns {
+padding-left: 0px;
+padding-right: 375px;
+}
+.main-inner .fauxcolumn-center-outer {
+left: 0px;
+right: 375px;
+/* IE6 does not respect left and right together */
+_width: expression(this.parentNode.offsetWidth -
+parseInt("0px") -
+parseInt("375px") + 'px');
+}
+.main-inner .fauxcolumn-left-outer {
+width: 0px;
+}
+.main-inner .fauxcolumn-right-outer {
+width: 375px;
+}
+.main-inner .column-left-outer {
+width: 0px;
+right: 100%;
+margin-left: -0px;
+}
+.main-inner .column-right-outer {
+width: 375px;
+margin-right: -375px;
+}
+#layout {
+min-width: 0;
+}
+#layout .content-outer {
+min-width: 0;
+width: 800px;
+}
+#layout .region-inner {
+min-width: 0;
+width: auto;
+}
+--></style>
+<!--Start of TBN Head Code JE-->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- Yieldbot.com Intent Tag LOADING -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- Yieldbot.com Intent Tag ACTIVATION -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<meta content='dad64b5dd1bb83cbad12662a494fbd1c' name='p:domain_verify'/>
+<!-- STRIPPED SCRIPT TAG --><!-- STRIPPED SCRIPT TAG --></head>
+<body class='loading variant-pale'>
+<div class='navbar section' id='navbar'><div class='widget Navbar' id='Navbar1'><!-- STRIPPED SCRIPT TAG -->
+<div id="navbar-iframe-container"></div>
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG --><!-- STRIPPED SCRIPT TAG -->
+</div></div>
+<div class='body-fauxcolumns'>
+<div class='fauxcolumn-outer body-fauxcolumn-outer'>
+<div class='cap-top'>
+<div class='cap-left'></div>
+<div class='cap-right'></div>
+</div>
+<div class='fauxborder-left'>
+<div class='fauxborder-right'></div>
+<div class='fauxcolumn-inner'>
+</div>
+</div>
+<div class='cap-bottom'>
+<div class='cap-left'></div>
+<div class='cap-right'></div>
+</div>
+</div>
+</div>
+<div class='content'>
+<div class='content-fauxcolumns'>
+<div class='fauxcolumn-outer content-fauxcolumn-outer'>
+<div class='cap-top'>
+<div class='cap-left'></div>
+<div class='cap-right'></div>
+</div>
+<div class='fauxborder-left'>
+<div class='fauxborder-right'></div>
+<div class='fauxcolumn-inner'>
+</div>
+</div>
+<div class='cap-bottom'>
+<div class='cap-left'></div>
+<div class='cap-right'></div>
+</div>
+</div>
+</div>
+<div class='content-outer'>
+<div class='content-cap-top cap-top'>
+<div class='cap-left'></div>
+<div class='cap-right'></div>
+</div>
+<div class='fauxborder-left content-fauxborder-left'>
+<div class='fauxborder-right content-fauxborder-right'></div>
+<div class='content-inner'>
+<header>
+<div class='header-outer'>
+<div class='header-cap-top cap-top'>
+<div class='cap-left'></div>
+<div class='cap-right'></div>
+</div>
+<div class='fauxborder-left header-fauxborder-left'>
+<div class='fauxborder-right header-fauxborder-right'></div>
+<div class='region-inner header-inner'>
+<div class='header section' id='header'></div>
+</div>
+</div>
+<div class='header-cap-bottom cap-bottom'>
+<div class='cap-left'></div>
+<div class='cap-right'></div>
+</div>
+</div>
+</header>
+<div class='tabs-outer'>
+<div class='tabs-cap-top cap-top'>
+<div class='cap-left'></div>
+<div class='cap-right'></div>
+</div>
+<div class='fauxborder-left tabs-fauxborder-left'>
+<div class='fauxborder-right tabs-fauxborder-right'></div>
+<div class='region-inner tabs-inner'>
+<div class='tabs section' id='crosscol'><div class='widget Header' id='Header1'>
+<div id='header-inner'>
+<a href='http://www.hungrycouplenyc.com/' style='display: block'>
+<img alt='   Hungry Couple' height='214px; ' id='Header1_headerimg' src='http://3.bp.blogspot.com/-PLqP1GrvmeM/VTPjQFwRR0I/AAAAAAAAVmI/Hkd2-5hGw8c/s1085/geosanslight92softened.jpg' style='display: block' width='1085px; '/>
+</a>
+</div>
+</div></div>
+<div class='tabs section' id='crosscol-overflow'><div class='widget PageList' id='PageList1'>
+<div class='widget-content'>
+<ul>
+<li><a href='http://www.hungrycouplenyc.com/'>Home</a></li>
+<li><a href='http://www.hungrycouplenyc.com/p/meet-hungry-couple.html'>About</a></li>
+<li><a href='http://www.hungrycouplenyc.com/p/work-with-us.html'>Work With Me</a></li>
+<li><a href='http://www.hungrycouplenyc.com/p/life-in-big-city.html'>Life in the Big City</a></li>
+<li><a href='http://www.hungrycouplenyc.com/p/on-road.html'>On the Road</a></li>
+<li><a href='http://www.hungrycouplenyc.com/p/a-cocktail-life.html'>A Cocktail Life</a></li>
+<li><a href='http://www.hungrycouplenyc.com/p/recipe-index.html'>Recipe Index</a></li>
+<li><a href='http://www.anitaschecter.com'>Portfolio</a></li>
+<li><a href='http://astore.amazon.com/hungcoup-20'>Shop!</a></li>
+</ul>
+<div class='clear'></div>
+<span class='widget-item-control'>
+<span class='item-control blog-admin'>
+<a class='quickedit' href='//www.blogger.com/rearrange?blogID=8274369273568143862&widgetType=PageList&widgetId=PageList1&action=editWidget&sectionId=crosscol-overflow' onclick='return _WidgetManager._PopupConfig(document.getElementById("PageList1"));' target='configPageList1' title='Edit'>
+<img alt='' height='18' src='//img1.blogblog.com/img/icon18_wrench_allbkg.png' width='18'/>
+</a>
+</span>
+</span>
+<div class='clear'></div>
+</div>
+</div></div>
+</div>
+</div>
+<div class='tabs-cap-bottom cap-bottom'>
+<div class='cap-left'></div>
+<div class='cap-right'></div>
+</div>
+</div>
+<div class='main-outer'>
+<div class='main-cap-top cap-top'>
+<div class='cap-left'></div>
+<div class='cap-right'></div>
+</div>
+<div class='fauxborder-left main-fauxborder-left'>
+<div class='fauxborder-right main-fauxborder-right'></div>
+<div class='region-inner main-inner'>
+<div class='columns fauxcolumns'>
+<div class='fauxcolumn-outer fauxcolumn-center-outer'>
+<div class='cap-top'>
+<div class='cap-left'></div>
+<div class='cap-right'></div>
+</div>
+<div class='fauxborder-left'>
+<div class='fauxborder-right'></div>
+<div class='fauxcolumn-inner'>
+</div>
+</div>
+<div class='cap-bottom'>
+<div class='cap-left'></div>
+<div class='cap-right'></div>
+</div>
+</div>
+<div class='fauxcolumn-outer fauxcolumn-left-outer'>
+<div class='cap-top'>
+<div class='cap-left'></div>
+<div class='cap-right'></div>
+</div>
+<div class='fauxborder-left'>
+<div class='fauxborder-right'></div>
+<div class='fauxcolumn-inner'>
+</div>
+</div>
+<div class='cap-bottom'>
+<div class='cap-left'></div>
+<div class='cap-right'></div>
+</div>
+</div>
+<div class='fauxcolumn-outer fauxcolumn-right-outer'>
+<div class='cap-top'>
+<div class='cap-left'></div>
+<div class='cap-right'></div>
+</div>
+<div class='fauxborder-left'>
+<div class='fauxborder-right'></div>
+<div class='fauxcolumn-inner'>
+</div>
+</div>
+<div class='cap-bottom'>
+<div class='cap-left'></div>
+<div class='cap-right'></div>
+</div>
+</div>
+<!-- corrects IE6 width calculation -->
+<div class='columns-inner'>
+<div class='column-center-outer'>
+<div class='column-center-inner'>
+<div class='main section' id='main'><div class='widget Blog' id='Blog1'>
+<div class='blog-posts hfeed'>
+
+          <div class="date-outer">
+        
+<h2 class='date-header'><span>Wednesday, January 13, 2016</span></h2>
+
+          <div class="date-posts">
+        
+<div class='post-outer'>
+<div class='post hentry' itemprop='blogPost' itemscope='itemscope' itemtype='http://schema.org/BlogPosting'>
+<meta content='http://4.bp.blogspot.com/-eLa65gducOc/VpbD3AhaehI/AAAAAAAAZVI/0kvPdDCG6eI/s1600/aIMG_2170f%2BVertical%2B690.jpg' itemprop='image_url'/>
+<meta content='8274369273568143862' itemprop='blogId'/>
+<meta content='662289017799682219' itemprop='postId'/>
+<a name='662289017799682219'></a>
+<h3 class='post-title entry-title' itemprop='name'>
+Crispy Potato and Hummus Balls
+</h3>
+<div class='post-header'>
+<div class='post-header-line-1'></div>
+</div>
+<div class='post-body entry-content' id='post-body-662289017799682219' itemprop='articleBody'>
+<div class="separator" style="clear: both; text-align: center;">
+<a href="http://4.bp.blogspot.com/-eLa65gducOc/VpbD3AhaehI/AAAAAAAAZVI/0kvPdDCG6eI/s1600/aIMG_2170f%2BVertical%2B690.jpg" imageanchor="1" style="margin-left: 1em; margin-right: 1em;"><img alt="Crispy Potato and Hummus Balls" border="0" src="http://4.bp.blogspot.com/-eLa65gducOc/VpbD3AhaehI/AAAAAAAAZVI/0kvPdDCG6eI/s1600/aIMG_2170f%2BVertical%2B690.jpg" title="Crispy Potato and Hummus Balls" /></a></div>
+<br />
+What's that sound? Oh, it's the sound of friends and family calling, emailing and texting, wanting to know when to show up to eat snacks and watch the big game. Now, they do know what time the game is on so they really just want to make sure you'll be providing a sufficient amount of snacks. Uh huh.<br />
+<br />
+<div class="separator" style="clear: both; text-align: center;">
+<a href="http://1.bp.blogspot.com/-f4irmj6eUpI/VpbWL9X3WcI/AAAAAAAAZVg/R0EocIuBeLQ/s1600/aIMG_2177fc%2B500.jpg" imageanchor="1" style="clear: right; float: right; margin-bottom: 1em; margin-left: 1em;"><img alt="Crispy Potato and Hummus Balls" border="0" src="http://1.bp.blogspot.com/-f4irmj6eUpI/VpbWL9X3WcI/AAAAAAAAZVg/R0EocIuBeLQ/s1600/aIMG_2177fc%2B500.jpg" title="Crispy Potato and Hummus Balls" /></a></div>
+OK, I'm not even going to pretend that I have any big love of sporting events although I can usually be counted on to watch the major ones and root for whichever team the people around me have decided we're rooting for. But I can definitely handle the snacks.<br />
+<br />
+In my house any gathering pretty much involves hummus because it's my go to dip for plates of veggies and chips. I've lost count of how many tubs of <b><i><a href="http://sabra.com/products/category/Hummus" rel="nofollow" target="_blank">Sabra hummus</a></i></b> I've bought over the years but enough that I would think they might notice if I stopped. Still, people seem to expect more for the SuperBowl than just the plate of crudite I normally serve. And, to tell the truth, it's kind of my chance to play around with fun and interesting snacks. Hummus will still be involved, though.<br />
+<br />
+These little balls are all crispy and crunchy on the outside but pillowy soft on the inside. Easy to make and perfect for dipping, too. Now if that doesn't say game day snack, I don't know what does. Enjoy and I hope your team wins. Whichever team that is!<br />
+<br />
+<div class="hrecipe f14">
+<br />
+<div class="separator" style="clear: both; text-align: center;">
+<a href="http://2.bp.blogspot.com/-D5NbAWtQDa0/VpbX2ZkIzMI/AAAAAAAAZVs/4k-mJK-YuP8/s1600/aIMG_2175fsq.jpg" imageanchor="1" style="clear: left; float: left; margin-bottom: 1em; margin-right: 1em;"><img alt="Crispy Potato and Hummus Balls" border="0" height="200" src="http://2.bp.blogspot.com/-D5NbAWtQDa0/VpbX2ZkIzMI/AAAAAAAAZVs/4k-mJK-YuP8/s200/aIMG_2175fsq.jpg" title="Crispy Potato and Hummus Balls" width="200" /></a></div>
+<div class="single_recipe_text" id="author" style="color: black; font-size: 15px; margin: 5px 5px 5px 0px; padding: 0;">
+by <span class="author">Hungry Couple</span></div>
+<div class="single_recipe_text" style="color: black; font-size: 12px; margin: 8px 4px 4px 4px; padding: 0;">
+<span style="font-weight: bold;">Prep Time:</span><span class="preptime"> 20 Minutes</span></div>
+<div class="single_recipe_text" style="color: black; font-size: 12px; margin: 4px; padding: 0;">
+<span style="font-weight: bold;">Cook Time:</span><span class="cooktime"> 55 Minutes</span></div>
+<div class="single_recipe_text" style="color: black; font-size: 12px; margin: 4px; padding: 0;">
+</div>
+<div id="get_media_div" style="clear: both; max-height: 100px;">
+<div id="recipe_id_div" style="display: none;">
+6076637</div>
+<!-- STRIPPED SCRIPT TAG --><!-- STRIPPED SCRIPT TAG --></div>
+<div id="ingredients">
+<div class="single_recipe_header" id="ingr_header" style="clear: both; color: black; font-size: 18px; padding: 0; text-decoration: none;">
+Ingredients<span class="single_recipe_text" style="color: black; font-size: 14px;"> (2 Dozen Balls)</span></div>
+<ul class="single_recipe_text" id="ingr" style="color: black; font-size: 14px;">
+<li class="ingredient" style="margin-bottom: 3px;">2 Large baking potatoes</li>
+<li class="ingredient" style="margin-bottom: 3px;">1/4 Cup <i><b><a href="http://sabra.com/products/Classic-Hummus" rel="nofollow" target="_blank">Sabra Classic Hummus</a></b></i></li>
+<li class="ingredient" style="margin-bottom: 3px;">1 - 2 Tablespoons milk</li>
+<li class="ingredient" style="margin-bottom: 3px;">2 Tablespoons chopped fresh cilantro or parsley</li>
+<li class="ingredient" style="margin-bottom: 3px;">Salt and pepper to taste</li>
+<li class="ingredient" style="margin-bottom: 3px;"><br /></li>
+<li class="ingredient" style="margin-bottom: 3px;"><b>Breading:</b></li>
+<li class="ingredient" style="margin-bottom: 3px;">4 Tablespoons unsalted butter, melted</li>
+<li class="ingredient" style="margin-bottom: 3px;">1/2 Cup breadcrumbs</li>
+<li class="ingredient" style="margin-bottom: 3px;"><br /></li>
+<li class="ingredient" style="margin-bottom: 3px;">Dipping sauce of your choice. I recommend <b><i><a href="http://sabra.com/products/farmers-ranch" rel="nofollow" target="_blank">Sabra Farmer's Ranch Greek Yogurt Dip</a></i></b>.</li>
+</ul>
+</div>
+<div id="instructions">
+<div class="single_recipe_header" id="inst_header" style="color: black; font-size: 18px; padding: 0; text-decoration: none;">
+Instructions</div>
+<div class="separator" style="clear: both; text-align: center;">
+<a href="http://2.bp.blogspot.com/--0IJqp8zO3Y/VpbYD75G5wI/AAAAAAAAZV0/KAaYVJNlsXc/s1600/aIMG_2181fc%2B500.jpg" imageanchor="1" style="clear: right; float: right; margin-bottom: 1em; margin-left: 1em;"><img alt="Crispy Potato and Hummus Balls" border="0" src="http://2.bp.blogspot.com/--0IJqp8zO3Y/VpbYD75G5wI/AAAAAAAAZV0/KAaYVJNlsXc/s1600/aIMG_2181fc%2B500.jpg" title="Crispy Potato and Hummus Balls" /></a></div>
+<div class="instruction">
+Pre-heat the oven to 400 degrees.</div>
+<div class="instruction">
+<br /></div>
+<div class="instruction">
+Peel and quarter the potatoes and cook in boiling salted water for about 15 minutes or until tender. Drain, return to the pot and mash. While mashing, stir in the hummus, milk and cilantro. Season with salt and pepper and allow to cool just enough to handle.</div>
+<div class="instruction">
+<br /></div>
+<div class="instruction">
+Add the melted butter to a bowl and the breadcrumbs to another bowl. Using a 1 oz. scoop, form balls of potato dough, dip in the butter and roll around in the breadcrumbs. Place the balls on a baking sheet lined with parchment paper and bake for 30 - 40 minutes or until golden brown. Serve warm with a dipping sauce.</div>
+<div class="instruction">
+<br /></div>
+</div>
+<div class="single_recipe_text" style="color: black; font-size: 10px; text-align: center; width: 100%;">
+Powered by <a class="single_recipe_header" href="http://www.recipage.com/" style="color: black; text-decoration: none;" target="_blank">Recipage</a></div>
+</div>
+<br />
+<div style="text-align: center;">
+<span style="background-color: white; color: #333333; font-family: 'Source Sans Pro', 'Helvetica Neue', sans-serif; line-height: 24.375px;">If you love chips and dips then check out Sabra&#8217;s Buy, Snap, Score promotion. If you buy 2 Sabra&#174; products (8 oz. or larger) and 2 bags of Stacy&#8217;s&#174;Pita Chips (6.7 oz. or larger) together before 2/15/216, text &#8220;DIP&#8221; to 811811 and follow the directions to submit a photo of your receipt OR upload your receipt to this </span><a href="http://dipzone.com/" rel="nofollow&#8221;" style="background-color: white; box-sizing: border-box; color: #010101; font-family: 'Source Sans Pro', 'Helvetica Neue', sans-serif; line-height: 24.375px;" target="_blank">website</a> <span style="background-color: white; color: #333333; font-family: 'Source Sans Pro', 'Helvetica Neue', sans-serif; line-height: 24.375px;">and receive a $5 gift card! </span></div>
+<br />
+<div style="text-align: center;">
+<span style="font-size: x-small;"><i>This recipe was sponsored by Sabra. Thank you for supporting the products I love and use in my kitchen.</i></span></div>
+<br />
+<div style='clear: both;'></div><div class='chicory-order-ingredients'></div>
+</div>
+<div class='post-footer'>
+<div class='post-footer-line post-footer-line-1'><span class='post-author vcard'>
+</span>
+<span class='post-timestamp'>
+</span>
+<span class='post-comment-link'>
+</span>
+<span class='post-icons'>
+<span class='item-control blog-admin pid-1151376813'>
+<a href='https://www.blogger.com/post-edit.g?blogID=8274369273568143862&postID=662289017799682219&from=pencil' title='Edit Post'>
+<img alt='' class='icon-action' height='18' src='//img2.blogblog.com/img/icon18_edit_allbkg.gif' width='18'/>
+</a>
+</span>
+</span>
+<span class='post-backlinks post-comment-link'>
+</span>
+<div class='post-share-buttons goog-inline-block'>
+</div>
+</div>
+<div class='post-footer-line post-footer-line-2'><span class='post-labels'>
+Labels:
+<a href='http://www.hungrycouplenyc.com/search/label/Appetizers%20and%20Snacks' rel='tag'>Appetizers and Snacks</a>
+</span>
+</div>
+<div class='post-footer-line post-footer-line-3'></div>
+</div>
+</div>
+<div class='comments' id='comments'>
+<a name='comments'></a>
+<h4>2 comments:</h4>
+<div class='comments-content'>
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<div id='comment-holder'>
+<div id='bc_0_3C' kind='c'><div id='bc_0_3CT'><div id='bc_0_2T' class='comment-thread' kind='r'  t='0' u='0'><ol id='bc_0_2TB'><li id='bc_0_0B' class='comment' kind='b'><div class='avatar-image-container'><img src='//1.bp.blogspot.com/-0xCFP9SA3Qw/VK-GdovtbEI/AAAAAAAABMg/jgenZr64rrI/s35/*'></img></div><div id='c7922064028331236277' class='comment-block'><div id='bc_0_0M' class='comment-header' kind='m'><cite class='user'><a rel='nofollow' href='https://www.blogger.com/profile/06635526268756076480'>Amy</a></cite><span class='icon user'></span><span class='datetime secondary-text'><a rel='nofollow' href='http://www.hungrycouplenyc.com/2016/01/crispy-potato-and-hummus-balls.html?showComment=1452817376814#c7922064028331236277'>January 14, 2016 at 7:22 PM</a></span></div><p id='bc_0_0MC' class='comment-content'>I don&#39;t know that I&#39;d be able to share these little nuggets of deliciousness! I know these are going to be a huge hit in our household for sure. We aren&#39;t sports fans but we do like something crispy, salty, savoury to nibble while we are watching &#39;American Horror Story&#39; :)</p><span id='bc_0_0MN' class='comment-actions secondary-text' kind='m'><a kind='i' href='javascript:;' target='_self' o='r'>Reply</a><span class='item-control blog-admin pid-884390714'><a o='d' target='_self' href='https://www.blogger.com/delete-comment.g?blogID=8274369273568143862&amp;postID=7922064028331236277'>Delete</a></span></span></div><div id='bc_0_0BR' class='comment-replies'></div><div id='bc_0_0B_box' class='comment-replybox-single'></div></li><li id='bc_0_1B' class='comment' kind='b'><div class='avatar-image-container'><img src='//lh4.googleusercontent.com/-SGKJO_B35PY/AAAAAAAAAAI/AAAAAAAAABU/CySgzFZDVdA/s35-c/photo.jpg'></img></div><div id='c4159516713677875479' class='comment-block'><div id='bc_0_1M' class='comment-header' kind='m'><cite class='user'><a rel='nofollow' href='https://www.blogger.com/profile/11058458072757121942'>Head Soccer</a></cite><span class='icon user'></span><span class='datetime secondary-text'><a rel='nofollow' href='http://www.hungrycouplenyc.com/2016/01/crispy-potato-and-hummus-balls.html?showComment=1452848963907#c4159516713677875479'>January 15, 2016 at 4:09 AM</a></span></div><p id='bc_0_1MC' class='comment-content'>Today, I read your post .. I follow the steps, and dinner was wonderful.<br />Had visited the sites you had posted and it was nice. <br />Nicely written information in this post, the quality of content is fine and picture very nice. Things are very open and intensely clear explanation of issues.<br /><a href="http://run3play.com/" rel="nofollow">Run 3</a>  | <a href="http://headsocceronline.com/" rel="nofollow">Head Soccer</a> | <br /><a href="http://mahjongfreegamesonline.com/" rel="nofollow">Mahjong Free Games</a> |  <a href="http://www.juegosdeterroronline.net/" rel="nofollow">Juegos De Terror</a> | <br /><a href="https://headsocceronline.wordpress.com/" rel="nofollow">sports heads football</a><br /><a href="http://headsocceronline.blogspot.com/" rel="nofollow">head football</a><br /><a href="http://headsoccer2.blogolink.com/" rel="nofollow">big head soccer</a><br /><br /></p><span id='bc_0_1MN' class='comment-actions secondary-text' kind='m'><a kind='i' href='javascript:;' target='_self' o='r'>Reply</a><span class='item-control blog-admin pid-2142283700'><a o='d' target='_self' href='https://www.blogger.com/delete-comment.g?blogID=8274369273568143862&amp;postID=4159516713677875479'>Delete</a></span></span></div><div id='bc_0_1BR' class='comment-replies'></div><div id='bc_0_1B_box' class='comment-replybox-single'></div></li></ol><div id='bc_0_2I' class='continue' kind='ci'><a href='javascript:;' target='_self'>Add comment</a></div><div id='bc_0_2T_box' class='comment-replybox-thread'></div><div id='bc_0_2L' class='loadmore loaded' kind='rb'><a href='javascript:;' target='_self'>Load more...</a></div></div></div></div>
+</div>
+</div>
+<p class='comment-footer'>
+<div class='comment-form'>
+<a name='comment-form'></a>
+<p>We&#39;d love to hear from you!</p>
+<a href='https://www.blogger.com/comment-iframe.g?blogID=8274369273568143862&postID=662289017799682219' id='comment-editor-src'></a>
+<iframe allowtransparency='true' class='blogger-iframe-colorize blogger-comment-from-post' frameborder='0' height='410px' id='comment-editor' name='comment-editor' src='' width='100%'></iframe>
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+</div>
+</p>
+<div id='backlinks-container'>
+<div id='Blog1_backlinks-container'>
+<a name='links'></a><h4>
+</h4>
+<p class='comment-footer'>
+<a class='comment-link' href='' id='Blog1_backlinks-create-link' target='_blank'>
+</a>
+</p>
+</div>
+</div>
+</div>
+</div>
+
+        </div></div>
+      
+</div>
+<div class='blog-pager' id='blog-pager'>
+<span id='blog-pager-older-link'>
+<a class='blog-pager-older-link' href='http://www.hungrycouplenyc.com/2016/01/spaghetti-squash-with-chicken-meatballs.html' id='Blog1_blog-pager-older-link' title='Older Post'>Older Post</a>
+</span>
+<a class='home-link' href='http://www.hungrycouplenyc.com/'>Home</a>
+</div>
+<div class='clear'></div>
+<div class='post-feeds'>
+<div class='feed-links'>
+Subscribe to:
+<a class='feed-link' href='http://www.hungrycouplenyc.com/feeds/662289017799682219/comments/default' target='_blank' type='application/atom+xml'>Post Comments (Atom)</a>
+</div>
+</div>
+<!-- STRIPPED SCRIPT TAG -->
+</div></div>
+</div>
+</div>
+<div class='column-left-outer'>
+<div class='column-left-inner'>
+<aside>
+</aside>
+</div>
+</div>
+<div class='column-right-outer'>
+<div class='column-right-inner'>
+<aside>
+<div class='sidebar section' id='sidebar-right-1'><div class='widget HTML' id='HTML11'>
+<div class='widget-content'>
+<!-- STRIPPED SCRIPT TAG --><!-- STRIPPED SCRIPT TAG --><!-- STRIPPED SCRIPT TAG --><noscript><iframe src='//p179.atemda.com/nojsadserving.ashx?pbId=179&wsName=Boldscreen_RON&wName=NoScript&bfDim=300x250&rank=1&clk=' width='300' height='250' frameborder='0' marginheight='0' marginwidth='0' scrolling='no'></iframe></noscript>
+</div>
+<div class='clear'></div>
+<span class='widget-item-control'>
+<span class='item-control blog-admin'>
+<a class='quickedit' href='//www.blogger.com/rearrange?blogID=8274369273568143862&widgetType=HTML&widgetId=HTML11&action=editWidget&sectionId=sidebar-right-1' onclick='return _WidgetManager._PopupConfig(document.getElementById("HTML11"));' target='configHTML11' title='Edit'>
+<img alt='' height='18' src='//img1.blogblog.com/img/icon18_wrench_allbkg.png' width='18'/>
+</a>
+</span>
+</span>
+<div class='clear'></div>
+</div><div class='widget HTML' id='HTML17'>
+<div class='widget-content'>
+<!-- Go to www.addthis.com/dashboard to customize your tools -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- Go to www.addthis.com/dashboard to customize your tools -->
+<div class="addthis_horizontal_follow_toolbox"></div>
+</div>
+<div class='clear'></div>
+<span class='widget-item-control'>
+<span class='item-control blog-admin'>
+<a class='quickedit' href='//www.blogger.com/rearrange?blogID=8274369273568143862&widgetType=HTML&widgetId=HTML17&action=editWidget&sectionId=sidebar-right-1' onclick='return _WidgetManager._PopupConfig(document.getElementById("HTML17"));' target='configHTML17' title='Edit'>
+<img alt='' height='18' src='//img1.blogblog.com/img/icon18_wrench_allbkg.png' width='18'/>
+</a>
+</span>
+</span>
+<div class='clear'></div>
+</div><div class='widget FollowByEmail' id='FollowByEmail1'>
+<h2 class='title'>Get Posts Delivered By Email:</h2>
+<div class='widget-content'>
+<div class='follow-by-email-inner'>
+<form action='https://feedburner.google.com/fb/a/mailverify' method='post' onsubmit='window.open("https://feedburner.google.com/fb/a/mailverify?uri=HungryCouple", "popupwindow", "scrollbars=yes,width=550,height=520"); return true' target='popupwindow'>
+<table width='100%'>
+<tr>
+<td>
+<input class='follow-by-email-address' name='email' placeholder='Email address...' type='text'/>
+</td>
+<td width='64px'>
+<input class='follow-by-email-submit' type='submit' value='Submit'/>
+</td>
+</tr>
+</table>
+<input name='uri' type='hidden' value='HungryCouple'/>
+<input name='loc' type='hidden' value='en_US'/>
+</form>
+</div>
+</div>
+<span class='item-control blog-admin'>
+<div class='clear'></div>
+<span class='widget-item-control'>
+<span class='item-control blog-admin'>
+<a class='quickedit' href='//www.blogger.com/rearrange?blogID=8274369273568143862&widgetType=FollowByEmail&widgetId=FollowByEmail1&action=editWidget&sectionId=sidebar-right-1' onclick='return _WidgetManager._PopupConfig(document.getElementById("FollowByEmail1"));' target='configFollowByEmail1' title='Edit'>
+<img alt='' height='18' src='//img1.blogblog.com/img/icon18_wrench_allbkg.png' width='18'/>
+</a>
+</span>
+</span>
+<div class='clear'></div>
+</span>
+</div><div class='widget CustomSearch' id='CustomSearch1'>
+<h2 class='title'>Search This Site</h2>
+<div class='widget-content'>
+<div id='CustomSearch1_form'>
+<span class='cse-status'>Loading...</span>
+</div>
+</div>
+<style type='text/css'>
+      #uds-searchControl .gs-result .gs-title,
+      #uds-searchControl .gs-result .gs-title *,
+      #uds-searchControl .gsc-results .gsc-trailing-more-results,
+      #uds-searchControl .gsc-results .gsc-trailing-more-results * {
+        color:#999999;
+      }
+
+      #uds-searchControl .gs-result .gs-title a:visited,
+      #uds-searchControl .gs-result .gs-title a:visited * {
+        color:#444444;
+      }
+
+      #uds-searchControl .gs-relativePublishedDate,
+      #uds-searchControl .gs-publishedDate {
+        color: transparent;
+      }
+
+      #uds-searchControl .gs-result a.gs-visibleUrl,
+      #uds-searchControl .gs-result .gs-visibleUrl {
+        color: #999999;
+      }
+
+      #uds-searchControl .gsc-results {
+        border-color: transparent;
+        background-color: transparent;
+      }
+
+      #uds-searchControl .gsc-tabhActive {
+        border-color: transparent;
+        border-top-color: transparent;
+        background-color: transparent;
+        color: #444444;
+      }
+
+      #uds-searchControl .gsc-tabhInactive {
+        border-color: transparent;
+        background-color: transparent;
+        color: #999999;
+      }
+
+      #uds-searchClearResults {
+        border-color: transparent;
+      }
+
+      #uds-searchClearResults:hover {
+        border-color: transparent;
+      }
+
+      #uds-searchControl .gsc-cursor-page {
+        color: #999999;
+      }
+
+      #uds-searchControl .gsc-cursor-current-page {
+        color: #444444;
+      }
+    </style>
+<div class='clear'></div>
+<span class='widget-item-control'>
+<span class='item-control blog-admin'>
+<a class='quickedit' href='//www.blogger.com/rearrange?blogID=8274369273568143862&widgetType=CustomSearch&widgetId=CustomSearch1&action=editWidget&sectionId=sidebar-right-1' onclick='return _WidgetManager._PopupConfig(document.getElementById("CustomSearch1"));' target='configCustomSearch1' title='Edit'>
+<img alt='' height='18' src='//img1.blogblog.com/img/icon18_wrench_allbkg.png' width='18'/>
+</a>
+</span>
+</span>
+<div class='clear'></div>
+</div><div class='widget HTML' id='HTML10'>
+<div class='widget-content'>
+<!-- TBN.hungrycouplenyc ATF 300x250 -->
+<div id='12345678-1'>
+    <!-- STRIPPED SCRIPT TAG -->
+</div>
+<div style="width:300px;"><a style="color: #ed5b3f; float: left; font-size:12px;" target="_blank" href="http://www.thebloggernetwork.com/media-kit/"><img src="http://www.thebloggernetwork.com/tbn-ad.png" alt="The Blogger Network" />Advertise with us</a>
+<a style="color: #ed5b3f; float: right; font-size:12px;" href="mailto:ads@thebloggernetwork.com?subject=Report of an Inappropriate Advertisement&body=For best service, please attach a screenshot">Report this ad</a>
+</div>
+</div>
+<div class='clear'></div>
+<span class='widget-item-control'>
+<span class='item-control blog-admin'>
+<a class='quickedit' href='//www.blogger.com/rearrange?blogID=8274369273568143862&widgetType=HTML&widgetId=HTML10&action=editWidget&sectionId=sidebar-right-1' onclick='return _WidgetManager._PopupConfig(document.getElementById("HTML10"));' target='configHTML10' title='Edit'>
+<img alt='' height='18' src='//img1.blogblog.com/img/icon18_wrench_allbkg.png' width='18'/>
+</a>
+</span>
+</span>
+<div class='clear'></div>
+</div><div class='widget Image' id='Image1'>
+<h2>Check out my column on About.com Food!</h2>
+<div class='widget-content'>
+<a href='http://mideastfood.about.com/'>
+<img alt='Check out my column on About.com Food!' height='367' id='Image1_img' src='http://2.bp.blogspot.com/-uBjkNkysB8k/VgiqNhBxYnI/AAAAAAAAXyg/HuSumjMy_CA/s367/Sidebar%2BCollage%2B2.jpg' width='308'/>
+</a>
+<br/>
+</div>
+<div class='clear'></div>
+<span class='widget-item-control'>
+<span class='item-control blog-admin'>
+<a class='quickedit' href='//www.blogger.com/rearrange?blogID=8274369273568143862&widgetType=Image&widgetId=Image1&action=editWidget&sectionId=sidebar-right-1' onclick='return _WidgetManager._PopupConfig(document.getElementById("Image1"));' target='configImage1' title='Edit'>
+<img alt='' height='18' src='//img1.blogblog.com/img/icon18_wrench_allbkg.png' width='18'/>
+</a>
+</span>
+</span>
+<div class='clear'></div>
+</div><div class='widget BlogArchive' id='BlogArchive1'>
+<h2>Archives</h2>
+<div class='widget-content'>
+<div id='ArchiveList'>
+<div id='BlogArchive1_ArchiveList'>
+<ul class='hierarchy'>
+<li class='archivedate expanded'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy toggle-open'>
+
+        &#9660; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/search?updated-min=2016-01-01T00:00:00-05:00&amp;updated-max=2017-01-01T00:00:00-05:00&amp;max-results=5'>
+2016
+</a>
+<span class='post-count' dir='ltr'>(5)</span>
+<ul class='hierarchy'>
+<li class='archivedate expanded'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy toggle-open'>
+
+        &#9660; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2016_01_01_archive.html'>
+January
+</a>
+<span class='post-count' dir='ltr'>(5)</span>
+<ul class='posts'>
+<li><a href='http://www.hungrycouplenyc.com/2016/01/crispy-potato-and-hummus-balls.html'>Crispy Potato and Hummus Balls</a></li>
+<li><a href='http://www.hungrycouplenyc.com/2016/01/spaghetti-squash-with-chicken-meatballs.html'>Spaghetti Squash with Chicken Meatballs</a></li>
+<li><a href='http://www.hungrycouplenyc.com/2016/01/yogurt-with-banana-and-honey-almond.html'>Yogurt with Banana and Honey Almond Crumble</a></li>
+<li><a href='http://www.hungrycouplenyc.com/2016/01/curried-potato-and-broccoli-soup.html'>Curried Potato and Broccoli Soup</a></li>
+<li><a href='http://www.hungrycouplenyc.com/2016/01/elsewhere-indecember-2015.html'>Elsewhere in...December 2015</a></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/search?updated-min=2015-01-01T00:00:00-05:00&amp;updated-max=2016-01-01T00:00:00-05:00&amp;max-results=50'>
+2015
+</a>
+<span class='post-count' dir='ltr'>(148)</span>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2015_12_01_archive.html'>
+December
+</a>
+<span class='post-count' dir='ltr'>(10)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2015_11_01_archive.html'>
+November
+</a>
+<span class='post-count' dir='ltr'>(12)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2015_10_01_archive.html'>
+October
+</a>
+<span class='post-count' dir='ltr'>(13)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2015_09_01_archive.html'>
+September
+</a>
+<span class='post-count' dir='ltr'>(12)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2015_08_01_archive.html'>
+August
+</a>
+<span class='post-count' dir='ltr'>(13)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2015_07_01_archive.html'>
+July
+</a>
+<span class='post-count' dir='ltr'>(14)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2015_06_01_archive.html'>
+June
+</a>
+<span class='post-count' dir='ltr'>(13)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2015_05_01_archive.html'>
+May
+</a>
+<span class='post-count' dir='ltr'>(13)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2015_04_01_archive.html'>
+April
+</a>
+<span class='post-count' dir='ltr'>(13)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2015_03_01_archive.html'>
+March
+</a>
+<span class='post-count' dir='ltr'>(13)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2015_02_01_archive.html'>
+February
+</a>
+<span class='post-count' dir='ltr'>(10)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2015_01_01_archive.html'>
+January
+</a>
+<span class='post-count' dir='ltr'>(12)</span>
+</li>
+</ul>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/search?updated-min=2014-01-01T00:00:00-05:00&amp;updated-max=2015-01-01T00:00:00-05:00&amp;max-results=50'>
+2014
+</a>
+<span class='post-count' dir='ltr'>(176)</span>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2014_12_01_archive.html'>
+December
+</a>
+<span class='post-count' dir='ltr'>(18)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2014_11_01_archive.html'>
+November
+</a>
+<span class='post-count' dir='ltr'>(14)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2014_10_01_archive.html'>
+October
+</a>
+<span class='post-count' dir='ltr'>(15)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2014_09_01_archive.html'>
+September
+</a>
+<span class='post-count' dir='ltr'>(13)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2014_08_01_archive.html'>
+August
+</a>
+<span class='post-count' dir='ltr'>(12)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2014_07_01_archive.html'>
+July
+</a>
+<span class='post-count' dir='ltr'>(15)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2014_06_01_archive.html'>
+June
+</a>
+<span class='post-count' dir='ltr'>(14)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2014_05_01_archive.html'>
+May
+</a>
+<span class='post-count' dir='ltr'>(16)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2014_04_01_archive.html'>
+April
+</a>
+<span class='post-count' dir='ltr'>(16)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2014_03_01_archive.html'>
+March
+</a>
+<span class='post-count' dir='ltr'>(16)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2014_02_01_archive.html'>
+February
+</a>
+<span class='post-count' dir='ltr'>(13)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2014_01_01_archive.html'>
+January
+</a>
+<span class='post-count' dir='ltr'>(14)</span>
+</li>
+</ul>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/search?updated-min=2013-01-01T00:00:00-05:00&amp;updated-max=2014-01-01T00:00:00-05:00&amp;max-results=50'>
+2013
+</a>
+<span class='post-count' dir='ltr'>(167)</span>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2013_12_01_archive.html'>
+December
+</a>
+<span class='post-count' dir='ltr'>(15)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2013_11_01_archive.html'>
+November
+</a>
+<span class='post-count' dir='ltr'>(13)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2013_10_01_archive.html'>
+October
+</a>
+<span class='post-count' dir='ltr'>(13)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2013_09_01_archive.html'>
+September
+</a>
+<span class='post-count' dir='ltr'>(14)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2013_08_01_archive.html'>
+August
+</a>
+<span class='post-count' dir='ltr'>(16)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2013_07_01_archive.html'>
+July
+</a>
+<span class='post-count' dir='ltr'>(16)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2013_06_01_archive.html'>
+June
+</a>
+<span class='post-count' dir='ltr'>(13)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2013_05_01_archive.html'>
+May
+</a>
+<span class='post-count' dir='ltr'>(15)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2013_04_01_archive.html'>
+April
+</a>
+<span class='post-count' dir='ltr'>(14)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2013_03_01_archive.html'>
+March
+</a>
+<span class='post-count' dir='ltr'>(13)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2013_02_01_archive.html'>
+February
+</a>
+<span class='post-count' dir='ltr'>(12)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2013_01_01_archive.html'>
+January
+</a>
+<span class='post-count' dir='ltr'>(13)</span>
+</li>
+</ul>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/search?updated-min=2012-01-01T00:00:00-05:00&amp;updated-max=2013-01-01T00:00:00-05:00&amp;max-results=50'>
+2012
+</a>
+<span class='post-count' dir='ltr'>(141)</span>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2012_12_01_archive.html'>
+December
+</a>
+<span class='post-count' dir='ltr'>(13)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2012_11_01_archive.html'>
+November
+</a>
+<span class='post-count' dir='ltr'>(12)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2012_10_01_archive.html'>
+October
+</a>
+<span class='post-count' dir='ltr'>(19)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2012_09_01_archive.html'>
+September
+</a>
+<span class='post-count' dir='ltr'>(13)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2012_08_01_archive.html'>
+August
+</a>
+<span class='post-count' dir='ltr'>(13)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2012_07_01_archive.html'>
+July
+</a>
+<span class='post-count' dir='ltr'>(11)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2012_06_01_archive.html'>
+June
+</a>
+<span class='post-count' dir='ltr'>(9)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2012_05_01_archive.html'>
+May
+</a>
+<span class='post-count' dir='ltr'>(14)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2012_04_01_archive.html'>
+April
+</a>
+<span class='post-count' dir='ltr'>(11)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2012_03_01_archive.html'>
+March
+</a>
+<span class='post-count' dir='ltr'>(12)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2012_02_01_archive.html'>
+February
+</a>
+<span class='post-count' dir='ltr'>(8)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2012_01_01_archive.html'>
+January
+</a>
+<span class='post-count' dir='ltr'>(6)</span>
+</li>
+</ul>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/search?updated-min=2011-01-01T00:00:00-05:00&amp;updated-max=2012-01-01T00:00:00-05:00&amp;max-results=50'>
+2011
+</a>
+<span class='post-count' dir='ltr'>(82)</span>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2011_12_01_archive.html'>
+December
+</a>
+<span class='post-count' dir='ltr'>(6)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2011_11_01_archive.html'>
+November
+</a>
+<span class='post-count' dir='ltr'>(7)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2011_10_01_archive.html'>
+October
+</a>
+<span class='post-count' dir='ltr'>(8)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2011_09_01_archive.html'>
+September
+</a>
+<span class='post-count' dir='ltr'>(8)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2011_08_01_archive.html'>
+August
+</a>
+<span class='post-count' dir='ltr'>(9)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2011_07_01_archive.html'>
+July
+</a>
+<span class='post-count' dir='ltr'>(10)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2011_06_01_archive.html'>
+June
+</a>
+<span class='post-count' dir='ltr'>(8)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2011_05_01_archive.html'>
+May
+</a>
+<span class='post-count' dir='ltr'>(5)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2011_04_01_archive.html'>
+April
+</a>
+<span class='post-count' dir='ltr'>(10)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2011_02_01_archive.html'>
+February
+</a>
+<span class='post-count' dir='ltr'>(4)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2011_01_01_archive.html'>
+January
+</a>
+<span class='post-count' dir='ltr'>(7)</span>
+</li>
+</ul>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/search?updated-min=2010-01-01T00:00:00-05:00&amp;updated-max=2011-01-01T00:00:00-05:00&amp;max-results=50'>
+2010
+</a>
+<span class='post-count' dir='ltr'>(54)</span>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2010_12_01_archive.html'>
+December
+</a>
+<span class='post-count' dir='ltr'>(4)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2010_11_01_archive.html'>
+November
+</a>
+<span class='post-count' dir='ltr'>(4)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2010_10_01_archive.html'>
+October
+</a>
+<span class='post-count' dir='ltr'>(9)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2010_09_01_archive.html'>
+September
+</a>
+<span class='post-count' dir='ltr'>(7)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2010_08_01_archive.html'>
+August
+</a>
+<span class='post-count' dir='ltr'>(12)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2010_07_01_archive.html'>
+July
+</a>
+<span class='post-count' dir='ltr'>(4)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2010_06_01_archive.html'>
+June
+</a>
+<span class='post-count' dir='ltr'>(1)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2010_05_01_archive.html'>
+May
+</a>
+<span class='post-count' dir='ltr'>(5)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2010_04_01_archive.html'>
+April
+</a>
+<span class='post-count' dir='ltr'>(3)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2010_03_01_archive.html'>
+March
+</a>
+<span class='post-count' dir='ltr'>(4)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2010_02_01_archive.html'>
+February
+</a>
+<span class='post-count' dir='ltr'>(1)</span>
+</li>
+</ul>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/search?updated-min=2009-01-01T00:00:00-05:00&amp;updated-max=2010-01-01T00:00:00-05:00&amp;max-results=32'>
+2009
+</a>
+<span class='post-count' dir='ltr'>(32)</span>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2009_12_01_archive.html'>
+December
+</a>
+<span class='post-count' dir='ltr'>(1)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2009_11_01_archive.html'>
+November
+</a>
+<span class='post-count' dir='ltr'>(4)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2009_10_01_archive.html'>
+October
+</a>
+<span class='post-count' dir='ltr'>(6)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2009_09_01_archive.html'>
+September
+</a>
+<span class='post-count' dir='ltr'>(1)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2009_08_01_archive.html'>
+August
+</a>
+<span class='post-count' dir='ltr'>(2)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2009_07_01_archive.html'>
+July
+</a>
+<span class='post-count' dir='ltr'>(1)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2009_06_01_archive.html'>
+June
+</a>
+<span class='post-count' dir='ltr'>(3)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2009_05_01_archive.html'>
+May
+</a>
+<span class='post-count' dir='ltr'>(4)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2009_04_01_archive.html'>
+April
+</a>
+<span class='post-count' dir='ltr'>(4)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2009_03_01_archive.html'>
+March
+</a>
+<span class='post-count' dir='ltr'>(5)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2009_02_01_archive.html'>
+February
+</a>
+<span class='post-count' dir='ltr'>(1)</span>
+</li>
+</ul>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/search?updated-min=2008-01-01T00:00:00-05:00&amp;updated-max=2009-01-01T00:00:00-05:00&amp;max-results=7'>
+2008
+</a>
+<span class='post-count' dir='ltr'>(7)</span>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2008_12_01_archive.html'>
+December
+</a>
+<span class='post-count' dir='ltr'>(5)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2008_10_01_archive.html'>
+October
+</a>
+<span class='post-count' dir='ltr'>(1)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2008_05_01_archive.html'>
+May
+</a>
+<span class='post-count' dir='ltr'>(1)</span>
+</li>
+</ul>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/search?updated-min=2007-01-01T00:00:00-05:00&amp;updated-max=2008-01-01T00:00:00-05:00&amp;max-results=2'>
+2007
+</a>
+<span class='post-count' dir='ltr'>(2)</span>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2007_09_01_archive.html'>
+September
+</a>
+<span class='post-count' dir='ltr'>(1)</span>
+</li>
+</ul>
+<ul class='hierarchy'>
+<li class='archivedate collapsed'>
+<a class='toggle' href='javascript:void(0)'>
+<span class='zippy'>
+
+        &#9658; 
+      
+</span>
+</a>
+<a class='post-count-link' href='http://www.hungrycouplenyc.com/2007_07_01_archive.html'>
+July
+</a>
+<span class='post-count' dir='ltr'>(1)</span>
+</li>
+</ul>
+</li>
+</ul>
+</div>
+</div>
+<div class='clear'></div>
+<span class='widget-item-control'>
+<span class='item-control blog-admin'>
+<a class='quickedit' href='//www.blogger.com/rearrange?blogID=8274369273568143862&widgetType=BlogArchive&widgetId=BlogArchive1&action=editWidget&sectionId=sidebar-right-1' onclick='return _WidgetManager._PopupConfig(document.getElementById("BlogArchive1"));' target='configBlogArchive1' title='Edit'>
+<img alt='' height='18' src='//img1.blogblog.com/img/icon18_wrench_allbkg.png' width='18'/>
+</a>
+</span>
+</span>
+<div class='clear'></div>
+</div>
+</div><div class='widget HTML' id='HTML8'>
+<div class='widget-content'>
+<!-- TBN.hungrycouplenyc BTF 300x250 -->
+<div id='12345678-2'>
+    <!-- STRIPPED SCRIPT TAG -->
+</div>
+<div style="width:300px;"><a style="color: #ed5b3f; float: left; font-size:12px;" target="_blank" href="http://www.thebloggernetwork.com/media-kit/"><img src="http://www.thebloggernetwork.com/tbn-ad.png" alt="The Blogger Network" />Advertise with us</a>
+<a style="color: #ed5b3f; float: right; font-size:12px;" href="mailto:ads@thebloggernetwork.com?subject=Report of an Inappropriate Advertisement&body=For best service, please attach a screenshot">Report this ad</a>
+</div>
+</div>
+<div class='clear'></div>
+<span class='widget-item-control'>
+<span class='item-control blog-admin'>
+<a class='quickedit' href='//www.blogger.com/rearrange?blogID=8274369273568143862&widgetType=HTML&widgetId=HTML8&action=editWidget&sectionId=sidebar-right-1' onclick='return _WidgetManager._PopupConfig(document.getElementById("HTML8"));' target='configHTML8' title='Edit'>
+<img alt='' height='18' src='//img1.blogblog.com/img/icon18_wrench_allbkg.png' width='18'/>
+</a>
+</span>
+</span>
+<div class='clear'></div>
+</div><div class='widget FeaturedPost' id='FeaturedPost1'>
+<h2 class='title'>Featured Post</h2>
+<div class='post-summary'>
+<h3><a href='http://www.hungrycouplenyc.com/2015/05/the-manhattan.html'>The Manhattan</a></h3>
+<p>
+   The classic, elegant Manhattan is one of the first cocktails I ever learned to drink. It seemed like such a grown up, classy thing to sip...
+</p>
+<img class='image' src='http://4.bp.blogspot.com/-wOJQMXwnBTg/VWfiSfqVLsI/AAAAAAAAWJg/PufSaZrwbyc/s1600/Manhattan%2B1%2BVertical%2B1%2B690.jpg'/>
+</div>
+<style type='text/css'>
+    .image {
+      width: 100%;
+    }
+  </style>
+<div class='clear'></div>
+<span class='widget-item-control'>
+<span class='item-control blog-admin'>
+<a class='quickedit' href='//www.blogger.com/rearrange?blogID=8274369273568143862&widgetType=FeaturedPost&widgetId=FeaturedPost1&action=editWidget&sectionId=sidebar-right-1' onclick='return _WidgetManager._PopupConfig(document.getElementById("FeaturedPost1"));' target='configFeaturedPost1' title='Edit'>
+<img alt='' height='18' src='//img1.blogblog.com/img/icon18_wrench_allbkg.png' width='18'/>
+</a>
+</span>
+</span>
+<div class='clear'></div>
+</div><div class='widget PopularPosts' id='PopularPosts1'>
+<h2>Popular Posts</h2>
+<div class='widget-content popular-posts'>
+<ul>
+<li>
+<div class='item-thumbnail-only'>
+<div class='item-thumbnail'>
+<a href='http://www.hungrycouplenyc.com/2014/06/mexican-tortilla-pie.html' target='_blank'>
+<img alt='' border='0' height='72' src='http://2.bp.blogspot.com/-HbISVuHwUyU/U5fBxOnsdMI/AAAAAAAARaY/fwYwDa8sX-M/s72-c/aIMG_5714fvertical+690.jpg' width='72'/>
+</a>
+</div>
+<div class='item-title'><a href='http://www.hungrycouplenyc.com/2014/06/mexican-tortilla-pie.html'>Mexican Tortilla Pie</a></div>
+</div>
+<div style='clear: both;'></div>
+</li>
+<li>
+<div class='item-thumbnail-only'>
+<div class='item-thumbnail'>
+<a href='http://www.hungrycouplenyc.com/2013/09/baked-spinach-chips.html' target='_blank'>
+<img alt='' border='0' height='72' src='http://3.bp.blogspot.com/-SeQ0Zjv5Ed4/UkUAvo9RNQI/AAAAAAAANTI/FgUY9TFWOZo/s72-c/IMG_2880fc.jpg' width='72'/>
+</a>
+</div>
+<div class='item-title'><a href='http://www.hungrycouplenyc.com/2013/09/baked-spinach-chips.html'>Baked Spinach Chips</a></div>
+</div>
+<div style='clear: both;'></div>
+</li>
+<li>
+<div class='item-thumbnail-only'>
+<div class='item-thumbnail'>
+<a href='http://www.hungrycouplenyc.com/2013/05/chocolate-chip-bread.html' target='_blank'>
+<img alt='' border='0' height='72' src='http://2.bp.blogspot.com/-zPEheGuZc2w/UZBo08gLo1I/AAAAAAAALbY/jmRtmSSTaGs/s72-c/aIMG_1213fc.jpg' width='72'/>
+</a>
+</div>
+<div class='item-title'><a href='http://www.hungrycouplenyc.com/2013/05/chocolate-chip-bread.html'>Chocolate Chip Bread</a></div>
+</div>
+<div style='clear: both;'></div>
+</li>
+<li>
+<div class='item-thumbnail-only'>
+<div class='item-thumbnail'>
+<a href='http://www.hungrycouplenyc.com/2012/05/ultimate-macaroni-salad.html' target='_blank'>
+<img alt='' border='0' height='72' src='http://4.bp.blogspot.com/-CFi6LNXxDeU/T8TIo-nuptI/AAAAAAAAC6g/IYGW6WaNJI4/s72-c/Macaroni+Salad+1.JPG' width='72'/>
+</a>
+</div>
+<div class='item-title'><a href='http://www.hungrycouplenyc.com/2012/05/ultimate-macaroni-salad.html'>The Ultimate Macaroni Salad</a></div>
+</div>
+<div style='clear: both;'></div>
+</li>
+<li>
+<div class='item-thumbnail-only'>
+<div class='item-thumbnail'>
+<a href='http://www.hungrycouplenyc.com/2014/07/no-churn-blueberry-cheese-cake-ice.html' target='_blank'>
+<img alt='' border='0' height='72' src='http://2.bp.blogspot.com/-4TLEEwfKm50/U8NTv-6350I/AAAAAAAAR4Q/UAXaElMrf44/s72-c/IMG_6236fvertical+690.jpg' width='72'/>
+</a>
+</div>
+<div class='item-title'><a href='http://www.hungrycouplenyc.com/2014/07/no-churn-blueberry-cheese-cake-ice.html'>No Churn Blueberry Cheesecake Ice Cream</a></div>
+</div>
+<div style='clear: both;'></div>
+</li>
+</ul>
+<div class='clear'></div>
+<span class='widget-item-control'>
+<span class='item-control blog-admin'>
+<a class='quickedit' href='//www.blogger.com/rearrange?blogID=8274369273568143862&widgetType=PopularPosts&widgetId=PopularPosts1&action=editWidget&sectionId=sidebar-right-1' onclick='return _WidgetManager._PopupConfig(document.getElementById("PopularPosts1"));' target='configPopularPosts1' title='Edit'>
+<img alt='' height='18' src='//img1.blogblog.com/img/icon18_wrench_allbkg.png' width='18'/>
+</a>
+</span>
+</span>
+<div class='clear'></div>
+</div>
+</div><div class='widget HTML' id='HTML14'>
+<div class='widget-content'>
+<!-- TBN.hungrycouplenyc BTF 300x250 -->
+<div id='12345678-3'>
+    <!-- STRIPPED SCRIPT TAG -->
+</div>
+
+<div style="width:300px;"><a style="color: #ed5b3f; float: left; font-size:12px;" target="_blank" href="http://www.thebloggernetwork.com/media-kit/"><img src="http://www.thebloggernetwork.com/tbn-ad.png" alt="The Blogger Network" />Advertise with us</a>
+<a style="color: #ed5b3f; float: right; font-size:12px;" href="mailto:ads@thebloggernetwork.com?subject=Report of an Inappropriate Advertisement&body=For best service, please attach a screenshot">Report this ad</a>
+</div>
+</div>
+<div class='clear'></div>
+<span class='widget-item-control'>
+<span class='item-control blog-admin'>
+<a class='quickedit' href='//www.blogger.com/rearrange?blogID=8274369273568143862&widgetType=HTML&widgetId=HTML14&action=editWidget&sectionId=sidebar-right-1' onclick='return _WidgetManager._PopupConfig(document.getElementById("HTML14"));' target='configHTML14' title='Edit'>
+<img alt='' height='18' src='//img1.blogblog.com/img/icon18_wrench_allbkg.png' width='18'/>
+</a>
+</span>
+</span>
+<div class='clear'></div>
+</div><div class='widget HTML' id='HTML16'>
+<div class='widget-content'>
+<a data-pin-do="embedUser" href="http://www.pinterest.com/hungrycouplenyc/"data-pin-scale-width="80" data-pin-scale-height="200" data-pin-board-width="400">Visit Anita at Hungry Couple's profile on Pinterest.</a><!-- Please call pinit.js only once per page --><!-- STRIPPED SCRIPT TAG -->
+</div>
+<div class='clear'></div>
+<span class='widget-item-control'>
+<span class='item-control blog-admin'>
+<a class='quickedit' href='//www.blogger.com/rearrange?blogID=8274369273568143862&widgetType=HTML&widgetId=HTML16&action=editWidget&sectionId=sidebar-right-1' onclick='return _WidgetManager._PopupConfig(document.getElementById("HTML16"));' target='configHTML16' title='Edit'>
+<img alt='' height='18' src='//img1.blogblog.com/img/icon18_wrench_allbkg.png' width='18'/>
+</a>
+</span>
+</span>
+<div class='clear'></div>
+</div><div class='widget HTML' id='HTML7'>
+<div class='widget-content'>
+<!-- STRIPPED SCRIPT TAG --><!-- STRIPPED SCRIPT TAG -->
+</div>
+<div class='clear'></div>
+<span class='widget-item-control'>
+<span class='item-control blog-admin'>
+<a class='quickedit' href='//www.blogger.com/rearrange?blogID=8274369273568143862&widgetType=HTML&widgetId=HTML7&action=editWidget&sectionId=sidebar-right-1' onclick='return _WidgetManager._PopupConfig(document.getElementById("HTML7"));' target='configHTML7' title='Edit'>
+<img alt='' height='18' src='//img1.blogblog.com/img/icon18_wrench_allbkg.png' width='18'/>
+</a>
+</span>
+</span>
+<div class='clear'></div>
+</div><div class='widget HTML' id='HTML5'>
+<div class='widget-content'>
+<!-- Your CGC Badge: Congratulations! --><!-- STRIPPED SCRIPT TAG --><!-- STRIPPED SCRIPT TAG --><!-- STRIPPED SCRIPT TAG --><!-- END CGC Badge -->
+</div>
+<div class='clear'></div>
+<span class='widget-item-control'>
+<span class='item-control blog-admin'>
+<a class='quickedit' href='//www.blogger.com/rearrange?blogID=8274369273568143862&widgetType=HTML&widgetId=HTML5&action=editWidget&sectionId=sidebar-right-1' onclick='return _WidgetManager._PopupConfig(document.getElementById("HTML5"));' target='configHTML5' title='Edit'>
+<img alt='' height='18' src='//img1.blogblog.com/img/icon18_wrench_allbkg.png' width='18'/>
+</a>
+</span>
+</span>
+<div class='clear'></div>
+</div><div class='widget HTML' id='HTML18'>
+<div class='widget-content'>
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+</div>
+<div class='clear'></div>
+<span class='widget-item-control'>
+<span class='item-control blog-admin'>
+<a class='quickedit' href='//www.blogger.com/rearrange?blogID=8274369273568143862&widgetType=HTML&widgetId=HTML18&action=editWidget&sectionId=sidebar-right-1' onclick='return _WidgetManager._PopupConfig(document.getElementById("HTML18"));' target='configHTML18' title='Edit'>
+<img alt='' height='18' src='//img1.blogblog.com/img/icon18_wrench_allbkg.png' width='18'/>
+</a>
+</span>
+</span>
+<div class='clear'></div>
+</div><div class='widget HTML' id='HTML1'>
+<div class='widget-content'>
+<!-- STRIPPED SCRIPT TAG -->
+</div>
+<div class='clear'></div>
+<span class='widget-item-control'>
+<span class='item-control blog-admin'>
+<a class='quickedit' href='//www.blogger.com/rearrange?blogID=8274369273568143862&widgetType=HTML&widgetId=HTML1&action=editWidget&sectionId=sidebar-right-1' onclick='return _WidgetManager._PopupConfig(document.getElementById("HTML1"));' target='configHTML1' title='Edit'>
+<img alt='' height='18' src='//img1.blogblog.com/img/icon18_wrench_allbkg.png' width='18'/>
+</a>
+</span>
+</span>
+<div class='clear'></div>
+</div><div class='widget HTML' id='HTML4'>
+<div class='widget-content'>
+<!-- STRIPPED SCRIPT TAG -->
+</div>
+<div class='clear'></div>
+<span class='widget-item-control'>
+<span class='item-control blog-admin'>
+<a class='quickedit' href='//www.blogger.com/rearrange?blogID=8274369273568143862&widgetType=HTML&widgetId=HTML4&action=editWidget&sectionId=sidebar-right-1' onclick='return _WidgetManager._PopupConfig(document.getElementById("HTML4"));' target='configHTML4' title='Edit'>
+<img alt='' height='18' src='//img1.blogblog.com/img/icon18_wrench_allbkg.png' width='18'/>
+</a>
+</span>
+</span>
+<div class='clear'></div>
+</div><div class='widget HTML' id='HTML19'><!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<a href="http://www.linkwithin.com/"><img src="http://www.linkwithin.com/pixel.png" alt="Related Posts Plugin for WordPress, Blogger..." style="border: 0" /></a></div><div class='widget HTML' id='HTML6'>
+<div class='widget-content'>
+<img src="http://track.blogmeetsbrand.com/track.png" />
+            <!-- STRIPPED SCRIPT TAG -->
+</div>
+<div class='clear'></div>
+<span class='widget-item-control'>
+<span class='item-control blog-admin'>
+<a class='quickedit' href='//www.blogger.com/rearrange?blogID=8274369273568143862&widgetType=HTML&widgetId=HTML6&action=editWidget&sectionId=sidebar-right-1' onclick='return _WidgetManager._PopupConfig(document.getElementById("HTML6"));' target='configHTML6' title='Edit'>
+<img alt='' height='18' src='//img1.blogblog.com/img/icon18_wrench_allbkg.png' width='18'/>
+</a>
+</span>
+</span>
+<div class='clear'></div>
+</div>
+<div class='widget HTML' id='HTML20'>
+<div class='widget-content'>
+<img src='http://www.findyourinfluence.com/fyiblogviews.aspx?tcode=NTc2Nyw4'/>
+</div>
+<div class='clear'></div>
+<span class='widget-item-control'>
+<span class='item-control blog-admin'>
+<a class='quickedit' href='//www.blogger.com/rearrange?blogID=8274369273568143862&widgetType=HTML&widgetId=HTML20&action=editWidget&sectionId=sidebar-right-1' onclick='return _WidgetManager._PopupConfig(document.getElementById("HTML20"));' target='configHTML20' title='Edit'>
+<img alt='' height='18' src='//img1.blogblog.com/img/icon18_wrench_allbkg.png' width='18'/>
+</a>
+</span>
+</span>
+<div class='clear'></div>
+</div></div>
+</aside>
+</div>
+</div>
+</div>
+<div style='clear: both'></div>
+<!-- columns -->
+</div>
+<!-- main -->
+</div>
+</div>
+<div class='main-cap-bottom cap-bottom'>
+<div class='cap-left'></div>
+<div class='cap-right'></div>
+</div>
+</div>
+<footer>
+<div class='footer-outer'>
+<div class='footer-cap-top cap-top'>
+<div class='cap-left'></div>
+<div class='cap-right'></div>
+</div>
+<div class='fauxborder-left footer-fauxborder-left'>
+<div class='fauxborder-right footer-fauxborder-right'></div>
+<div class='region-inner footer-inner'>
+<div class='foot section' id='footer-1'><div class='widget HTML' id='HTML9'>
+<div class='widget-content'>
+<!-- STRIPPED SCRIPT TAG -->
+</div>
+<div class='clear'></div>
+<span class='widget-item-control'>
+<span class='item-control blog-admin'>
+<a class='quickedit' href='//www.blogger.com/rearrange?blogID=8274369273568143862&widgetType=HTML&widgetId=HTML9&action=editWidget&sectionId=footer-1' onclick='return _WidgetManager._PopupConfig(document.getElementById("HTML9"));' target='configHTML9' title='Edit'>
+<img alt='' height='18' src='//img1.blogblog.com/img/icon18_wrench_allbkg.png' width='18'/>
+</a>
+</span>
+</span>
+<div class='clear'></div>
+</div><div class='widget HTML' id='HTML3'><!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<a href="http://www.linkwithin.com/"><img src="http://www.linkwithin.com/pixel.png" alt="Related Posts Plugin for WordPress, Blogger..." style="border: 0" /></a></div><div class='widget HTML' id='HTML12'>
+<div class='widget-content'>
+<!-- Start of StatCounter Code for Blogger / Blogspot -->
+<!-- STRIPPED SCRIPT TAG -->
+<noscript><div class="statcounter"><a title="blogspot visit counter" href="http://statcounter.com/blogger/" class="statcounter"><img class="statcounter" src="http://c.statcounter.com/9339273/0/e868be01/1/" alt="blogspot visit counter" /></a></div></noscript>
+<!-- End of StatCounter Code for Blogger / Blogspot -->
+</div>
+<div class='clear'></div>
+<span class='widget-item-control'>
+<span class='item-control blog-admin'>
+<a class='quickedit' href='//www.blogger.com/rearrange?blogID=8274369273568143862&widgetType=HTML&widgetId=HTML12&action=editWidget&sectionId=footer-1' onclick='return _WidgetManager._PopupConfig(document.getElementById("HTML12"));' target='configHTML12' title='Edit'>
+<img alt='' height='18' src='//img1.blogblog.com/img/icon18_wrench_allbkg.png' width='18'/>
+</a>
+</span>
+</span>
+<div class='clear'></div>
+</div><div class='widget HTML' id='HTML15'>
+<div class='widget-content'>
+<!-- TBN.hungrycouplenyc BTF 728x90 -->
+<div id='12345678-4'>
+     <!-- STRIPPED SCRIPT TAG -->
+</div>
+<div style="width:728px;"><a style="color: #ed5b3f; float: left; font-size:12px;" target="_blank" href="http://www.thebloggernetwork.com/media-kit/"><img src="http://www.thebloggernetwork.com/tbn-ad.png" alt="The Blogger Network" />Advertise with us</a>
+<a style="color: #ed5b3f; float: right; font-size:12px;" href="mailto:ads@thebloggernetwork.com?subject=Report of an Inappropriate Advertisement&body=For best service, please attach a screenshot">Report this ad</a>
+</div>
+</div>
+<div class='clear'></div>
+<span class='widget-item-control'>
+<span class='item-control blog-admin'>
+<a class='quickedit' href='//www.blogger.com/rearrange?blogID=8274369273568143862&widgetType=HTML&widgetId=HTML15&action=editWidget&sectionId=footer-1' onclick='return _WidgetManager._PopupConfig(document.getElementById("HTML15"));' target='configHTML15' title='Edit'>
+<img alt='' height='18' src='//img1.blogblog.com/img/icon18_wrench_allbkg.png' width='18'/>
+</a>
+</span>
+</span>
+<div class='clear'></div>
+</div><div class='widget HTML' id='HTML2'>
+<div class='widget-content'>
+<a href="http://www.hungrycouplenyc.com/p/privacy-policy.html">Privacy Policy</a>
+</div>
+<div class='clear'></div>
+<span class='widget-item-control'>
+<span class='item-control blog-admin'>
+<a class='quickedit' href='//www.blogger.com/rearrange?blogID=8274369273568143862&widgetType=HTML&widgetId=HTML2&action=editWidget&sectionId=footer-1' onclick='return _WidgetManager._PopupConfig(document.getElementById("HTML2"));' target='configHTML2' title='Edit'>
+<img alt='' height='18' src='//img1.blogblog.com/img/icon18_wrench_allbkg.png' width='18'/>
+</a>
+</span>
+</span>
+<div class='clear'></div>
+</div></div>
+<!-- outside of the include in order to lock Attribution widget -->
+<div class='foot section' id='footer-3'><div class='widget Attribution' id='Attribution1'>
+<div class='widget-content' style='text-align: center;'>
+Simple template. Powered by <a href='https://www.blogger.com' target='_blank'>Blogger</a>.
+</div>
+<div class='clear'></div>
+<span class='widget-item-control'>
+<span class='item-control blog-admin'>
+<a class='quickedit' href='//www.blogger.com/rearrange?blogID=8274369273568143862&widgetType=Attribution&widgetId=Attribution1&action=editWidget&sectionId=footer-3' onclick='return _WidgetManager._PopupConfig(document.getElementById("Attribution1"));' target='configAttribution1' title='Edit'>
+<img alt='' height='18' src='//img1.blogblog.com/img/icon18_wrench_allbkg.png' width='18'/>
+</a>
+</span>
+</span>
+<div class='clear'></div>
+</div></div>
+</div>
+</div>
+<div class='footer-cap-bottom cap-bottom'>
+<div class='cap-left'></div>
+<div class='cap-right'></div>
+</div>
+</div>
+</footer>
+<!-- content -->
+</div>
+</div>
+<div class='content-cap-bottom cap-bottom'>
+<div class='cap-left'></div>
+<div class='cap-right'></div>
+</div>
+</div>
+</div>
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG --><!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+</body>
+</html>


### PR DESCRIPTION
# Change Summary
The Hungry Couple uses a Frankenstein combination of Microformat and Microdata, rendering us unable to parse the name of her recipes.

As a solution, I built a custom Hungrycouplenyccom scraper on top of the Microformat scraper that also grabs the recipe title in a "Microdata" style. 

If a case like this appears again, I may consider writing more generalized scrapers that merge data from multiple format scrapers.
# Release Notes
Note that I accidentally branched off of another feature branch, CORE-1132.
# Testing
Tested with a new unit test for Hungry Couple, as well as an integration test through the scraper using the URL http://www.hungrycouplenyc.com/2016/01/crispy-potato-and-hummus-balls.html