### PR TITLE
CORE-1161: always check the content attribute of meta tags for schema.org recipes

### DIFF
--- a/lib/RecipeParser/Parser/MicrodataSchema.php
+++ b/lib/RecipeParser/Parser/MicrodataSchema.php
@@ -18,15 +18,24 @@ class RecipeParser_Parser_MicrodataSchema {
             // Title
             $nodes = $xpath->query('.//*[@itemprop="name"]', $microdata);
             if ($nodes->length) {
-                $value = trim($nodes->item(0)->nodeValue);
+                if ($nodes->item(0)->hasAttribute('content')) {
+                    $line = $nodes->item(0)->getAttribute('content');
+                } else {
+                    $line = $nodes->item(0)->nodeValue;
+                }
+                $value = trim($line);
                 $recipe->title = RecipeParser_Text::formatTitle($value);
             }
 
             // Summary
             $nodes = $xpath->query('.//*[@itemprop="description"]', $microdata);
             if ($nodes->length) {
-                $value = $nodes->item(0)->nodeValue;
-                $value = RecipeParser_Text::formatAsParagraphs($value);
+                if ($nodes->item(0)->hasAttribute('content')) {
+                    $line = $nodes->item(0)->getAttribute('content');
+                } else {
+                    $line = $nodes->item(0)->nodeValue;
+                }
+                $value = RecipeParser_Text::formatAsParagraphs($line);
                 $recipe->description = $value;
             }
 
@@ -69,8 +78,12 @@ class RecipeParser_Parser_MicrodataSchema {
             // Ingredients 
             $nodes = $xpath->query('.//*[@itemprop="ingredients"]', $microdata);
             foreach ($nodes as $node) {
-                $value = $node->nodeValue;
-                $value = RecipeParser_Text::formatAsOneLine($value);
+                if ($nodes->item(0)->hasAttribute('content')) {
+                    $line = $node->getAttribute('content');
+                } else {
+                    $line = $node->nodeValue;
+                }
+                $value = RecipeParser_Text::formatAsOneLine($line);
                 if (empty($value)) {
                     continue;
                 }

--- a/tests/RecipeParser_Parser_MicrodataSchemaTest.php
+++ b/tests/RecipeParser_Parser_MicrodataSchemaTest.php
@@ -29,7 +29,7 @@ class RecipeParser_Parser_MicrodataSchemaTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('', $recipe->instructions[0]['name']);
         $this->assertEquals(3, count($recipe->instructions[0]['list']));
 
-        $this->assertEquals('http://schema.example.com/images/bananabread.jpg', 
+        $this->assertEquals('http://schema.example.com/images/bananabread.jpg',
                             $recipe->photo_url);
     }
 
@@ -163,7 +163,7 @@ class RecipeParser_Parser_MicrodataSchemaTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('', $recipe->instructions[0]['name']);
         $this->assertEquals(4, count($recipe->instructions[0]['list']));
 
-        $this->assertEquals('http://s3.amazonaws.com/gmi-digital-library/605b6c2e-b017-4aae-8db0-14f64b203642.jpg',
+        $this->assertEquals('http://images.edge-generalmills.com/c763803d-a37c-4e65-859f-74baa1f88356.jpg',
                             $recipe->photo_url);
     }
 
@@ -186,6 +186,19 @@ class RecipeParser_Parser_MicrodataSchemaTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals('http://d1kg9jbrq423rq.cloudfront.net/sites/default/files/3112.jpg',
                             $recipe->photo_url);
+    }
+    
+    public function test_the_worlds_best_paleo_breaded_shrimp() {
+        $path = "data/healthstartsinthekitchen_com_the_worlds_best_paleo_breaded_shrimp_curl.html";
+        $url = "http://www.healthstartsinthekitchen.com/recipe/the-worlds-best-paleo-breaded-shrimp-made-with-tigernut-flour/";
+
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
+        if (isset($_SERVER['VERBOSE'])) print_r($recipe);
+        
+        $this->assertEquals(1, count($recipe->ingredients));
+        $this->assertEquals(8, count($recipe->ingredients[0]['list']));
+        $this->assertEquals('Grain-Free Breaded Shrimp {Made with TigerNut Flour}', $recipe->title);
     }
 
 }

--- a/tests/data/bettycrocker_com_blueberry_banana_oat_bread_betty_crocker_curl.html
+++ b/tests/data/bettycrocker_com_blueberry_banana_oat_bread_betty_crocker_curl.html
@@ -1,7 +1,7 @@
 <!--
-ONETSP_URL: http://www.bettycrocker.com/recipes/coffee-toffee-cake-with-caramel-frosting/557b8338-f603-4cc4-95e0-ec44089964bd
+ONETSP_URL: http://www.bettycrocker.com/recipes/blueberry-banana-oat-bread/886c41eb-a229-4ab5-ac74-41b68c4ce0ac
 ONETSP_USER_AGENT: curl
-ONETSP_TIME: Mon, 01 Feb 2016 21:00:59 +0000
+ONETSP_TIME: Mon, 01 Feb 2016 21:00:58 +0000
 -->
 
 
@@ -13,14 +13,14 @@ ONETSP_TIME: Mon, 01 Feb 2016 21:00:59 +0000
 <!-- STRIPPED CONDITIONAL COMMENT -->
 <!-- STRIPPED CONDITIONAL COMMENT -->
 <head id="Head1"><title>
-	Coffee-Toffee Cake with Caramel Frosting recipe from Betty Crocker
+	Blueberry-Banana-Oat Bread recipe from Betty Crocker
 </title><meta http-equiv="Content-Type" content="text/html; charset=UTF-8" /><meta name="fragment" content="!" /><meta name="CODE_LANGUAGE" content="VB" /><meta name="vs_defaultClientScript" content="JavaScript" /><meta name="vs_targetSchema" content="http://schemas.microsoft.com/intellisense/ie5" /><meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, user-scalable=0" />
     <!-- STRIPPED SCRIPT TAG -->
     <!-- STRIPPED SCRIPT TAG -->
     <!-- STRIPPED SCRIPT TAG -->
     <!-- STRIPPED SCRIPT TAG -->
     <!-- STRIPPED SCRIPT TAG -->
-<link rel="canonical" href="http://www.bettycrocker.com/recipes/coffee-toffee-cake-with-caramel-frosting/557b8338-f603-4cc4-95e0-ec44089964bd" /><meta name="description" content="Quick and easy, this homey cake is rich in coffee, toffee and caramel flavors." /><link href="/Styles/Responsive/Master.min.css?v=20160119" type="text/css" rel="stylesheet" /><link href="/Services/HttpContentCombiner.ashx?s=CommonCSS&amp;t=text/css&amp;v=20160119" type="text/css" rel="stylesheet" /><link rel="search" href="/BettyOpenSearch.xml" type="application/opensearchdescription+xml" title="BettyCrocker.com" /><meta name="KEYWORDS" content="cooking recipes, family recipes, food recipes, recipes, baking recipes, cooking tips, baking tips" /><meta name="TITLE" content="Recipes" /><meta property="og:title" content="Coffee-Toffee Cake with Caramel Frosting" /><meta property="og:url" content="http://www.bettycrocker.com/recipes/coffee-toffee-cake-with-caramel-frosting/557b8338-f603-4cc4-95e0-ec44089964bd" /><meta property="og:image" content="http://images.edge-generalmills.com/c763803d-a37c-4e65-859f-74baa1f88356.jpg" /><meta property="og:description" content="Quick and easy, this homey cake is rich in coffee, toffee and caramel flavors." /><meta property="og:type" content="food" /><meta property="fb:app_id" content="124758810890523" /><meta property="twitter:card" content="summary" /><link href="/styles/nonCMS/RelatedContent.css" type="text/css" rel="stylesheet" /><meta property="og:site_name" content="bettycrocker.com" /><meta property="og:image" content="http://www.bettycrocker.com/Images/Icons/BCFacebookThumbnail.png" /><meta property="fb:app_id" content="124758810890523" /><link href='' type='text/css' rel='stylesheet' />
+<link rel="canonical" href="http://www.bettycrocker.com/recipes/blueberry-banana-oat-bread/886c41eb-a229-4ab5-ac74-41b68c4ce0ac" /><meta name="description" content="Betty Crocker&#39;s Diabetes Cookbook shares a recipe!  Looking for a low-fat treat? Here&#39;s a keeper." /><link href="/Styles/Responsive/Master.min.css?v=20160119" type="text/css" rel="stylesheet" /><link href="/Services/HttpContentCombiner.ashx?s=CommonCSS&amp;t=text/css&amp;v=20160119" type="text/css" rel="stylesheet" /><link rel="search" href="/BettyOpenSearch.xml" type="application/opensearchdescription+xml" title="BettyCrocker.com" /><meta name="KEYWORDS" content="cooking recipes, family recipes, food recipes, recipes, baking recipes, cooking tips, baking tips" /><meta name="TITLE" content="Recipes" /><meta property="og:title" content="Blueberry-Banana-Oat Bread" /><meta property="og:url" content="http://www.bettycrocker.com/recipes/blueberry-banana-oat-bread/886c41eb-a229-4ab5-ac74-41b68c4ce0ac" /><meta property="og:image" content="http://images.edge-generalmills.com/6000b7ea-dde7-4e02-84b6-cc53a4a824e7.jpg" /><meta property="og:description" content="Betty Crocker&#39;s Diabetes Cookbook shares a recipe!  Looking for a low-fat treat? Here&#39;s a keeper." /><meta property="og:type" content="food" /><meta property="fb:app_id" content="124758810890523" /><meta property="twitter:card" content="summary" /><link href="/styles/nonCMS/RelatedContent.css" type="text/css" rel="stylesheet" /><meta property="og:site_name" content="bettycrocker.com" /><meta property="og:image" content="http://www.bettycrocker.com/Images/Icons/BCFacebookThumbnail.png" /><meta property="fb:app_id" content="124758810890523" /><link href='' type='text/css' rel='stylesheet' />
             <!-- STRIPPED SCRIPT TAG -->
         
           <!-- STRIPPED SCRIPT TAG -->
@@ -29,10 +29,10 @@ ONETSP_TIME: Mon, 01 Feb 2016 21:00:59 +0000
 <body id="body" class="responsive">
     
 
-    <form name="mainform" method="post" action="/recipes/coffee-toffee-cake-with-caramel-frosting/557b8338-f603-4cc4-95e0-ec44089964bd" id="mainform">
+    <form name="mainform" method="post" action="/recipes/blueberry-banana-oat-bread/886c41eb-a229-4ab5-ac74-41b68c4ce0ac" id="mainform">
 <div>
-<input type="hidden" name="ParentPageUrl" id="ParentPageUrl" value="http://www.bettycrocker.com:10806/recipes/coffee-toffee-cake-with-caramel-frosting/557b8338-f603-4cc4-95e0-ec44089964bd" />
-<input type="hidden" name="__VIEWSTATE" id="__VIEWSTATE" value="/wEPDwUKLTE0NTgzNzE4MQ8WAh4TVmFsaWRhdGVSZXF1ZXN0TW9kZQIBFgICAw9kFgICAxBkZBYWAgEPFgIeBFRleHQFRjxzY3JpcHQgdHlwZT0ndGV4dC9qYXZhc2NyaXB0Jz52YXIgcHVibGlzaERhdGVQYXJhbWV0ZXIgPSAnJzs8L3NjcmlwdD5kAg0PZBYCZg8WAh4KTWV0aG9kTmFtZQUVQXBwbHlNYXJpbmFTY3JpcHRCYXNlZAITDxYCHwEFBSANCg0KZAIVDxYCHwEFnQM8c2NyaXB0Pg0KZG9jdW1lbnQud3JpdGUodW5lc2NhcGUoIiUzQ3NjcmlwdCBzcmM9JyIgKyAoZG9jdW1lbnQubG9jYXRpb24ucHJvdG9jb2wgPT0gImh0dHBzOiIgPyAiaHR0cHM6Ly9zYiIgOiAiaHR0cDovL2IiKSArICIuc2NvcmVjYXJkcmVzZWFyY2guY29tL2JlYWNvbi5qcycgJTNFJTNDL3NjcmlwdCUzRSIpKTsNCjwvc2NyaXB0Pg0KPHNjcmlwdD4NCkNPTVNDT1JFLmJlYWNvbih7DQpjMToyLA0KYzI6NjAzNTI0MSwNCmMzOiIiLA0KYzQ6IiIsDQpjNToiIiwNCmM2OiIiLA0KYzE1OiIiDQp9KTsNCjwvc2NyaXB0Pg0KPG5vc2NyaXB0Pg0KPGltZyBzcmM9Imh0dHA6Ly9iLnNjb3JlY2FyZHJlc2VhcmNoLmNvbS9wP2MxPTImYzI9NjAzNTI0MSZjMz0mYzQ9JmM1PSZjNj0mYzE1PSZjaj0xIiAvPg0KPC9ub3NjcmlwdD4NCmQCFw8WAh8CBQ5SdW5XZWJBY3Rpdml0eWQCGw9kFgQCAQ9kFgYCAw9kFgQCAg8PFgIeD1ZhbGlkYXRpb25Hcm91cAUKTW9kYWxMb2dpbmRkAgMPDxYCHwMFCk1vZGFsTG9naW5kZAIFD2QWAgICDw8WAh8DBQpNb2RhbExvZ2luZGQCFQ8PFgIeC05hdmlnYXRlVXJsBZQBL1JlZ2lzdGVyL0ZvcmdvdFBhc3N3b3JkP1JldHVyblVybD1odHRwOi8vd3d3LmJldHR5Y3JvY2tlci5jb20vcmVjaXBlcy9jb2ZmZWUtdG9mZmVlLWNha2Utd2l0aC1jYXJhbWVsLWZyb3N0aW5nLzU1N2I4MzM4LWY2MDMtNGNjNC05NWUwLWVjNDQwODk5NjRiZGRkAgIPZBYCAgMPFgIeBVZhbHVlBXFodHRwOi8vd3d3LmJldHR5Y3JvY2tlci5jb20vcmVjaXBlcy9jb2ZmZWUtdG9mZmVlLWNha2Utd2l0aC1jYXJhbWVsLWZyb3N0aW5nLzU1N2I4MzM4LWY2MDMtNGNjNC05NWUwLWVjNDQwODk5NjRiZGQCHQ9kFgJmDw8WAh4HVmlzaWJsZWhkZAIfD2QWAmYPZBYEAgEPZBYCZg8PFgIfBmhkZAIJD2QWAmYPZBYCZg8PFgIfBmhkZAIhD2QWAmYPZBYCZg9kFgJmDxYCHgVjbGFzcwUhY2hhbm5lbExpbmtzIHByb2R1Y3QtY2hhbm5lbExpbmtzZAIjD2QWAmYPZBYCZg9kFgoCAg9kFgJmD2QWAmYPZBYCAgIPDxYCHwZoZGQCBQ9kFgICAQ9kFgJmDw8WAh8GaGRkAggPZBYEAggPZBYCZg9kFgpmDxYCHwcFE251dHJpdGlvbi1wYXJhZ3JhcGgWBAICDxUBDSUgRGFpbHkgVmFsdWVkAhEPFgIfBmhkAgEPFgIfBmhkAgIPFgIeB2NvbnRlbnQFBlBUMkgwTWQCAw8WAh8IBQdQVDBIMTVNZAIEDxUBAjE1ZAIJD2QWAmYPDxYCHwZoZGQCCQ9kFgICAQ9kFgJmD2QWAmYPFgIeC18hSXRlbUNvdW50AgYWDGYPZBYCZg8VCAZyZWNpcGUkZWQxMTlmZjItYjA1Yi00NmFkLThmZjQtYTA3NmViYWJkN2Q0WC9yZWNpcGVzL2Nob2NvbGF0ZS1zdG91dC1jYWtlLXdpdGgtY2FyYW1lbC1mcm9zdGluZy9lZDExOWZmMi1iMDViLTQ2YWQtOGZmNC1hMDc2ZWJhYmQ3ZDRMaHR0cDovL2ltYWdlcy5lZGdlLWdlbmVyYWxtaWxscy5jb20vMTNlMTUyMjMtOTljZi00NjlhLThhODYtNzAzNmU3M2U4YmM5LmpwZwBYL3JlY2lwZXMvY2hvY29sYXRlLXN0b3V0LWNha2Utd2l0aC1jYXJhbWVsLWZyb3N0aW5nL2VkMTE5ZmYyLWIwNWItNDZhZC04ZmY0LWEwNzZlYmFiZDdkNCpDaG9jb2xhdGUgU3RvdXQgQ2FrZSB3aXRoIENhcmFtZWwgRnJvc3RpbmcAZAIBD2QWAmYPFQgGcmVjaXBlJDUxM2Q4NGYzLTRhMDUtNDZkNi1hMzlkLTFhYzhlMDg5MmNjNlQvcmVjaXBlcy9naW5nZXItY2FrZS13aXRoLWNhcmFtZWwtYXBwbGUtdG9wcGluZy81MTNkODRmMy00YTA1LTQ2ZDYtYTM5ZC0xYWM4ZTA4OTJjYzZMaHR0cDovL2ltYWdlcy5lZGdlLWdlbmVyYWxtaWxscy5jb20vNzQzYzUyYjEtYmU3ZC00ZmU2LThkYmItOTcxNzU5NjE2MDlmLmpwZwBUL3JlY2lwZXMvZ2luZ2VyLWNha2Utd2l0aC1jYXJhbWVsLWFwcGxlLXRvcHBpbmcvNTEzZDg0ZjMtNGEwNS00NmQ2LWEzOWQtMWFjOGUwODkyY2M2JkdpbmdlciBDYWtlIHdpdGggQ2FyYW1lbC1BcHBsZSBUb3BwaW5nAGQCAg9kFgJmDxUIBnJlY2lwZSQ4NDAxYTg3ZS1iMWExLTRjODAtYjkxYi02ZDg2NWMwNGNhZDJaL3JlY2lwZXMvYnJvd25lZC1idXR0ZXItY29va2llcy13aXRoLWNhcmFtZWwtZnJvc3RpbmcvODQwMWE4N2UtYjFhMS00YzgwLWI5MWItNmQ4NjVjMDRjYWQyTGh0dHA6Ly9pbWFnZXMuZWRnZS1nZW5lcmFsbWlsbHMuY29tLzNkMDBkYjZiLWU0ODQtNDZkZi1hMGRmLTgwNmU3YmZiMmUxOS5qcGcAWi9yZWNpcGVzL2Jyb3duZWQtYnV0dGVyLWNvb2tpZXMtd2l0aC1jYXJhbWVsLWZyb3N0aW5nLzg0MDFhODdlLWIxYTEtNGM4MC1iOTFiLTZkODY1YzA0Y2FkMixCcm93bmVkIEJ1dHRlciBDb29raWVzIHdpdGggQ2FyYW1lbCBGcm9zdGluZwBkAgMPZBYCZg8VCAZyZWNpcGUkNjdkZmM3M2UtZWNjNS00Mjc3LWIzMzAtMzNkN2I1NWVmMWU5Wy9yZWNpcGVzL3RvYXN0ZWQtYWxtb25kLWN1cGNha2VzLXdpdGgtY2FyYW1lbC1mcm9zdGluZy82N2RmYzczZS1lY2M1LTQyNzctYjMzMC0zM2Q3YjU1ZWYxZTlMaHR0cDovL2ltYWdlcy5lZGdlLWdlbmVyYWxtaWxscy5jb20vM2UyYjNlMmYtNTQyMy00NjQ0LThmMGYtYzliZDEyZjdlMjYzLmpwZwBbL3JlY2lwZXMvdG9hc3RlZC1hbG1vbmQtY3VwY2FrZXMtd2l0aC1jYXJhbWVsLWZyb3N0aW5nLzY3ZGZjNzNlLWVjYzUtNDI3Ny1iMzMwLTMzZDdiNTVlZjFlOS1Ub2FzdGVkIEFsbW9uZCBDdXBjYWtlcyB3aXRoIENhcmFtZWwgRnJvc3RpbmcAZAIED2QWAmYPFQgGcmVjaXBlJGNmNjhiZWM4LWQxNWQtNGQ5Yi1iOGFkLTRlNThlOTg4ZWZiZVIvcmVjaXBlcy9hcHBsZS13YWxudXQtY2FrZS13aXRoLWNhcmFtZWwtZ2xhemUvY2Y2OGJlYzgtZDE1ZC00ZDliLWI4YWQtNGU1OGU5ODhlZmJlTGh0dHA6Ly9pbWFnZXMuZWRnZS1nZW5lcmFsbWlsbHMuY29tLzk2ZDk2NDZhLTg4OGUtNGMzYy1iOGE4LWY0NWM1ZTk5N2E1Yy5qcGcAUi9yZWNpcGVzL2FwcGxlLXdhbG51dC1jYWtlLXdpdGgtY2FyYW1lbC1nbGF6ZS9jZjY4YmVjOC1kMTVkLTRkOWItYjhhZC00ZTU4ZTk4OGVmYmUkQXBwbGUtV2FsbnV0IENha2Ugd2l0aCBDYXJhbWVsIEdsYXplAGQCBQ9kFgJmDxUIBnJlY2lwZSRiYjk1Yzg5My01YWIyLTRjYWQtOWQzMC0yZWRmNzM2NjZhODFgL3JlY2lwZXMvaG9uZXktZ2luZ2VyYnJlYWQtY2FrZXMtd2l0aC1jYXJhbWVsLWFwcGxlLXRvcHBpbmcvYmI5NWM4OTMtNWFiMi00Y2FkLTlkMzAtMmVkZjczNjY2YTgxTGh0dHA6Ly9pbWFnZXMuZWRnZS1nZW5lcmFsbWlsbHMuY29tLzUyZmNmMTc0LTA0NGMtNDQzZi1hYmQ2LWEzY2YxNGQzZWQwZS5qcGcAYC9yZWNpcGVzL2hvbmV5LWdpbmdlcmJyZWFkLWNha2VzLXdpdGgtY2FyYW1lbC1hcHBsZS10b3BwaW5nL2JiOTVjODkzLTVhYjItNGNhZC05ZDMwLTJlZGY3MzY2NmE4MTJIb25leSBHaW5nZXJicmVhZCBDYWtlcyB3aXRoIENhcmFtZWwgQXBwbGUgVG9wcGluZwBkAgwPZBYCZg9kFgJmD2QWAmYPFgQfAWUfBmhkAicPDxYCHwZnZGQYAgUeX19Db250cm9sc1JlcXVpcmVQb3N0QmFja0tleV9fFgEFEExvZ2luJFJlbWVtYmVyTWUFH2N0bDA4JFVzZXJTdGF0ZVdpZGdldCRNdWx0aVZpZXcPD2QCAWSCLJ/eDV/IS4SP+ADo2QpTOhgTbA==" />
+<input type="hidden" name="ParentPageUrl" id="ParentPageUrl" value="http://www.bettycrocker.com:10806/recipes/blueberry-banana-oat-bread/886c41eb-a229-4ab5-ac74-41b68c4ce0ac" />
+<input type="hidden" name="__VIEWSTATE" id="__VIEWSTATE" value="/wEPDwUKLTE0NTgzNzE4MQ8WAh4TVmFsaWRhdGVSZXF1ZXN0TW9kZQIBFgICAw9kFgICAxBkZBYWAgEPFgIeBFRleHQFRjxzY3JpcHQgdHlwZT0ndGV4dC9qYXZhc2NyaXB0Jz52YXIgcHVibGlzaERhdGVQYXJhbWV0ZXIgPSAnJzs8L3NjcmlwdD5kAg0PZBYCZg8WAh4KTWV0aG9kTmFtZQUVQXBwbHlNYXJpbmFTY3JpcHRCYXNlZAITDxYCHwEFBSANCg0KZAIVDxYCHwEFnQM8c2NyaXB0Pg0KZG9jdW1lbnQud3JpdGUodW5lc2NhcGUoIiUzQ3NjcmlwdCBzcmM9JyIgKyAoZG9jdW1lbnQubG9jYXRpb24ucHJvdG9jb2wgPT0gImh0dHBzOiIgPyAiaHR0cHM6Ly9zYiIgOiAiaHR0cDovL2IiKSArICIuc2NvcmVjYXJkcmVzZWFyY2guY29tL2JlYWNvbi5qcycgJTNFJTNDL3NjcmlwdCUzRSIpKTsNCjwvc2NyaXB0Pg0KPHNjcmlwdD4NCkNPTVNDT1JFLmJlYWNvbih7DQpjMToyLA0KYzI6NjAzNTI0MSwNCmMzOiIiLA0KYzQ6IiIsDQpjNToiIiwNCmM2OiIiLA0KYzE1OiIiDQp9KTsNCjwvc2NyaXB0Pg0KPG5vc2NyaXB0Pg0KPGltZyBzcmM9Imh0dHA6Ly9iLnNjb3JlY2FyZHJlc2VhcmNoLmNvbS9wP2MxPTImYzI9NjAzNTI0MSZjMz0mYzQ9JmM1PSZjNj0mYzE1PSZjaj0xIiAvPg0KPC9ub3NjcmlwdD4NCmQCFw8WAh8CBQ5SdW5XZWJBY3Rpdml0eWQCGw9kFgQCAQ9kFgYCAw9kFgQCAg8PFgIeD1ZhbGlkYXRpb25Hcm91cAUKTW9kYWxMb2dpbmRkAgMPDxYCHwMFCk1vZGFsTG9naW5kZAIFD2QWAgICDw8WAh8DBQpNb2RhbExvZ2luZGQCFQ8PFgIeC05hdmlnYXRlVXJsBYYBL1JlZ2lzdGVyL0ZvcmdvdFBhc3N3b3JkP1JldHVyblVybD1odHRwOi8vd3d3LmJldHR5Y3JvY2tlci5jb20vcmVjaXBlcy9ibHVlYmVycnktYmFuYW5hLW9hdC1icmVhZC84ODZjNDFlYi1hMjI5LTRhYjUtYWM3NC00MWI2OGM0Y2UwYWNkZAICD2QWAgIDDxYCHgVWYWx1ZQVjaHR0cDovL3d3dy5iZXR0eWNyb2NrZXIuY29tL3JlY2lwZXMvYmx1ZWJlcnJ5LWJhbmFuYS1vYXQtYnJlYWQvODg2YzQxZWItYTIyOS00YWI1LWFjNzQtNDFiNjhjNGNlMGFjZAIdD2QWAmYPDxYCHgdWaXNpYmxlaGRkAh8PZBYCZg9kFgQCAQ9kFgJmDw8WAh8GaGRkAgkPZBYCZg9kFgJmDw8WAh8GaGRkAiEPZBYCZg9kFgJmD2QWAmYPFgIeBWNsYXNzBSFjaGFubmVsTGlua3MgcHJvZHVjdC1jaGFubmVsTGlua3NkAiMPZBYCZg9kFgJmD2QWCgICD2QWAmYPZBYCZg9kFgICAg8PFgIfBmhkZAIFD2QWAgIBD2QWAmYPDxYCHwZoZGQCCA9kFgQCCA9kFgJmD2QWCmYPFgIfBwUTbnV0cml0aW9uLXBhcmFncmFwaBYEAgIPFQENJSBEYWlseSBWYWx1ZWQCEQ8WAh8GaGQCAQ8WAh8GaGQCAg8WAh4HY29udGVudAUHUFQzSDI1TWQCAw8WAh8IBQdQVDBIMTVNZAIEDxUBAjE2ZAIJD2QWAmYPDxYCHwZoZGQCCQ9kFgICAQ9kFgJmD2QWAmYPFgIeC18hSXRlbUNvdW50AgYWDGYPZBYCZg8VCAZyZWNpcGUkYTE5NmFkYTQtMGVjNS00OWMwLThjOTUtNmEzMzQwZmQwMGY0UC9yZWNpcGVzL2Fwcmljb3QtYW5kLXdoaXRlLWNob2NvbGF0ZS1zY29uZXMvYTE5NmFkYTQtMGVjNS00OWMwLThjOTUtNmEzMzQwZmQwMGY0TGh0dHA6Ly9pbWFnZXMuZWRnZS1nZW5lcmFsbWlsbHMuY29tL2IzZTZmZTQ3LWZlZmMtNGU2NS04NGE3LWMwOTU2MTkzNjQ2NC5qcGcAUC9yZWNpcGVzL2Fwcmljb3QtYW5kLXdoaXRlLWNob2NvbGF0ZS1zY29uZXMvYTE5NmFkYTQtMGVjNS00OWMwLThjOTUtNmEzMzQwZmQwMGY0IkFwcmljb3QgYW5kIFdoaXRlIENob2NvbGF0ZSBTY29uZXMAZAIBD2QWAmYPFQgGcmVjaXBlJGEzZjc3ZTIyLThhZDItNGNkYy1hODFhLTU0ODNmZWIyYWY3M04vcmVjaXBlcy9hcHBsZS1kdW1wbGluZy1mcmVuY2gtdG9hc3QtYmFrZS9hM2Y3N2UyMi04YWQyLTRjZGMtYTgxYS01NDgzZmViMmFmNzNMaHR0cDovL2ltYWdlcy5lZGdlLWdlbmVyYWxtaWxscy5jb20vYzVkN2U0NDItNmFkZC00YTc1LTkyZjUtZDliMTIxNDc1YzcwLmpwZwBOL3JlY2lwZXMvYXBwbGUtZHVtcGxpbmctZnJlbmNoLXRvYXN0LWJha2UvYTNmNzdlMjItOGFkMi00Y2RjLWE4MWEtNTQ4M2ZlYjJhZjczIEFwcGxlIER1bXBsaW5nIEZyZW5jaCBUb2FzdCBCYWtlAGQCAg9kFgJmDxUIBnJlY2lwZSRjNDMyZmE0Yy04ZWE2LTQ4YzItYjMyZS1iNDMxMGE3MWMwZjVJL3JlY2lwZXMvZ2xhemVkLWxlbW9uLWJsdWViZXJyeS1sb2FmL2M0MzJmYTRjLThlYTYtNDhjMi1iMzJlLWI0MzEwYTcxYzBmNUxodHRwOi8vaW1hZ2VzLmVkZ2UtZ2VuZXJhbG1pbGxzLmNvbS8yYTU2YjA0ZS0xZmNjLTQ1NmYtOTFlMi0zYzMyZDVjNjdmNjUuanBnAEkvcmVjaXBlcy9nbGF6ZWQtbGVtb24tYmx1ZWJlcnJ5LWxvYWYvYzQzMmZhNGMtOGVhNi00OGMyLWIzMmUtYjQzMTBhNzFjMGY1G0dsYXplZCBMZW1vbi1CbHVlYmVycnkgTG9hZgBkAgMPZBYCZg8VCAZyZWNpcGUkODk5MGUxNWMtZmMxZC00YThkLWI4YjMtNGIzN2Y0NWVjYTQ5Ny9yZWNpcGVzL2Nvcm5icmVhZC84OTkwZTE1Yy1mYzFkLTRhOGQtYjhiMy00YjM3ZjQ1ZWNhNDlMaHR0cDovL2ltYWdlcy5lZGdlLWdlbmVyYWxtaWxscy5jb20vOWU3Mjg0YjctNjZhYi00OGU0LWIzNWYtMTNhMzQ3Njg3YjU1LmpwZwA3L3JlY2lwZXMvY29ybmJyZWFkLzg5OTBlMTVjLWZjMWQtNGE4ZC1iOGIzLTRiMzdmNDVlY2E0OQlDb3JuYnJlYWQAZAIED2QWAmYPFQgGcmVjaXBlJDAyYTg3ZWQzLWQ5YWUtNDQ4OC04OTg1LTE1YWIwOTRlMWI5NzovcmVjaXBlcy90dXJ0bGUtYnJlYWQvMDJhODdlZDMtZDlhZS00NDg4LTg5ODUtMTVhYjA5NGUxYjk3TGh0dHA6Ly9pbWFnZXMuZWRnZS1nZW5lcmFsbWlsbHMuY29tLzAxMTVhYWNiLTFiYjAtNDBlMS1iYmI5LTg3NTM2MDMyYTY2OC5qcGcAOi9yZWNpcGVzL3R1cnRsZS1icmVhZC8wMmE4N2VkMy1kOWFlLTQ0ODgtODk4NS0xNWFiMDk0ZTFiOTcMVHVydGxlIEJyZWFkAGQCBQ9kFgJmDxUIBnJlY2lwZSQ3OTBmMzMzOC01OWM2LTQzMTItYTNjMS0zZTRkMGNmNmIxMDFJL3JlY2lwZXMvb2xkLWZhc2hpb25lZC1icmVhZC1wdWRkaW5nLzc5MGYzMzM4LTU5YzYtNDMxMi1hM2MxLTNlNGQwY2Y2YjEwMUxodHRwOi8vaW1hZ2VzLmVkZ2UtZ2VuZXJhbG1pbGxzLmNvbS9kMDVjMmNhYi0wZWRkLTQzMjctYWExYy1iOTZhMzNhMTRiNjkuanBnAEkvcmVjaXBlcy9vbGQtZmFzaGlvbmVkLWJyZWFkLXB1ZGRpbmcvNzkwZjMzMzgtNTljNi00MzEyLWEzYzEtM2U0ZDBjZjZiMTAxG09sZC1GYXNoaW9uZWQgQnJlYWQgUHVkZGluZwBkAgwPZBYCZg9kFgJmD2QWAmYPFgQfAWUfBmhkAicPDxYCHwZnZGQYAgUeX19Db250cm9sc1JlcXVpcmVQb3N0QmFja0tleV9fFgEFEExvZ2luJFJlbWVtYmVyTWUFH2N0bDA4JFVzZXJTdGF0ZVdpZGdldCRNdWx0aVZpZXcPD2QCAWTXexz+9ng9UIOKqw3uNJxr+0gxSQ==" />
 </div>
 
 
@@ -139,8 +139,8 @@ ONETSP_TIME: Mon, 01 Feb 2016 21:00:59 +0000
                     <div class="modal_login_form_line">
                         <input id="Login_RememberMe" type="checkbox" name="Login$RememberMe" checked="checked" /><label for="Login_RememberMe">Remember me next time.</label>
                     </div>
-                    <input name="Login$hdnDestinationURL" type="hidden" id="Login_hdnDestinationURL" value="http://www.bettycrocker.com/recipes/coffee-toffee-cake-with-caramel-frosting/557b8338-f603-4cc4-95e0-ec44089964bd" />
-                    <input name="Login$CurrentUrlHidden" type="hidden" id="Login_CurrentUrlHidden" value="http://www.bettycrocker.com/recipes/coffee-toffee-cake-with-caramel-frosting/557b8338-f603-4cc4-95e0-ec44089964bd" />
+                    <input name="Login$hdnDestinationURL" type="hidden" id="Login_hdnDestinationURL" value="http://www.bettycrocker.com/recipes/blueberry-banana-oat-bread/886c41eb-a229-4ab5-ac74-41b68c4ce0ac" />
+                    <input name="Login$CurrentUrlHidden" type="hidden" id="Login_CurrentUrlHidden" value="http://www.bettycrocker.com/recipes/blueberry-banana-oat-bread/886c41eb-a229-4ab5-ac74-41b68c4ce0ac" />
                     <input name="Login$LoginActionHidden" type="hidden" id="Login_LoginActionHidden" />
                 </div>
             </div>
@@ -177,7 +177,7 @@ ONETSP_TIME: Mon, 01 Feb 2016 21:00:59 +0000
                 <div class="left_container01">
                     <input type="image" src="/~/media/Images/Shared/Registration/Login.png" id="ModalLogin"
                         class="PngFix" />
-                    <a id="Login_PasswordRecoveryLink" href="/Register/ForgotPassword?ReturnUrl=http://www.bettycrocker.com/recipes/coffee-toffee-cake-with-caramel-frosting/557b8338-f603-4cc4-95e0-ec44089964bd" style="float: right; line-height: 2.5em;">Forgot Password?</a>
+                    <a id="Login_PasswordRecoveryLink" href="/Register/ForgotPassword?ReturnUrl=http://www.bettycrocker.com/recipes/blueberry-banana-oat-bread/886c41eb-a229-4ab5-ac74-41b68c4ce0ac" style="float: right; line-height: 2.5em;">Forgot Password?</a>
                 </div>
                 <div class="right_container01">
                     <img src="/~/media/images/shared/registration/modaloffer.png" />
@@ -219,7 +219,7 @@ ONETSP_TIME: Mon, 01 Feb 2016 21:00:59 +0000
       <div class="bcHeaderContainer"> 
             
 	<div class="newsletterCtaWrapper anonymousNewsletterCtaWrapper">
-		<iframe src="https://www.bettycrocker.com/Profile/HeaderNewsLetterCTA?parentUrl=%2frecipes%2fcoffee-toffee-cake-with-caramel-frosting%2f557b8338-f603-4cc4-95e0-ec44089964bd&amp;disablePageView=1" class="newsletterCtaContainer" scrolling="no" frameborder="0" marginheight="0" marginwidth="0"></iframe>
+		<iframe src="https://www.bettycrocker.com/Profile/HeaderNewsLetterCTA?parentUrl=%2frecipes%2fblueberry-banana-oat-bread%2f886c41eb-a229-4ab5-ac74-41b68c4ce0ac&amp;disablePageView=1" class="newsletterCtaContainer" scrolling="no" frameborder="0" marginheight="0" marginwidth="0"></iframe>
 	</div>
 
             <div class="bcHeadWrapper">                 
@@ -234,7 +234,7 @@ ONETSP_TIME: Mon, 01 Feb 2016 21:00:59 +0000
 
         
         <ul class="links">
-            <li class="joinFree"><a class="register" href="/registration/fullpage?IsRegistrationFirstStep=true&esrc=16690&RegAction=HeaderJoinFree&returnUrl=%2frecipes%2fcoffee-toffee-cake-with-caramel-frosting%2f557b8338-f603-4cc4-95e0-ec44089964bd">Join Free</a></li>
+            <li class="joinFree"><a class="register" href="/registration/fullpage?IsRegistrationFirstStep=true&esrc=16690&RegAction=HeaderJoinFree&returnUrl=%2frecipes%2fblueberry-banana-oat-bread%2f886c41eb-a229-4ab5-ac74-41b68c4ce0ac">Join Free</a></li>
             
             <li><a class="login uwLogInLink" href="javascript:void(0);">Log in</a></li>
             <li class="searchToggle"><a href="javascript:void(0);"></a></li>
@@ -248,7 +248,7 @@ ONETSP_TIME: Mon, 01 Feb 2016 21:00:59 +0000
                     <div class="searchBoxWrapper">
                         
 
-<div class="search-box-container search clearfix" id="285904d0-62af-4061-891d-7797d4a18e21">
+<div class="search-box-container search clearfix" id="a4d12991-bf21-44bd-adb3-ad760c105459">
     <div class="search-box-hints">
         <input class="search-box" data-bind="value : searchBoxText, valueUpdate: 'keydown', hasfocus : searchBoxHasFocus, event: { focus: getDataSourceType }, attr: {enable : searchBoxEnable}" />
         <div class="search-hint-container" data-bind="visible:showHints, html:searchHintsHtml"></div>
@@ -982,7 +982,7 @@ ONETSP_TIME: Mon, 01 Feb 2016 21:00:59 +0000
   "esrc": 15841,
   "isRegistrationFirstStep": false,
   "RegAction": "AddToFavorites",
-  "returnUrl": "/recipes/coffee-toffee-cake-with-caramel-frosting/557b8338-f603-4cc4-95e0-ec44089964bd?AutoOpen=AddToFavorites"
+  "returnUrl": "/recipes/blueberry-banana-oat-bread/886c41eb-a229-4ab5-ac74-41b68c4ce0ac?AutoOpen=AddToFavorites"
 });'>
                     <p>Save</p>
                 </a>
@@ -997,7 +997,7 @@ ONETSP_TIME: Mon, 01 Feb 2016 21:00:59 +0000
                 <a class='ab_print popup' onclick='return false;'>
                     <p>Print</p>
                 </a>
-                <a class='ab_print link' href="/recipes/coffee-toffee-cake-with-caramel-frosting/557b8338-f603-4cc4-95e0-ec44089964bd?p=1">
+                <a class='ab_print link' href="/recipes/blueberry-banana-oat-bread/886c41eb-a229-4ab5-ac74-41b68c4ce0ac?p=1">
                     <p>Print</p>
                 </a>
                 
@@ -1009,7 +1009,7 @@ ONETSP_TIME: Mon, 01 Feb 2016 21:00:59 +0000
   "esrc": 15840,
   "isRegistrationFirstStep": false,
   "RegAction": "AddToGroceryList",
-  "returnUrl": "/recipes/coffee-toffee-cake-with-caramel-frosting/557b8338-f603-4cc4-95e0-ec44089964bd?AutoOpen=AddToGroceryList"
+  "returnUrl": "/recipes/blueberry-banana-oat-bread/886c41eb-a229-4ab5-ac74-41b68c4ce0ac?AutoOpen=AddToGroceryList"
 });'>
                     <p>Add</p>
                 </a>
@@ -1053,7 +1053,7 @@ ONETSP_TIME: Mon, 01 Feb 2016 21:00:59 +0000
             <div class="d33 t100 m100">
                 
   <div class="recipePartTitle">
-      <h1 itemprop="name" class="recipePartTitleText">Coffee-Toffee Cake with Caramel Frosting</h1>
+      <h1 itemprop="name" class="recipePartTitleText">Blueberry-Banana-Oat Bread</h1>
       </div>
   
 <div class="recipePartBadgeList">
@@ -1063,14 +1063,14 @@ ONETSP_TIME: Mon, 01 Feb 2016 21:00:59 +0000
 <div class="RatingReviewView">
     <div class="RatingReviewHotspot">
         <div class="RatingHotspot">
-            <span class="stars star-90"></span>
-            <span class="ratingsValue">&nbsp15 Ratings</span>
+            <span class="stars star-70"></span>
+            <span class="ratingsValue">&nbsp105 Ratings</span>
         </div>
-            <a class="reviewLink" href="#">8 Comments</a>
+            <a class="reviewLink" href="#">24 Comments</a>
         
         <div itemprop="aggregateRating" itemscope itemtype="http://schema.org/AggregateRating">
-            <meta itemprop="ratingValue" content="4.5" />
-            <meta itemprop="reviewCount" content="8" />
+            <meta itemprop="ratingValue" content="3.5" />
+            <meta itemprop="reviewCount" content="24" />
             <meta itemprop="bestRating" content="5"/>
             <meta itemprop="worstRating" content="1"/>
         </div> 
@@ -1084,16 +1084,16 @@ ONETSP_TIME: Mon, 01 Feb 2016 21:00:59 +0000
                 
                   
     
-            <div data-picture="" data-alt="Coffee-Toffee Cake with Caramel Frosting" class='recipePartRecipeImage '>
-                <div data-src="http://images.edge-generalmills.com/c763803d-a37c-4e65-859f-74baa1f88356.jpg"></div>
-                <div data-src="http://images.edge-generalmills.com/646b5ebe-f83f-41d7-9041-50102e567716.jpg" data-media='(min-width: 10px)'></div>                
-                <div data-src="http://images.edge-generalmills.com/d6f4c5d2-c5f2-47ed-ab6f-ec8dc6fea2be.jpg" data-media='(min-width: 200px)'></div>
-                <div data-src="http://images.edge-generalmills.com/c763803d-a37c-4e65-859f-74baa1f88356.jpg" data-media='(min-width: 320px)'></div>
+            <div data-picture="" data-alt="Blueberry-Banana-Oat Bread" class='recipePartRecipeImage '>
+                <div data-src="http://images.edge-generalmills.com/6000b7ea-dde7-4e02-84b6-cc53a4a824e7.jpg"></div>
+                <div data-src="http://images.edge-generalmills.com/4e020757-4645-4897-9de2-3204df372cdb.jpg" data-media='(min-width: 10px)'></div>                
+                <div data-src="http://images.edge-generalmills.com/55a2c74c-4a9f-449c-8358-25dd2776bfa7.jpg" data-media='(min-width: 200px)'></div>
+                <div data-src="http://images.edge-generalmills.com/6000b7ea-dde7-4e02-84b6-cc53a4a824e7.jpg" data-media='(min-width: 320px)'></div>
                 <noscript>
-                    <img src="http://images.edge-generalmills.com/c763803d-a37c-4e65-859f-74baa1f88356.jpg" alt="Coffee-Toffee Cake with Caramel Frosting"/>
+                    <img src="http://images.edge-generalmills.com/6000b7ea-dde7-4e02-84b6-cc53a4a824e7.jpg" alt="Blueberry-Banana-Oat Bread"/>
                 </noscript>
             </div>
-            <meta itemprop="image" content="http://images.edge-generalmills.com/646b5ebe-f83f-41d7-9041-50102e567716.jpg" />
+            <meta itemprop="image" content="http://images.edge-generalmills.com/4e020757-4645-4897-9de2-3204df372cdb.jpg" />
    
                   
                 </div>
@@ -1116,11 +1116,11 @@ ONETSP_TIME: Mon, 01 Feb 2016 21:00:59 +0000
         <li>
             <span class="attributeName">Total Time</span>
             
-                                <span class="attributeValue">2</span>
+                                <span class="attributeValue">3</span>
                             
                                <span class="attributeValueLabel">hr</span>
                         
-                                <span class="attributeValue">0</span>
+                                <span class="attributeValue">25</span>
                             
                                <span class="attributeValueLabel">min</span>
                         
@@ -1129,7 +1129,7 @@ ONETSP_TIME: Mon, 01 Feb 2016 21:00:59 +0000
         <li>
             <span class="attributeName">Servings</span>
             
-                    <span class="attributeValue">15</span>
+                    <span class="attributeValue">16</span>
             
         </li>
         
@@ -1158,7 +1158,7 @@ ONETSP_TIME: Mon, 01 Feb 2016 21:00:59 +0000
                 <a class='ab_print popup' onclick='return false;'>
                     <p>Print</p>
                 </a>
-                <a class='ab_print link' href="/recipes/coffee-toffee-cake-with-caramel-frosting/557b8338-f603-4cc4-95e0-ec44089964bd?p=1">
+                <a class='ab_print link' href="/recipes/blueberry-banana-oat-bread/886c41eb-a229-4ab5-ac74-41b68c4ce0ac?p=1">
                     <p>Print</p>
                 </a>
                 
@@ -1170,7 +1170,7 @@ ONETSP_TIME: Mon, 01 Feb 2016 21:00:59 +0000
   "esrc": 15841,
   "isRegistrationFirstStep": false,
   "RegAction": "AddToFavorites",
-  "returnUrl": "/recipes/coffee-toffee-cake-with-caramel-frosting/557b8338-f603-4cc4-95e0-ec44089964bd?AutoOpen=AddToFavorites"
+  "returnUrl": "/recipes/blueberry-banana-oat-bread/886c41eb-a229-4ab5-ac74-41b68c4ce0ac?AutoOpen=AddToFavorites"
 });'>
                     <p>Save</p>
                 </a>
@@ -1262,7 +1262,7 @@ ONETSP_TIME: Mon, 01 Feb 2016 21:00:59 +0000
             
 <div class="recipePartDescription">
     <p itemprop="description" class="recipePartDescriptionText">        
-        Quick and easy, this homey cake is rich in coffee, toffee and caramel flavors.
+        <b><i>Betty Crocker's Diabetes Cookbook</i> shares a recipe! </b> Looking for a low-fat treat? Here's a keeper.
     </p>
 </div>
 
@@ -1546,67 +1546,17 @@ ONETSP_TIME: Mon, 01 Feb 2016 21:00:59 +0000
             
                 <dl class="recipePartIngredient" itemprop="ingredients" 
                     
-                            data-base-ingredient="Instant Coffee" 
-                        
-                            data-category="Coffee / Tea / Cocoa" 
-                         >
-                    <dt>
-                        <span>
-                            1/4
-                        </span>
-                    </dt>
-                    <dd>
-                        <span>
-                            <span class="type">
-                                
-                            </span>
-                            cup instant coffee granules or crystals
-                        </span>
-                        
-                        
-                        <span class="savingsIndicator" style="display: none;" data-bind="visible: getHasSavingsComputed(1832), click: getSavingsIndicatorClickHandler(1832), html: configuration.ContentToIndicateSavingsOnAnIngredient"></span>
-                        
-                    </dd>
-                </dl>
-            
-                <dl class="recipePartIngredient" itemprop="ingredients" 
-                    
-                            data-base-ingredient="Water" 
-                        
-                            data-category="Bottled Water" 
-                         >
-                    <dt>
-                        <span>
-                            1/4
-                        </span>
-                    </dt>
-                    <dd>
-                        <span>
-                            <span class="type">
-                                
-                            </span>
-                            cup boiling water
-                        </span>
-                        
-                        
-                        <span class="savingsIndicator" style="display: none;" data-bind="visible: getHasSavingsComputed(3533), click: getSavingsIndicatorClickHandler(3533), html: configuration.ContentToIndicateSavingsOnAnIngredient"></span>
-                        
-                    </dd>
-                </dl>
-            
-                <dl class="recipePartIngredient" itemprop="ingredients" 
-                    
-                            data-base-ingredient="Betty Crocker SuperMoist White Cake Mix" 
+                            data-base-ingredient="Bisquick Original Baking Mix" 
                         
                             data-category="Baking Goods" 
                         
-                            data-brand="BC Supermoist Dessert Mix &amp; Frosting"
+                            data-brand="Bisquick"
                         
-                            data-flavor-format="BC SUPERMOIST FAVORITES CAKE MIX" 
+                            data-flavor-format="BISCUIT/SCONE MIX" 
                          >
                     <dt>
                         <span>
-                            1
+                            2 3/4
                         </span>
                     </dt>
                     <dd>
@@ -1614,24 +1564,24 @@ ONETSP_TIME: Mon, 01 Feb 2016 21:00:59 +0000
                             <span class="type">
                                 
                             </span>
-                            box Betty Crocker&#8482; SuperMoist&#8482; white cake mix
+                            cups Bisquick Heart Smart® mix
                         </span>
                         
                         
-                        <span class="savingsIndicator" style="display: none;" data-bind="visible: getHasSavingsComputed(7994), click: getSavingsIndicatorClickHandler(7994), html: configuration.ContentToIndicateSavingsOnAnIngredient"></span>
+                        <span class="savingsIndicator" style="display: none;" data-bind="visible: getHasSavingsComputed(4732), click: getSavingsIndicatorClickHandler(4732), html: configuration.ContentToIndicateSavingsOnAnIngredient"></span>
                         
                     </dd>
                 </dl>
             
                 <dl class="recipePartIngredient" itemprop="ingredients" 
                     
-                            data-base-ingredient="Water" 
+                            data-base-ingredient="Sugar" 
                         
-                            data-category="Bottled Water" 
+                            data-category="Baking Goods" 
                          >
                     <dt>
                         <span>
-                            1
+                            2/3
                         </span>
                     </dt>
                     <dd>
@@ -1639,20 +1589,20 @@ ONETSP_TIME: Mon, 01 Feb 2016 21:00:59 +0000
                             <span class="type">
                                 
                             </span>
-                            cup water
+                            cup sugar
                         </span>
                         
                         
-                        <span class="savingsIndicator" style="display: none;" data-bind="visible: getHasSavingsComputed(3533), click: getSavingsIndicatorClickHandler(3533), html: configuration.ContentToIndicateSavingsOnAnIngredient"></span>
+                        <span class="savingsIndicator" style="display: none;" data-bind="visible: getHasSavingsComputed(3237), click: getSavingsIndicatorClickHandler(3237), html: configuration.ContentToIndicateSavingsOnAnIngredient"></span>
                         
                     </dd>
                 </dl>
             
                 <dl class="recipePartIngredient" itemprop="ingredients" 
                     
-                            data-base-ingredient="Vegetable Oil" 
+                            data-base-ingredient="Quick Cooking Oats" 
                         
-                            data-category="Condiments / Oils" 
+                            data-category="Baking Goods" 
                          >
                     <dt>
                         <span>
@@ -1664,11 +1614,61 @@ ONETSP_TIME: Mon, 01 Feb 2016 21:00:59 +0000
                             <span class="type">
                                 
                             </span>
-                            cup vegetable oil
+                            cup quick-cooking oats
                         </span>
                         
                         
-                        <span class="savingsIndicator" style="display: none;" data-bind="visible: getHasSavingsComputed(3494), click: getSavingsIndicatorClickHandler(3494), html: configuration.ContentToIndicateSavingsOnAnIngredient"></span>
+                        <span class="savingsIndicator" style="display: none;" data-bind="visible: getHasSavingsComputed(2668), click: getSavingsIndicatorClickHandler(2668), html: configuration.ContentToIndicateSavingsOnAnIngredient"></span>
+                        
+                    </dd>
+                </dl>
+            
+                <dl class="recipePartIngredient" itemprop="ingredients" 
+                    
+                            data-base-ingredient="Bananas" 
+                        
+                            data-category="Fruit (Produce)" 
+                         >
+                    <dt>
+                        <span>
+                            1
+                        </span>
+                    </dt>
+                    <dd>
+                        <span>
+                            <span class="type">
+                                
+                            </span>
+                            cup mashed very ripe bananas (2 medium)
+                        </span>
+                        
+                        
+                        <span class="savingsIndicator" style="display: none;" data-bind="visible: getHasSavingsComputed(179), click: getSavingsIndicatorClickHandler(179), html: configuration.ContentToIndicateSavingsOnAnIngredient"></span>
+                        
+                    </dd>
+                </dl>
+            
+                <dl class="recipePartIngredient" itemprop="ingredients" 
+                    
+                            data-base-ingredient="Milk" 
+                        
+                            data-category="Dairy" 
+                         >
+                    <dt>
+                        <span>
+                            1/4
+                        </span>
+                    </dt>
+                    <dd>
+                        <span>
+                            <span class="type">
+                                
+                            </span>
+                            cup milk
+                        </span>
+                        
+                        
+                        <span class="savingsIndicator" style="display: none;" data-bind="visible: getHasSavingsComputed(2183), click: getSavingsIndicatorClickHandler(2183), html: configuration.ContentToIndicateSavingsOnAnIngredient"></span>
                         
                     </dd>
                 </dl>
@@ -1681,7 +1681,7 @@ ONETSP_TIME: Mon, 01 Feb 2016 21:00:59 +0000
                          >
                     <dt>
                         <span>
-                            3
+                            2
                         </span>
                     </dt>
                     <dd>
@@ -1700,13 +1700,9 @@ ONETSP_TIME: Mon, 01 Feb 2016 21:00:59 +0000
             
                 <dl class="recipePartIngredient" itemprop="ingredients" 
                     
-                            data-base-ingredient="Betty Crocker Rich &amp; Creamy Vanilla Frosting" 
+                            data-base-ingredient="Frozen Blueberries" 
                         
-                            data-category="Baking Goods" 
-                        
-                            data-brand="BC Other Dessert Mix &amp; Frosting"
-                        
-                            data-flavor-format="READY TO SPREAD FROSTING" 
+                            data-category="Fruit (Packaged)" 
                          >
                     <dt>
                         <span>
@@ -1718,61 +1714,11 @@ ONETSP_TIME: Mon, 01 Feb 2016 21:00:59 +0000
                             <span class="type">
                                 
                             </span>
-                            container Betty Crocker&#8482; Rich &amp; Creamy vanilla frosting
+                            cup fresh or frozen (thawed and drained) blueberries
                         </span>
                         
                         
-                        <span class="savingsIndicator" style="display: none;" data-bind="visible: getHasSavingsComputed(12495), click: getSavingsIndicatorClickHandler(12495), html: configuration.ContentToIndicateSavingsOnAnIngredient"></span>
-                        
-                    </dd>
-                </dl>
-            
-                <dl class="recipePartIngredient" itemprop="ingredients" 
-                    
-                            data-base-ingredient="Caramel Ice Cream Topping" 
-                        
-                            data-category="Desserts" 
-                         >
-                    <dt>
-                        <span>
-                            1/4
-                        </span>
-                    </dt>
-                    <dd>
-                        <span>
-                            <span class="type">
-                                
-                            </span>
-                            cup caramel topping
-                        </span>
-                        
-                        
-                        <span class="savingsIndicator" style="display: none;" data-bind="visible: getHasSavingsComputed(4037), click: getSavingsIndicatorClickHandler(4037), html: configuration.ContentToIndicateSavingsOnAnIngredient"></span>
-                        
-                    </dd>
-                </dl>
-            
-                <dl class="recipePartIngredient" itemprop="ingredients" 
-                    
-                            data-base-ingredient="Chocolate-covered English Toffee" 
-                        
-                            data-category="Desserts" 
-                         >
-                    <dt>
-                        <span>
-                            3
-                        </span>
-                    </dt>
-                    <dd>
-                        <span>
-                            <span class="type">
-                                
-                            </span>
-                            bars (1.4 oz each) chocolate-covered English toffee candy, coarsely chopped
-                        </span>
-                        
-                        
-                        <span class="savingsIndicator" style="display: none;" data-bind="visible: getHasSavingsComputed(795), click: getSavingsIndicatorClickHandler(795), html: configuration.ContentToIndicateSavingsOnAnIngredient"></span>
+                        <span class="savingsIndicator" style="display: none;" data-bind="visible: getHasSavingsComputed(1392), click: getSavingsIndicatorClickHandler(1392), html: configuration.ContentToIndicateSavingsOnAnIngredient"></span>
                         
                     </dd>
                 </dl>
@@ -1795,29 +1741,24 @@ ONETSP_TIME: Mon, 01 Feb 2016 21:00:59 +0000
                     
                            <li class="recipePartStep" itemprop="recipeInstructions">
                                <span class="recipePartStepHeading">1</span>
-                               <span class="recipePartStepDescription">Heat oven to 350°F (325°F for dark or nonstick pan). Grease bottom and sides of 13x9-inch pan. In small bowl, dissolve coffee granules in boiling water.</span>
+                               <span class="recipePartStepDescription">Heat oven to 375°F. Grease bottom only of 9x5-inch loaf pan with shortening or cooking spray.</span>
                            </li>
                     
                            <li class="recipePartStep" itemprop="recipeInstructions">
                                <span class="recipePartStepHeading">2</span>
-                               <span class="recipePartStepDescription">In large bowl, beat cake mix, 1 cup water, the oil, eggs and coffee mixture with electric mixer on low speed 30 seconds, then on medium speed 2 minutes, scraping bowl occasionally. Pour into pan.</span>
+                               <span class="recipePartStepDescription">In large bowl, stir Bisquick mix, sugar, oats, bananas, milk and eggs until moistened; beat vigorously 30 seconds. Gently stir in blueberries. Pour into pan.</span>
                            </li>
                     
                            <li class="recipePartStep" itemprop="recipeInstructions">
                                <span class="recipePartStepHeading">3</span>
-                               <span class="recipePartStepDescription">Bake as directed on box for 13x9-inch pan. Cool completely, about 1 hour.</span>
-                           </li>
-                    
-                           <li class="recipePartStep" itemprop="recipeInstructions">
-                               <span class="recipePartStepHeading">4</span>
-                               <span class="recipePartStepDescription">In medium bowl, mix frosting and caramel topping. Frost cake with frosting mixture. Sprinkle with toffee candy. Store loosely covered.</span>
+                               <span class="recipePartStepDescription">Bake 45 to 60 minutes or until toothpick inserted in center comes out clean. Cool 10 minutes. Loosen loaf from sides of pan; remove from pan and place top side up on cooling rack. Cool completely, about 2 hours, before slicing.</span>
                            </li>
                     
                </ul>
         </div>
 
-<div class="advertisement" id="fd89aaf2-77e3-4725-98c1-0bd5afab312c" data-bind="visible: showAd">
-    <div class="doubleClickAd" id="591dc8d0-1371-448c-a441-bcbc44454e94"></div>
+<div class="advertisement" id="b845bac6-b0c8-45ff-9938-d2a4f142c133" data-bind="visible: showAd">
+    <div class="doubleClickAd" id="9dbc5dcb-2a7a-4137-ba16-a81325cc21a2"></div>
     <div class="adCaptionText">ADVERTISEMENT</div>
 </div>
 
@@ -1829,7 +1770,11 @@ ONETSP_TIME: Mon, 01 Feb 2016 21:00:59 +0000
     <div class="recipePartExpertTipsTop"></div>
     <div class="recipePartTipsInfo">
             
-                   <p>For an Irish cream cake, substitute 1/4 cup Irish cream liqueur for the caramel topping.</p>
+                   <p>Not only are oats 100 percent whole grain and a great source of fiber, they also add a nutty flavor and texture to many baked goods.  Oats also contain soluble fiber, which can help lower cholesterol.</p>
+            
+                   <p>If you're using frozen (thawed) blueberries, be sure to drain them on a paper towel to soak up all the extra juice.</p>
+            
+                   <p>Enjoy a slice of this scrumptious bread with a hard-cooked egg for a hearty breakfast.  If your meal plan allows 3 or more Carbohydrate Choices, pour a glass of juice or opt for a fresh orange.</p>
             
     </div>
     <div class="recipePartExpertTipsBottom"></div>
@@ -1841,48 +1786,48 @@ ONETSP_TIME: Mon, 01 Feb 2016 21:00:59 +0000
     </span>
     <div id="main_0_mainbody_8_NutritionInformation" class="nutrition-paragraph">
         <h4>NUTRITION INFORMATION PER SERVING</h4>
-         <h5 class="nutrition-serving-size"><strong>Serving Size: </strong>1 Serving</h5>
+         <h5 class="nutrition-serving-size"><strong>Serving Size: </strong>1 Slice</h5>
 
         <dl class="nutrition-section nutrition-calories">
             
 
-<dt class="nutrition-fact-title">Calories</dt><dd class="nutrition-fact-units">390</dd><dd class="nutrition-fact-percent"></dd>
+<dt class="nutrition-fact-title">Calories</dt><dd class="nutrition-fact-units">140</dd><dd class="nutrition-fact-percent"></dd>
 
             
 
-<dt class="nutrition-fact-title">Calories from Fat</dt><dd class="nutrition-fact-units">160</dd><dd class="nutrition-fact-percent"></dd>
+<dt class="nutrition-fact-title">Calories from Fat</dt><dd class="nutrition-fact-units">20</dd><dd class="nutrition-fact-percent"></dd>
 
         </dl>
         <h5 class="nutrition-daily-value">% Daily Value</h5>
         <dl class="nutrition-section nutrition-nutrients nutrition-daily-value-section">
             
 
-<dt class="nutrition-fact-title">Total Fat</dt><dd class="nutrition-fact-units">18g</dd><dd class="nutrition-fact-percent">28%</dd>
+<dt class="nutrition-fact-title">Total Fat</dt><dd class="nutrition-fact-units">2g</dd><dd class="nutrition-fact-percent">3%</dd>
 
             <dt class="nutrition-subsection nutrition-fat">
                 <dl>
                     
 
-<dt class="nutrition-fact-title">Saturated Fat</dt><dd class="nutrition-fact-units">5g</dd><dd class="nutrition-fact-percent">26%</dd>
+<dt class="nutrition-fact-title">Saturated Fat</dt><dd class="nutrition-fact-units">0g</dd><dd class="nutrition-fact-percent">0%</dd>
 
                     
 
-<dt class="nutrition-fact-title">Trans Fat</dt><dd class="nutrition-fact-units">3g</dd><dd class="nutrition-fact-percent">3%</dd>
+<dt class="nutrition-fact-title">Trans Fat</dt><dd class="nutrition-fact-units">0g</dd><dd class="nutrition-fact-percent">0%</dd>
 
                 </dl>
             </dt>
             
 
-<dt class="nutrition-fact-title">Cholesterol</dt><dd class="nutrition-fact-units">45mg</dd><dd class="nutrition-fact-percent">16%</dd>
+<dt class="nutrition-fact-title">Cholesterol</dt><dd class="nutrition-fact-units">25mg</dd><dd class="nutrition-fact-percent">9%</dd>
 
             
 
-<dt class="nutrition-fact-title">Sodium</dt><dd class="nutrition-fact-units">360mg</dd><dd class="nutrition-fact-percent">15%</dd>
+<dt class="nutrition-fact-title">Sodium</dt><dd class="nutrition-fact-units">180mg</dd><dd class="nutrition-fact-percent">8%</dd>
 
             
             
 
-<dt class="nutrition-fact-title">Total Carbohydrate</dt><dd class="nutrition-fact-units">55g</dd><dd class="nutrition-fact-percent">18%</dd>
+<dt class="nutrition-fact-title">Total Carbohydrate</dt><dd class="nutrition-fact-units">28g</dd><dd class="nutrition-fact-percent">9%</dd>
             
             <dt class="nutrition-subsection nutrition-carbs">
                 <dl>
@@ -1892,7 +1837,7 @@ ONETSP_TIME: Mon, 01 Feb 2016 21:00:59 +0000
 
                     
 
-<dt class="nutrition-fact-title">Sugars</dt><dd class="nutrition-fact-units">39g</dd><dd class="nutrition-fact-percent">39%</dd>
+<dt class="nutrition-fact-title">Sugars</dt><dd class="nutrition-fact-units">13g</dd><dd class="nutrition-fact-percent">13%</dd>
 
                 </dl>
             </dt>
@@ -1905,7 +1850,7 @@ ONETSP_TIME: Mon, 01 Feb 2016 21:00:59 +0000
         <dl class="nutrition-section nutrition-vitamins">
             
 
-<dt class="nutrition-fact-title">Vitamin A</dt><dd class="nutrition-fact-units">2%</dd><dd class="nutrition-fact-percent">2%</dd>
+<dt class="nutrition-fact-title">Vitamin A</dt><dd class="nutrition-fact-units">0%</dd><dd class="nutrition-fact-percent">0%</dd>
 
             
 
@@ -1913,36 +1858,36 @@ ONETSP_TIME: Mon, 01 Feb 2016 21:00:59 +0000
 
             
 
-<dt class="nutrition-fact-title">Calcium</dt><dd class="nutrition-fact-units">4%</dd><dd class="nutrition-fact-percent">4%</dd>
+<dt class="nutrition-fact-title">Calcium</dt><dd class="nutrition-fact-units">8%</dd><dd class="nutrition-fact-percent">8%</dd>
 
             
 
-<dt class="nutrition-fact-title">Iron</dt><dd class="nutrition-fact-units">4%</dd><dd class="nutrition-fact-percent">4%</dd>
+<dt class="nutrition-fact-title">Iron</dt><dd class="nutrition-fact-units">6%</dd><dd class="nutrition-fact-percent">6%</dd>
 
         </dl>
         <div class="nutrition-section nutrition-exchanges">
-            <h5>Exchanges:</h5>1 Starch; 0 Fruit; 2 1/2 Other Carbohydrate; 0 Skim Milk; 0 Low-Fat Milk; 0 Milk; 0 Vegetable; 0 Very Lean Meat; 0 Lean Meat; 0 High-Fat Meat; 3 1/2 Fat;
+            <h5>Exchanges:</h5>1 Starch; 0 Fruit; 1 Other Carbohydrate; 0 Skim Milk; 0 Low-Fat Milk; 0 Milk; 0 Vegetable; 0 Very Lean Meat; 0 Lean Meat; 0 High-Fat Meat; 0 Fat;
         </div>
         <div id="main_0_mainbody_8_CarbohydrateChoices" class="nutrition-section nutrition-carbs">
-            <h5>Carbohydrate Choice</h5>3 1/2
+            <h5>Carbohydrate Choice</h5>2
         </div>
         <em class="nutrition-dailyvalues-notice">*Percent Daily Values are based on a 2,000 calorie diet.</em>
         
-        <meta itemprop="calories" content="390 "/><meta itemprop="carbohydrateContent" content="55 g"/><meta itemprop="cholesterolContent" content="45 mg"/><meta itemprop="fatContent" content="3 1/2 "/><meta itemprop="fiberContent" content="0 g"/><meta itemprop="proteinContent" content="3 g"/><meta itemprop="saturatedFatContent" content="5 g"/><meta itemprop="servingSize" content="1 Serving "/><meta itemprop="sodiumContent" content="360 mg"/><meta itemprop="sugarContent" content="39 g"/><meta itemprop="transFatContent" content="3 g"/>
+        <meta itemprop="calories" content="140 "/><meta itemprop="carbohydrateContent" content="28 g"/><meta itemprop="cholesterolContent" content="25 mg"/><meta itemprop="fatContent" content="0 "/><meta itemprop="fiberContent" content="0 g"/><meta itemprop="proteinContent" content="3 g"/><meta itemprop="saturatedFatContent" content="0 g"/><meta itemprop="servingSize" content="1 Slice "/><meta itemprop="sodiumContent" content="180 mg"/><meta itemprop="sugarContent" content="13 g"/><meta itemprop="transFatContent" content="0 g"/>
     </div>
     
 </div>
-<meta id="main_0_mainbody_8_RecipeTotalTime" itemprop="totalTime" content="PT2H0M"></meta>
+<meta id="main_0_mainbody_8_RecipeTotalTime" itemprop="totalTime" content="PT3H25M"></meta>
 
 <meta itemprop="prepTime" content="PT0H15M"></meta>
-<meta itemprop="recipeYield" content="15"/>
+<meta itemprop="recipeYield" content="16"/>
 
 <div class="recipeTrademarks">
     
 
 </div>
 
-<div class="contentList" id="4b2c6fbf-9c1b-4715-affd-952f96f7c518" data-bind="css: { 'fetching': isFetching }, infiniteScroll: { enable: $root.useInfiniteScrolling(), scroll: $root.getMoreItems}, visible: renderingCompletedSuccessfully" style="display: none">
+<div class="contentList" id="ae6e8cce-37f5-4da4-9cdd-a938135acef9" data-bind="css: { 'fetching': isFetching }, infiniteScroll: { enable: $root.useInfiniteScrolling(), scroll: $root.getMoreItems}, visible: renderingCompletedSuccessfully" style="display: none">
     <div class="alert alert-error" data-bind="visible: isInPageEditor && fatalErrorMessage()" style="display: none">
         <p data-bind="text: fatalErrorMessage"></p>
     </div>
@@ -2005,8 +1950,8 @@ ONETSP_TIME: Mon, 01 Feb 2016 21:00:59 +0000
 <!-- STRIPPED SCRIPT TAG -->
 
 
-<div class="advertisement" id="dfcbf0f4-a1be-427a-af73-9f725ece15ac" data-bind="visible: showAd">
-    <div class="doubleClickAd" id="0df66442-88db-4069-b995-ba0f1b2e4e4a"></div>
+<div class="advertisement" id="abb93ff8-ba11-40d4-9105-3910e6fd79d5" data-bind="visible: showAd">
+    <div class="doubleClickAd" id="aef65e60-b528-4c72-9440-3b142e95315c"></div>
     <div class="adCaptionText">ADVERTISEMENT</div>
 </div>
 
@@ -2016,8 +1961,8 @@ ONETSP_TIME: Mon, 01 Feb 2016 21:00:59 +0000
 
         <div id="ContentList" class="d33 t100 m100">
             
-<div class="advertisement" id="dec259e1-f1c6-4ebf-9745-d721d5222179" data-bind="visible: showAd">
-    <div class="doubleClickAd" id="3bf38dbf-ffab-4659-98b7-bb7bff27578b"></div>
+<div class="advertisement" id="7ab29e26-0bed-4a95-a268-90cc930e60af" data-bind="visible: showAd">
+    <div class="doubleClickAd" id="9fe846ae-28b5-43ae-9786-49292cb44592"></div>
     <div class="adCaptionText">ADVERTISEMENT</div>
 </div>
 
@@ -2028,39 +1973,39 @@ ONETSP_TIME: Mon, 01 Feb 2016 21:00:59 +0000
     <div class="relatedContentHeader">TRY THESE NEXT</div>
     <div class="relatedContentItems">
         
-                <div class="relatedContentItem recipe" data-content-id="ed119ff2-b05b-46ad-8ff4-a076ebabd7d4">
-                    <a href='/recipes/chocolate-stout-cake-with-caramel-frosting/ed119ff2-b05b-46ad-8ff4-a076ebabd7d4'><img class="relatedContentThumbnail" src='http://images.edge-generalmills.com/13e15223-99cf-469a-8a86-7036e73e8bc9.jpg' alt='' /></a>                
-                    <a href='/recipes/chocolate-stout-cake-with-caramel-frosting/ed119ff2-b05b-46ad-8ff4-a076ebabd7d4'><div class="relatedContentTitle">Chocolate Stout Cake with Caramel Frosting</div></a>
+                <div class="relatedContentItem recipe" data-content-id="a196ada4-0ec5-49c0-8c95-6a3340fd00f4">
+                    <a href='/recipes/apricot-and-white-chocolate-scones/a196ada4-0ec5-49c0-8c95-6a3340fd00f4'><img class="relatedContentThumbnail" src='http://images.edge-generalmills.com/b3e6fe47-fefc-4e65-84a7-c09561936464.jpg' alt='' /></a>                
+                    <a href='/recipes/apricot-and-white-chocolate-scones/a196ada4-0ec5-49c0-8c95-6a3340fd00f4'><div class="relatedContentTitle">Apricot and White Chocolate Scones</div></a>
                     <div class="relatedContentDescription"></div>
                 </div>
             
-                <div class="relatedContentItem recipe" data-content-id="513d84f3-4a05-46d6-a39d-1ac8e0892cc6">
-                    <a href='/recipes/ginger-cake-with-caramel-apple-topping/513d84f3-4a05-46d6-a39d-1ac8e0892cc6'><img class="relatedContentThumbnail" src='http://images.edge-generalmills.com/743c52b1-be7d-4fe6-8dbb-97175961609f.jpg' alt='' /></a>                
-                    <a href='/recipes/ginger-cake-with-caramel-apple-topping/513d84f3-4a05-46d6-a39d-1ac8e0892cc6'><div class="relatedContentTitle">Ginger Cake with Caramel-Apple Topping</div></a>
+                <div class="relatedContentItem recipe" data-content-id="a3f77e22-8ad2-4cdc-a81a-5483feb2af73">
+                    <a href='/recipes/apple-dumpling-french-toast-bake/a3f77e22-8ad2-4cdc-a81a-5483feb2af73'><img class="relatedContentThumbnail" src='http://images.edge-generalmills.com/c5d7e442-6add-4a75-92f5-d9b121475c70.jpg' alt='' /></a>                
+                    <a href='/recipes/apple-dumpling-french-toast-bake/a3f77e22-8ad2-4cdc-a81a-5483feb2af73'><div class="relatedContentTitle">Apple Dumpling French Toast Bake</div></a>
                     <div class="relatedContentDescription"></div>
                 </div>
             
-                <div class="relatedContentItem recipe" data-content-id="8401a87e-b1a1-4c80-b91b-6d865c04cad2">
-                    <a href='/recipes/browned-butter-cookies-with-caramel-frosting/8401a87e-b1a1-4c80-b91b-6d865c04cad2'><img class="relatedContentThumbnail" src='http://images.edge-generalmills.com/3d00db6b-e484-46df-a0df-806e7bfb2e19.jpg' alt='' /></a>                
-                    <a href='/recipes/browned-butter-cookies-with-caramel-frosting/8401a87e-b1a1-4c80-b91b-6d865c04cad2'><div class="relatedContentTitle">Browned Butter Cookies with Caramel Frosting</div></a>
+                <div class="relatedContentItem recipe" data-content-id="c432fa4c-8ea6-48c2-b32e-b4310a71c0f5">
+                    <a href='/recipes/glazed-lemon-blueberry-loaf/c432fa4c-8ea6-48c2-b32e-b4310a71c0f5'><img class="relatedContentThumbnail" src='http://images.edge-generalmills.com/2a56b04e-1fcc-456f-91e2-3c32d5c67f65.jpg' alt='' /></a>                
+                    <a href='/recipes/glazed-lemon-blueberry-loaf/c432fa4c-8ea6-48c2-b32e-b4310a71c0f5'><div class="relatedContentTitle">Glazed Lemon-Blueberry Loaf</div></a>
                     <div class="relatedContentDescription"></div>
                 </div>
             
-                <div class="relatedContentItem recipe" data-content-id="67dfc73e-ecc5-4277-b330-33d7b55ef1e9">
-                    <a href='/recipes/toasted-almond-cupcakes-with-caramel-frosting/67dfc73e-ecc5-4277-b330-33d7b55ef1e9'><img class="relatedContentThumbnail" src='http://images.edge-generalmills.com/3e2b3e2f-5423-4644-8f0f-c9bd12f7e263.jpg' alt='' /></a>                
-                    <a href='/recipes/toasted-almond-cupcakes-with-caramel-frosting/67dfc73e-ecc5-4277-b330-33d7b55ef1e9'><div class="relatedContentTitle">Toasted Almond Cupcakes with Caramel Frosting</div></a>
+                <div class="relatedContentItem recipe" data-content-id="8990e15c-fc1d-4a8d-b8b3-4b37f45eca49">
+                    <a href='/recipes/cornbread/8990e15c-fc1d-4a8d-b8b3-4b37f45eca49'><img class="relatedContentThumbnail" src='http://images.edge-generalmills.com/9e7284b7-66ab-48e4-b35f-13a347687b55.jpg' alt='' /></a>                
+                    <a href='/recipes/cornbread/8990e15c-fc1d-4a8d-b8b3-4b37f45eca49'><div class="relatedContentTitle">Cornbread</div></a>
                     <div class="relatedContentDescription"></div>
                 </div>
             
-                <div class="relatedContentItem recipe" data-content-id="cf68bec8-d15d-4d9b-b8ad-4e58e988efbe">
-                    <a href='/recipes/apple-walnut-cake-with-caramel-glaze/cf68bec8-d15d-4d9b-b8ad-4e58e988efbe'><img class="relatedContentThumbnail" src='http://images.edge-generalmills.com/96d9646a-888e-4c3c-b8a8-f45c5e997a5c.jpg' alt='' /></a>                
-                    <a href='/recipes/apple-walnut-cake-with-caramel-glaze/cf68bec8-d15d-4d9b-b8ad-4e58e988efbe'><div class="relatedContentTitle">Apple-Walnut Cake with Caramel Glaze</div></a>
+                <div class="relatedContentItem recipe" data-content-id="02a87ed3-d9ae-4488-8985-15ab094e1b97">
+                    <a href='/recipes/turtle-bread/02a87ed3-d9ae-4488-8985-15ab094e1b97'><img class="relatedContentThumbnail" src='http://images.edge-generalmills.com/0115aacb-1bb0-40e1-bbb9-87536032a668.jpg' alt='' /></a>                
+                    <a href='/recipes/turtle-bread/02a87ed3-d9ae-4488-8985-15ab094e1b97'><div class="relatedContentTitle">Turtle Bread</div></a>
                     <div class="relatedContentDescription"></div>
                 </div>
             
-                <div class="relatedContentItem recipe" data-content-id="bb95c893-5ab2-4cad-9d30-2edf73666a81">
-                    <a href='/recipes/honey-gingerbread-cakes-with-caramel-apple-topping/bb95c893-5ab2-4cad-9d30-2edf73666a81'><img class="relatedContentThumbnail" src='http://images.edge-generalmills.com/52fcf174-044c-443f-abd6-a3cf14d3ed0e.jpg' alt='' /></a>                
-                    <a href='/recipes/honey-gingerbread-cakes-with-caramel-apple-topping/bb95c893-5ab2-4cad-9d30-2edf73666a81'><div class="relatedContentTitle">Honey Gingerbread Cakes with Caramel Apple Topping</div></a>
+                <div class="relatedContentItem recipe" data-content-id="790f3338-59c6-4312-a3c1-3e4d0cf6b101">
+                    <a href='/recipes/old-fashioned-bread-pudding/790f3338-59c6-4312-a3c1-3e4d0cf6b101'><img class="relatedContentThumbnail" src='http://images.edge-generalmills.com/d05c2cab-0edd-4327-aa1c-b96a33a14b69.jpg' alt='' /></a>                
+                    <a href='/recipes/old-fashioned-bread-pudding/790f3338-59c6-4312-a3c1-3e4d0cf6b101'><div class="relatedContentTitle">Old-Fashioned Bread Pudding</div></a>
                     <div class="relatedContentDescription"></div>
                 </div>
             
@@ -2070,20 +2015,20 @@ ONETSP_TIME: Mon, 01 Feb 2016 21:00:59 +0000
         
         <div id="Newsletter" class="d33 t100 m100">
              
-<div class="railNewsletterCtaWrapper"><iframe src="https://www.bettycrocker.com/Profile/RailNewsLetterCTA?parentUrl=%2frecipes%2fcoffee-toffee-cake-with-caramel-frosting%2f557b8338-f603-4cc4-95e0-ec44089964bd&amp;disablePageView=1" class="newsletterCtaContainer" scrolling="no" frameborder="0" marginheight="0" marginwidth="0"></iframe></div> 
+<div class="railNewsletterCtaWrapper"><iframe src="https://www.bettycrocker.com/Profile/RailNewsLetterCTA?parentUrl=%2frecipes%2fblueberry-banana-oat-bread%2f886c41eb-a229-4ab5-ac74-41b68c4ce0ac&amp;disablePageView=1" class="newsletterCtaContainer" scrolling="no" frameborder="0" marginheight="0" marginwidth="0"></iframe></div> 
          </div>   
 
         <div id="ContentList2" class="d33 t100 m100"> 
              
-<div class="advertisement" id="78473c0d-fae7-4273-948e-cc2819142078" data-bind="visible: showAd">
-    <div class="doubleClickAd" id="0c9f145f-bcb2-4db9-aa15-b38a617edd5d"></div>
+<div class="advertisement" id="de2bdffd-5b19-4344-86e7-aa2bf9ea2a97" data-bind="visible: showAd">
+    <div class="doubleClickAd" id="10c5162f-2308-4523-b5c9-8b886de3b9a1"></div>
     <div class="adCaptionText">ADVERTISEMENT</div>
 </div>
 
 <!-- STRIPPED SCRIPT TAG -->
 
 
-<div class="contentList" id="3e7ce382-4d9b-4b85-9e01-7311815ea849" data-bind="css: { 'fetching': isFetching }, infiniteScroll: { enable: $root.useInfiniteScrolling(), scroll: $root.getMoreItems}, visible: renderingCompletedSuccessfully" style="display: none">
+<div class="contentList" id="d2243074-878a-441f-99d9-2b8c86dcc590" data-bind="css: { 'fetching': isFetching }, infiniteScroll: { enable: $root.useInfiniteScrolling(), scroll: $root.getMoreItems}, visible: renderingCompletedSuccessfully" style="display: none">
     <div class="alert alert-error" data-bind="visible: isInPageEditor && fatalErrorMessage()" style="display: none">
         <p data-bind="text: fatalErrorMessage"></p>
     </div>
@@ -2160,7 +2105,7 @@ ONETSP_TIME: Mon, 01 Feb 2016 21:00:59 +0000
     data-ratingandreview="review" 
     data-options='{ 
         "categoryID": "Recipe", 
-        "streamID": "557b8338-f603-4cc4-95e0-ec44089964bd", 
+        "streamID": "886c41eb-a229-4ab5-ac74-41b68c4ce0ac", 
         "renderReviewsForSEO": false,
         "waterMark": "*Rate this recipe. And we would also love to hear your comments."
     }'
@@ -2197,8 +2142,8 @@ ONETSP_TIME: Mon, 01 Feb 2016 21:00:59 +0000
 </div>
 <div id="FullWidthAd" class="d100 t100 m100">
     
-<div class="advertisement" id="299b7b3f-1509-49e0-81c5-bba5e7c45bc0" data-bind="visible: showAd">
-    <div class="doubleClickAd" id="f92b3b56-c22a-48d1-9e99-fdf274a8f73c"></div>
+<div class="advertisement" id="4ec69c49-8c86-4c76-8bb0-0bffed6e6c26" data-bind="visible: showAd">
+    <div class="doubleClickAd" id="bf139296-f6ff-4d71-a730-3c52fe10e62e"></div>
     <div class="adCaptionText">ADVERTISEMENT</div>
 </div>
 
@@ -2208,7 +2153,7 @@ ONETSP_TIME: Mon, 01 Feb 2016 21:00:59 +0000
 
 
 
-<span id="maxymiser-counts" data-view="3688" data-favorite="0" data-email="0" data-print="0"></span>
+<span id="maxymiser-counts" data-view="5922" data-favorite="130" data-email="0" data-print="369"></span>
             <div style="display: none;">
                 ENDECA_EXCLUDE_START
             </div>
@@ -2224,7 +2169,7 @@ ONETSP_TIME: Mon, 01 Feb 2016 21:00:59 +0000
         </div>
         
     <div class="footerNewsletterCtaWrapper">
-        <iframe src="https://www.bettycrocker.com/Profile/FooterNewsLetterCTA?parentUrl=%2frecipes%2fcoffee-toffee-cake-with-caramel-frosting%2f557b8338-f603-4cc4-95e0-ec44089964bd&amp;disablePageView=1" class="newsletterCtaContainer" scrolling="no" frameborder="0" marginheight="0" marginwidth="0"></iframe>
+        <iframe src="https://www.bettycrocker.com/Profile/FooterNewsLetterCTA?parentUrl=%2frecipes%2fblueberry-banana-oat-bread%2f886c41eb-a229-4ab5-ac74-41b68c4ce0ac&amp;disablePageView=1" class="newsletterCtaContainer" scrolling="no" frameborder="0" marginheight="0" marginwidth="0"></iframe>
     </div>
 
         <div id="Footer">
@@ -2237,27 +2182,27 @@ ONETSP_TIME: Mon, 01 Feb 2016 21:00:59 +0000
         <li>Follow Betty:</li>
     
         <li>
-            <a id="ctl11_repeaterBottomLinks_ctl01_lnkBottomFooter" class="blueLink" href="http://www.facebook.com/bettycrocker" target="_blank"><img id="ctl11_repeaterBottomLinks_ctl01_imgBottomFooter" src="/~/media/Images/global/Logos/social_facebook.png" style="border-width:0px;" /></a>
+            <a id="ctl13_repeaterBottomLinks_ctl01_lnkBottomFooter" class="blueLink" href="http://www.facebook.com/bettycrocker" target="_blank"><img id="ctl13_repeaterBottomLinks_ctl01_imgBottomFooter" src="/~/media/Images/global/Logos/social_facebook.png" style="border-width:0px;" /></a>
         </li>
     
         <li>
-            <a id="ctl11_repeaterBottomLinks_ctl02_lnkBottomFooter" class="blueLink" href="http://www.pinterest.com/bettycrocker" target="_blank"><img id="ctl11_repeaterBottomLinks_ctl02_imgBottomFooter" src="/~/media/Images/global/Logos/social_pinterest.png" style="border-width:0px;" /></a>
+            <a id="ctl13_repeaterBottomLinks_ctl02_lnkBottomFooter" class="blueLink" href="http://www.pinterest.com/bettycrocker" target="_blank"><img id="ctl13_repeaterBottomLinks_ctl02_imgBottomFooter" src="/~/media/Images/global/Logos/social_pinterest.png" style="border-width:0px;" /></a>
         </li>
     
         <li>
-            <a id="ctl11_repeaterBottomLinks_ctl03_lnkBottomFooter" class="blueLink" href="http://instagram.com/bettycrocker" target="_blank"><img id="ctl11_repeaterBottomLinks_ctl03_imgBottomFooter" src="/~/media/Images/global/Logos/social_instagram.png" style="border-width:0px;" /></a>
+            <a id="ctl13_repeaterBottomLinks_ctl03_lnkBottomFooter" class="blueLink" href="http://instagram.com/bettycrocker" target="_blank"><img id="ctl13_repeaterBottomLinks_ctl03_imgBottomFooter" src="/~/media/Images/global/Logos/social_instagram.png" style="border-width:0px;" /></a>
         </li>
     
         <li>
-            <a id="ctl11_repeaterBottomLinks_ctl04_lnkBottomFooter" class="blueLink" href="http://www.twitter.com/bettycrocker" target="_blank"><img id="ctl11_repeaterBottomLinks_ctl04_imgBottomFooter" src="/~/media/Images/global/Logos/social_twitter.png" style="border-width:0px;" /></a>
+            <a id="ctl13_repeaterBottomLinks_ctl04_lnkBottomFooter" class="blueLink" href="http://www.twitter.com/bettycrocker" target="_blank"><img id="ctl13_repeaterBottomLinks_ctl04_imgBottomFooter" src="/~/media/Images/global/Logos/social_twitter.png" style="border-width:0px;" /></a>
         </li>
     
         <li>
-            <a id="ctl11_repeaterBottomLinks_ctl05_lnkBottomFooter" class="blueLink" href="http://www.youtube.com/user/BettyCrockerTV" target="_blank"><img id="ctl11_repeaterBottomLinks_ctl05_imgBottomFooter" src="/~/media/Images/global/Logos/social_youtube.png" style="border-width:0px;" /></a>
+            <a id="ctl13_repeaterBottomLinks_ctl05_lnkBottomFooter" class="blueLink" href="http://www.youtube.com/user/BettyCrockerTV" target="_blank"><img id="ctl13_repeaterBottomLinks_ctl05_imgBottomFooter" src="/~/media/Images/global/Logos/social_youtube.png" style="border-width:0px;" /></a>
         </li>
     
         <li>
-            <a id="ctl11_repeaterBottomLinks_ctl06_lnkBottomFooter" class="blueLink" href="/Profile/YourAccount?RegAction=Footer"><img id="ctl11_repeaterBottomLinks_ctl06_imgBottomFooter" src="/~/media/Images/global/Logos/social_newsletter.png" style="border-width:0px;" /></a>
+            <a id="ctl13_repeaterBottomLinks_ctl06_lnkBottomFooter" class="blueLink" href="/Profile/YourAccount?RegAction=Footer"><img id="ctl13_repeaterBottomLinks_ctl06_imgBottomFooter" src="/~/media/Images/global/Logos/social_newsletter.png" style="border-width:0px;" /></a>
         </li>
     
             </ul>
@@ -2457,4 +2402,4 @@ Override implementation of sharebar toggle for tablet view.  -->
     <!-- STRIPPED SCRIPT TAG -->
 </body>
 </html>
-<!-- ST: 635899356589635266, PID: 1 -->
+<!-- ST: 635899356581454723, PID: 1 -->

--- a/tests/data/bettycrocker_com_unknown_title_curl.html
+++ b/tests/data/bettycrocker_com_unknown_title_curl.html
@@ -1,0 +1,6 @@
+<!--
+ONETSP_URL: http://www.bettycrocker.com/recipes/banana-cake-with-fudge-frosting/ec14f90a-4ed3-4ef7-8f69-d9d5aadcebc3
+ONETSP_USER_AGENT: curl
+ONETSP_TIME: Mon, 01 Feb 2016 21:00:55 +0000
+-->
+

--- a/tests/data/healthstartsinthekitchen_com_the_worlds_best_paleo_breaded_shrimp_curl.html
+++ b/tests/data/healthstartsinthekitchen_com_the_worlds_best_paleo_breaded_shrimp_curl.html
@@ -1,0 +1,793 @@
+<!--
+ONETSP_URL: http://www.healthstartsinthekitchen.com/recipe/the-worlds-best-paleo-breaded-shrimp-made-with-tigernut-flour/
+ONETSP_USER_AGENT: curl
+ONETSP_TIME: Mon, 01 Feb 2016 21:01:07 +0000
+-->
+
+<!DOCTYPE html>
+<html lang="en-US" prefix="og: http://ogp.me/ns#">
+<head >
+<meta charset="UTF-8" />
+<title>The World&#039;s Best Paleo Breaded Shrimp {Made with TigerNut Flour}</title><meta name="viewport" content="width=device-width, initial-scale=1" />
+
+<!-- This site is optimized with the Yoast SEO plugin v3.0.7 - https://yoast.com/wordpress/plugins/seo/ -->
+<meta name="description" content="The World&#039;s Best Paleo Breaded Shrimp {Made with TigerNut Flour}"/>
+<meta name="robots" content="noodp"/>
+<link rel="canonical" href="http://www.healthstartsinthekitchen.com/recipe/the-worlds-best-paleo-breaded-shrimp-made-with-tigernut-flour/" />
+<meta property="og:locale" content="en_US" />
+<meta property="og:type" content="article" />
+<meta property="og:title" content="The World&#039;s Best Paleo Breaded Shrimp {Made with TigerNut Flour}" />
+<meta property="og:description" content="The World&#039;s Best Paleo Breaded Shrimp {Made with TigerNut Flour}" />
+<meta property="og:url" content="http://www.healthstartsinthekitchen.com/recipe/the-worlds-best-paleo-breaded-shrimp-made-with-tigernut-flour/" />
+<meta property="og:site_name" content="Health Starts in the Kitchen" />
+<meta property="article:author" content="www.facebook.com/hayleyryczek" />
+<meta property="article:tag" content="diary fee" />
+<meta property="article:tag" content="gluten free" />
+<meta property="article:tag" content="grain free" />
+<meta property="article:tag" content="low carb" />
+<meta property="article:tag" content="nut free" />
+<meta property="article:tag" content="paleo" />
+<meta property="article:tag" content="primal" />
+<meta property="article:tag" content="seed free" />
+<meta property="article:tag" content="soy free" />
+<meta property="article:tag" content="tiger nuts" />
+<meta property="article:tag" content="tigernut" />
+<meta property="article:section" content="Main Dish" />
+<meta property="og:image" content="http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/breaded-shrimp.jpg" />
+<!-- / Yoast SEO plugin. -->
+
+<link rel="alternate" type="application/rss+xml" title="Health Starts in the Kitchen &raquo; Feed" href="http://www.healthstartsinthekitchen.com/feed/" />
+<link rel="alternate" type="application/rss+xml" title="Health Starts in the Kitchen &raquo; Comments Feed" href="http://www.healthstartsinthekitchen.com/comments/feed/" />
+<link rel="alternate" type="application/rss+xml" title="Health Starts in the Kitchen &raquo; The World&#8217;s Best Paleo Breaded Shrimp {Made with TigerNut Flour} Comments Feed" href="http://www.healthstartsinthekitchen.com/recipe/the-worlds-best-paleo-breaded-shrimp-made-with-tigernut-flour/feed/" />
+<!-- This site is powered by Shareaholic - https://shareaholic.com -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+
+<!-- Shareaholic Content Tags -->
+<meta name='shareaholic:site_name' content='Health Starts in the Kitchen' />
+<meta name='shareaholic:language' content='en-US' />
+<meta name='shareaholic:url' content='http://www.healthstartsinthekitchen.com/recipe/the-worlds-best-paleo-breaded-shrimp-made-with-tigernut-flour/' />
+<meta name='shareaholic:keywords' content='diary fee, gluten free, grain free, low carb, nut free, paleo, primal, seed free, soy free, tiger nuts, tigernut, the world&amp;#039;s best paleo breaded shrimp {made with tigernut flour}, main dish, recipes' />
+<meta name='shareaholic:article_published_time' content='2015-10-07T15:21:08+00:00' />
+<meta name='shareaholic:article_modified_time' content='2016-02-01T18:02:09+00:00' />
+<meta name='shareaholic:shareable_page' content='true' />
+<meta name='shareaholic:article_author_name' content='Hayley Ryczek' />
+<meta name='shareaholic:site_id' content='9d9616e365e89c6d4bb38c5011b990f4' />
+<meta name='shareaholic:wp_version' content='7.6.2.3' />
+<meta name='shareaholic:image' content='http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/breaded-shrimp.jpg' />
+<!-- Shareaholic Content Tags End -->
+
+<!-- Shareaholic Open Graph Tags -->
+<meta property='og:image' content='http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/breaded-shrimp.jpg' />
+<!-- Shareaholic Open Graph Tags End -->
+		<!-- STRIPPED SCRIPT TAG -->
+		<style type="text/css">
+img.wp-smiley,
+img.emoji {
+	display: inline !important;
+	border: none !important;
+	box-shadow: none !important;
+	height: 1em !important;
+	width: 1em !important;
+	margin: 0 .07em !important;
+	vertical-align: -0.1em !important;
+	background: none !important;
+	padding: 0 !important;
+}
+</style>
+<link rel='stylesheet' id='pt-cv-bootstrap-style-css'  href='http://www.healthstartsinthekitchen.com/wp-content/plugins/content-views-query-and-display-post-page/assets/bootstrap/css/bootstrap.custom.css?ver=3.3.0' type='text/css' media='all' />
+<link rel='stylesheet' id='pt-cv-public-style-css'  href='http://www.healthstartsinthekitchen.com/wp-content/plugins/content-views-query-and-display-post-page/public/assets/css/public.css?ver=1.7.7' type='text/css' media='all' />
+<link rel='stylesheet' id='daily-dish-pro-theme-css'  href='http://www.healthstartsinthekitchen.com/wp-content/themes/daily-dish-pro/style.css?ver=1.0.2' type='text/css' media='all' />
+<link rel='stylesheet' id='contact-form-7-css'  href='http://www.healthstartsinthekitchen.com/wp-content/plugins/contact-form-7/includes/css/styles.css?ver=4.3.1' type='text/css' media='all' />
+<link rel='stylesheet' id='wpupg_style1-css'  href='http://www.healthstartsinthekitchen.com/wp-content/plugins/wp-ultimate-post-grid/css/filter.css?ver=1.9' type='text/css' media='all' />
+<link rel='stylesheet' id='wpupg_style2-css'  href='http://www.healthstartsinthekitchen.com/wp-content/plugins/wp-ultimate-post-grid/css/pagination.css?ver=1.9' type='text/css' media='all' />
+<link rel='stylesheet' id='wpupg_style3-css'  href='http://www.healthstartsinthekitchen.com/wp-content/plugins/wp-ultimate-post-grid/css/grid.css?ver=1.9' type='text/css' media='all' />
+<link rel='stylesheet' id='wpupg_style4-css'  href='http://www.healthstartsinthekitchen.com/wp-content/plugins/wp-ultimate-post-grid/css/layout_base.css?ver=1.9' type='text/css' media='all' />
+<link rel='stylesheet' id='wpurp_style1-css'  href='http://www.healthstartsinthekitchen.com/wp-content/plugins/wp-ultimate-recipe-premium/core/css/layout_base.css?ver=2.1.2' type='text/css' media='all' />
+<link rel='stylesheet' id='wpurp_style2-css'  href='http://www.healthstartsinthekitchen.com/wp-content/plugins/wp-ultimate-recipe-premium/core/vendor/select2/select2.css?ver=2.1.2' type='text/css' media='all' />
+<link rel='stylesheet' id='wpurp_style3-css'  href='http://www.healthstartsinthekitchen.com/wp-content/plugins/wp-ultimate-recipe-premium/premium/addons/user-menus/css/user-menus.css?ver=2.1.2' type='text/css' media='all' />
+<link rel='stylesheet' id='wpurp_style4-css'  href='http://www.healthstartsinthekitchen.com/wp-content/plugins/wp-ultimate-recipe-premium/premium/addons/user-ratings/css/user-ratings.css?ver=2.1.2' type='text/css' media='all' />
+<link rel='stylesheet' id='wpurp_style5-css'  href='http://fonts.googleapis.com/css?family=Open+Sans&#038;ver=2.1.2' type='text/css' media='all' />
+<link rel='stylesheet' id='wpurp_style6-css'  href='http://www.healthstartsinthekitchen.com/wp-content/plugins/wp-ultimate-recipe-premium/premium/addons/nutritional-information/css/nutrition-label.css?ver=2.1.2' type='text/css' media='all' />
+<link rel='stylesheet' id='jquery-pin-it-button-style-css'  href='http://www.healthstartsinthekitchen.com/wp-content/plugins/jquery-pin-it-button-for-images/css/style.css?ver=1.38a' type='text/css' media='all' />
+<link rel='stylesheet' id='dashicons-css'  href='http://www.healthstartsinthekitchen.com/wp-includes/css/dashicons.min.css?ver=4.4.1' type='text/css' media='all' />
+<link rel='stylesheet' id='daily-dish-google-fonts-css'  href='//fonts.googleapis.com/css?family=Alice%7CLato%3A400%2C700%2C900&#038;ver=1.0.2' type='text/css' media='all' />
+<link rel='stylesheet' id='mc4wp-form-basic-css'  href='http://www.healthstartsinthekitchen.com/wp-content/plugins/mailchimp-for-wp/assets/css/form-basic.min.css?ver=3.1' type='text/css' media='all' />
+<link rel='stylesheet' id='optimizepress-default-css'  href='http://www.healthstartsinthekitchen.com/wp-content/plugins/optimizePressPlugin/lib/assets/default.min.css?ver=2.5.3.1' type='text/css' media='all' />
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<link rel='https://api.w.org/' href='http://www.healthstartsinthekitchen.com/wp-json/' />
+<link rel="EditURI" type="application/rsd+xml" title="RSD" href="http://www.healthstartsinthekitchen.com/xmlrpc.php?rsd" />
+<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="http://www.healthstartsinthekitchen.com/wp-includes/wlwmanifest.xml" /> 
+<meta name="generator" content="WordPress 4.4.1" />
+<link rel='shortlink' href='http://www.healthstartsinthekitchen.com/?p=7480' />
+<link rel="alternate" type="application/json+oembed" href="http://www.healthstartsinthekitchen.com/wp-json/oembed/1.0/embed?url=http%3A%2F%2Fwww.healthstartsinthekitchen.com%2Frecipe%2Fthe-worlds-best-paleo-breaded-shrimp-made-with-tigernut-flour%2F" />
+<link rel="alternate" type="text/xml+oembed" href="http://www.healthstartsinthekitchen.com/wp-json/oembed/1.0/embed?url=http%3A%2F%2Fwww.healthstartsinthekitchen.com%2Frecipe%2Fthe-worlds-best-paleo-breaded-shrimp-made-with-tigernut-flour%2F&#038;format=xml" />
+<!-- Begin comScore Tag -->
+<!-- STRIPPED SCRIPT TAG -->
+<noscript>
+  <img src="http://b.scorecardresearch.com/p?c1=2&c2=20567959&cv=2.0&cj=1" />
+</noscript>
+<!-- End comScore Tag -->
+
+<!-- Yieldbot.com Intent Tag LOADING -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- Yieldbot.com Intent Tag ACTIVATION -->
+<!-- STRIPPED SCRIPT TAG -->
+
+<!-- Criteo RTA Header Script -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- End Criteo RTA Header Script -->
+
+<!-- STRIPPED SCRIPT TAG -->
+
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<style type='text/css'>
+	.wp-nutrition-label { border: 1px solid #ccc; font-family: helvetica, arial, sans-serif; font-size: .9em; width: 22em; padding: 1em 1.25em 1em 1.25em; line-height: 1.4em; margin: 1em; }
+	.wp-nutrition-label hr { border:none; border-bottom: solid 8px #666; margin: 3px 0px; }
+	.wp-nutrition-label .heading { font-size: 2.6em; font-weight: 900; margin: 0; line-height: 1em; }
+	.wp-nutrition-label .indent { margin-left: 1em; }
+	.wp-nutrition-label .small { font-size: .8em; line-height: 1.2em; }
+	.wp-nutrition-label .item_row { border-top: solid 1px #ccc; padding: 3px 0; }
+	.wp-nutrition-label .amount-per { padding: 0 0 8px 0; }
+	.wp-nutrition-label .daily-value { padding: 0 0 8px 0; font-weight: bold; text-align: right; border-top: solid 4px #666; }
+	.wp-nutrition-label .f-left { float: left; }
+	.wp-nutrition-label .f-right { float: right; }
+	.wp-nutrition-label .noborder { border: none; }
+	
+	.cf:before,.cf:after { content: " "; display: table;}
+	.cf:after { clear: both; }
+	.cf { *zoom: 1; }  
+</style>
+<style type="text/css"> .enews .screenread {
+	height: 1px;
+    left: -1000em;
+    overflow: hidden;
+    position: absolute;
+    top: -1000em;
+    width: 1px; } </style><!-- STRIPPED SCRIPT TAG -->
+		<!-- STRIPPED CONDITIONAL COMMENT -->
+
+		<style type="text/css">
+			a.pinit-button {
+				width: 75px !important;
+				height: 75px !important;
+				background: transparent url('http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/04/pinit.png') no-repeat 0 0 !important;
+				background-size: 75px 75px !important
+			}
+
+			a.pinit-button.pinit-top-left {
+				margin: 20px 0 0 20px			}
+
+			a.pinit-button.pinit-top-right {
+				margin: 20px 20px 0 0			}
+
+			a.pinit-button.pinit-bottom-left {
+				margin: 0 0 20px  20px			}
+
+			a.pinit-button.pinit-bottom-right {
+				margin: 0 20px  20px 0			}
+
+			img.pinit-hover {
+				opacity: 0.5 !important;
+				filter:alpha(opacity=50) !important; /* For IE8 and earlier */
+			}
+		</style>
+	<link rel="Shortcut Icon" href="http://www.healthstartsinthekitchen.com/wp-content/themes/daily-dish-pro/images/favicon.ico" type="image/x-icon" />
+<style type="text/css">.site-title a { background: url(http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/04/logo2.png) no-repeat !important; }</style>
+<!-- STRIPPED CONDITIONAL COMMENT -->
+<style type="text/css">/* MailChimp for WP - Checkbox Styles */
+.mc4wp-checkbox-wp-comment-form {
+  clear: both;
+  display: block;
+  position: static;
+  width: auto; }
+  .mc4wp-checkbox-wp-comment-form input {
+    float: none;
+    width: auto;
+    position: static;
+    margin: 0 6px 0 0;
+    padding: 0;
+    vertical-align: middle;
+    display: inline-block !important;
+    max-width: 21px;
+    -webkit-appearance: checkbox; }
+  .mc4wp-checkbox-wp-comment-form label {
+    float: none;
+    display: block;
+    cursor: pointer;
+    width: auto;
+    position: static; }
+</style><style type="text/css">/* MailChimp for WP - Checkbox Styles */
+.mc4wp-checkbox-wp-registration-form {
+  clear: both;
+  display: block;
+  position: static;
+  width: auto; }
+  .mc4wp-checkbox-wp-registration-form input {
+    float: none;
+    width: auto;
+    position: static;
+    margin: 0 6px 0 0;
+    padding: 0;
+    vertical-align: middle;
+    display: inline-block !important;
+    max-width: 21px;
+    -webkit-appearance: checkbox; }
+  .mc4wp-checkbox-wp-registration-form label {
+    float: none;
+    display: block;
+    cursor: pointer;
+    width: auto;
+    position: static; }
+</style>
+        <!-- STRIPPED CONDITIONAL COMMENT -->
+        <!-- STRIPPED CONDITIONAL COMMENT -->
+    <style type="text/css" id="custom-background-css">
+body.custom-background { background-image: url('http://www.healthstartsinthekitchen.com/wp-content/themes/daily-dish-pro/images/bg.png'); background-repeat: repeat; background-position: top left; background-attachment: fixed; }
+</style>
+</head>
+<body class="single single-recipe postid-7480 custom-background op-plugin custom-header header-image content-sidebar" itemscope itemtype="http://schema.org/WebPage"><div class="before-header"><div class="wrap"><section id="text-41" class="widget widget_text"><div class="widget-wrap">			<div class="textwidget"><div style="width:728px; margin:0 auto; position:relative" class="hideme"><!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG --> 
+</div>
+</div>
+		</div></section>
+</div></div><div class="site-container"><header class="site-header" itemscope itemtype="http://schema.org/WPHeader"><div class="wrap"><aside class="widget-area header-widget-area"><section id="search-1" class="widget widget_search"><div class="widget-wrap"><form class="search-form" itemprop="potentialAction" itemscope itemtype="http://schema.org/SearchAction" method="get" action="http://www.healthstartsinthekitchen.com/" role="search"><meta itemprop="target" content="http://www.healthstartsinthekitchen.com/?s={s}"/><input itemprop="query-input" type="search" name="s" placeholder="Search this website &#x2026;" /><input type="submit" value="Search"  /></form></div></section>
+</aside><div class="title-area"><p class="site-title" itemprop="headline"><a href="http://www.healthstartsinthekitchen.com/">Health Starts in the Kitchen</a></p><p class="site-description" itemprop="description">Helping to Make the World a Healthier Place, One Kitchen at a Time!</p></div></div></header><nav class="nav-primary" itemscope itemtype="http://schema.org/SiteNavigationElement"><div class="wrap"><ul id="menu-primary" class="menu genesis-nav-menu menu-primary"><li id="menu-item-6044" class="recipes menu-item menu-item-type-taxonomy menu-item-object-category current-recipe-ancestor current-menu-parent current-recipe-parent menu-item-has-children menu-item-6044"><a href="http://www.healthstartsinthekitchen.com/category/recipes/" itemprop="url"><span itemprop="name">Recipes</span></a>
+<ul class="sub-menu">
+	<li id="menu-item-6049" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-6049"><a href="http://www.healthstartsinthekitchen.com/category/recipes/snacks-appetizers/" itemprop="url"><span itemprop="name">Appetizers &#038; Snacks</span></a></li>
+	<li id="menu-item-6050" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-6050"><a href="http://www.healthstartsinthekitchen.com/category/recipes/beverages-drinks/" itemprop="url"><span itemprop="name">Beverages &#038; Drinks</span></a></li>
+	<li id="menu-item-6056" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-6056"><a href="http://www.healthstartsinthekitchen.com/category/recipes/breads/" itemprop="url"><span itemprop="name">Breads</span></a></li>
+	<li id="menu-item-6057" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-6057"><a href="http://www.healthstartsinthekitchen.com/category/recipes/breakfast-recipes/" itemprop="url"><span itemprop="name">Breakfast</span></a></li>
+	<li id="menu-item-6051" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-6051"><a href="http://www.healthstartsinthekitchen.com/category/recipes/condiments-sauces-dressings/" itemprop="url"><span itemprop="name">Condiments, Sauces &#038; Dressings</span></a></li>
+	<li id="menu-item-6052" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-6052"><a href="http://www.healthstartsinthekitchen.com/category/recipes/desserts-sweets-treats/" itemprop="url"><span itemprop="name">Desserts, Sweets &#038; Treats</span></a></li>
+	<li id="menu-item-6053" class="menu-item menu-item-type-taxonomy menu-item-object-category current-recipe-ancestor current-menu-parent current-recipe-parent menu-item-6053"><a href="http://www.healthstartsinthekitchen.com/category/recipes/main-dish/" itemprop="url"><span itemprop="name">Main Dish</span></a></li>
+	<li id="menu-item-6058" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-6058"><a href="http://www.healthstartsinthekitchen.com/category/recipes/pressure-cooker-recipes/" itemprop="url"><span itemprop="name">Pressure Cooker</span></a></li>
+	<li id="menu-item-6059" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-6059"><a href="http://www.healthstartsinthekitchen.com/category/recipes/recipe-round-ups/" itemprop="url"><span itemprop="name">Recipe Round-Ups</span></a></li>
+	<li id="menu-item-6060" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-6060"><a href="http://www.healthstartsinthekitchen.com/category/recipes/soups/" itemprop="url"><span itemprop="name">Soups &#038; Stews</span></a></li>
+	<li id="menu-item-6054" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-6054"><a href="http://www.healthstartsinthekitchen.com/category/recipes/veggies-sidedishes-salads/" itemprop="url"><span itemprop="name">Veggies, Side Dishes &#038; Salads</span></a></li>
+</ul>
+</li>
+<li id="menu-item-6048" class="homestead menu-item menu-item-type-taxonomy menu-item-object-category menu-item-has-children menu-item-6048"><a href="http://www.healthstartsinthekitchen.com/category/ryczek-homestead/" itemprop="url"><span itemprop="name">Ryczek Homestead</span></a>
+<ul class="sub-menu">
+	<li id="menu-item-6064" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-6064"><a href="http://www.healthstartsinthekitchen.com/category/ryczek-homestead/backyard-chickens/" itemprop="url"><span itemprop="name">Backyard Chickens &#038; Turkeys</span></a></li>
+	<li id="menu-item-6065" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-6065"><a href="http://www.healthstartsinthekitchen.com/category/ryczek-homestead/foraging/" itemprop="url"><span itemprop="name">Foraging &#038; Wild Edibles</span></a></li>
+	<li id="menu-item-6066" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-6066"><a href="http://www.healthstartsinthekitchen.com/category/ryczek-homestead/organic-gardening-ourhomestead/" itemprop="url"><span itemprop="name">Organic Gardening</span></a></li>
+	<li id="menu-item-6067" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-6067"><a href="http://www.healthstartsinthekitchen.com/category/ryczek-homestead/preserving-food/" itemprop="url"><span itemprop="name">Preserving Food (Canning, Drying &#038; Fermenting)</span></a></li>
+</ul>
+</li>
+<li id="menu-item-6045" class="natural menu-item menu-item-type-taxonomy menu-item-object-category menu-item-has-children menu-item-6045"><a href="http://www.healthstartsinthekitchen.com/category/natural-living/" itemprop="url"><span itemprop="name">Natural Living</span></a>
+<ul class="sub-menu">
+	<li id="menu-item-6061" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-6061"><a href="http://www.healthstartsinthekitchen.com/category/natural-living/essential-oils-2/" itemprop="url"><span itemprop="name">Essential Oils</span></a></li>
+	<li id="menu-item-6055" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-6055"><a href="http://www.healthstartsinthekitchen.com/category/natural-living/beauty/" itemprop="url"><span itemprop="name">Natural Beauty</span></a></li>
+	<li id="menu-item-6062" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-6062"><a href="http://www.healthstartsinthekitchen.com/category/natural-living/natural-home/" itemprop="url"><span itemprop="name">Natural Home</span></a></li>
+	<li id="menu-item-6063" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-6063"><a href="http://www.healthstartsinthekitchen.com/category/natural-living/natural-pet-care/" itemprop="url"><span itemprop="name">Natural Pet Care</span></a></li>
+</ul>
+</li>
+<li id="menu-item-6046" class="health and wellness menu-item menu-item-type-taxonomy menu-item-object-category menu-item-6046"><a href="http://www.healthstartsinthekitchen.com/category/health-and-wellness/" itemprop="url"><span itemprop="name">Health &#038; Wellness</span></a></li>
+<li id="menu-item-6047" class="resources menu-item menu-item-type-taxonomy menu-item-object-category menu-item-has-children menu-item-6047"><a href="http://www.healthstartsinthekitchen.com/category/resources/" itemprop="url"><span itemprop="name">Resources</span></a>
+<ul class="sub-menu">
+	<li id="menu-item-7453" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-7453"><a href="http://www.healthstartsinthekitchen.com/shop-nyr-organic/" itemprop="url"><span itemprop="name">NYR Organic</span></a></li>
+	<li id="menu-item-7452" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-7452"><a href="http://www.healthstartsinthekitchen.com/shop-young-living-essential-oils/" itemprop="url"><span itemprop="name">Young Living Essential Oils</span></a></li>
+	<li id="menu-item-7456" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-7456"><a href="http://www.healthstartsinthekitchen.com/shop-thrive-market/" itemprop="url"><span itemprop="name">Thrive Market</span></a></li>
+	<li id="menu-item-6068" class="menu-item menu-item-type-taxonomy menu-item-object-category menu-item-6068"><a href="http://www.healthstartsinthekitchen.com/category/resources/productbook-reviews/" itemprop="url"><span itemprop="name">Recommended Products &#038; Books</span></a></li>
+</ul>
+</li>
+<li id="menu-item-7240" class="books menu-item menu-item-type-custom menu-item-object-custom menu-item-has-children menu-item-7240"><a href="#" itemprop="url"><span itemprop="name">My Books</span></a>
+<ul class="sub-menu">
+	<li id="menu-item-7241" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-7241"><a href="http://www.healthstartsinthekitchen.com/without-grain" itemprop="url"><span itemprop="name">Without Grain</span></a></li>
+	<li id="menu-item-7242" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-7242"><a href="http://amzn.to/1L0crEy" itemprop="url"><span itemprop="name">Fermented Foods at Every Meal</span></a></li>
+	<li id="menu-item-7243" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-7243"><a href="http://www.healthstartsinthekitchen.com/salads-without-grain-ebook" itemprop="url"><span itemprop="name">Salads Without Grain</span></a></li>
+	<li id="menu-item-7244" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-7244"><a href="http://www.healthstartsinthekitchen.com/gf-grab-n-go-ebook/" itemprop="url"><span itemprop="name">GF Grab-N-Go&#8217;s</span></a></li>
+</ul>
+</li>
+</ul></div></nav><div class="site-inner"><div class="content-sidebar-wrap"><main class="content"><article class="post-7480 recipe type-recipe status-publish has-post-thumbnail category-main-dish category-recipes tag-diary-fee tag-gluten-free-2 tag-grain-free tag-low-carb tag-nut-free tag-paleo tag-primal tag-seed-free tag-soy-free-2 tag-tiger-nuts tag-tigernut ingredient-cocktail-sauce ingredient-eggs ingredient-frozen-wild-caught-shrimp-16-20-count ingredient-lard ingredient-potato-starch ingredient-sea-salt ingredient-seasoned-salt ingredient-tigernut-flour post type-post entry" itemscope itemtype="http://schema.org/CreativeWork"><header class="entry-header"><h1 class="entry-title" itemprop="headline">The World&#8217;s Best Paleo Breaded Shrimp {Made with TigerNut Flour}</h1> 
+<p class="entry-meta"><time class="entry-time" itemprop="datePublished" datetime="2015-10-07T11:21:08+00:00">October 7, 2015</time> <span class="entry-author" itemprop="author" itemscope itemtype="http://schema.org/Person"><a href="http://www.healthstartsinthekitchen.com/author/admin/" class="entry-author-link" itemprop="url" rel="author"><span class="entry-author-name" itemprop="name">Hayley Ryczek</span></a></span> <span class="entry-comments-link"><a href="http://www.healthstartsinthekitchen.com/recipe/the-worlds-best-paleo-breaded-shrimp-made-with-tigernut-flour/#respond">Leave a Comment</a></span> </p></header><div class="entry-content" itemprop="text"><input class="jpibfi" type="hidden" ><div class='shareaholic-canvas' data-app-id='20703020' data-app='share_buttons' data-title='The World&#039;s Best Paleo Breaded Shrimp {Made with TigerNut Flour}' data-link='http://www.healthstartsinthekitchen.com/recipe/the-worlds-best-paleo-breaded-shrimp-made-with-tigernut-flour/' data-summary=''></div><h2><img class="alignnone size-full wp-image-7483" src="http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/breaded-shrimp.jpg" alt="Grain-Free Breaded Shrimp {Made with Tiger Nut Flour}" width="720" height="480" srcset="http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/breaded-shrimp-150x100.jpg 150w, http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/breaded-shrimp-600x400.jpg 600w, http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/breaded-shrimp-300x200.jpg 300w, http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/breaded-shrimp.jpg 720w" sizes="(max-width: 720px) 100vw, 720px" /></h2>
+<p>It&#8217;s just basic math, I was craving breaded, fried shrimp and I just got an amazing box of <a href="http://www.organicgemini.com?rfsn=131091.6879">TigerNut goodies from Organic Gemini</a>, 1+1=2&#8230;.. and that my friends is how The World’s Best Paleo Breaded Shrimp {Made with TigerNut Flour} was made!</p>
+<h2>What is a TigerNut?</h2>
+<p>While they are called &#8220;nuts,&#8221; these cute little round tubers are actually the root from the chufa sedge plant. <a href="http://www.organicgemini.com?rfsn=131091.6879">TigerNuts</a> comprised up to 80% of our Paleo ancestors’ diet around 2 million years ago (according to an Oxford University study).</p>
+<p><strong><a href="http://www.organicgemini.com?rfsn=131091.6879">TigerNuts</a> are one of the few remaining truly &#8216;<em>Paleo&#8217;</em> foods still available in today&#8217;s modern world!</strong></p>
+<p><img class="alignnone size-full wp-image-7503" src="http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/tigernuts.jpg" alt="Grain-Free Breaded Shrimp {Made with TigerNut Flour}" width="720" height="482" srcset="http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/tigernuts-600x402.jpg 600w, http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/tigernuts-300x201.jpg 300w, http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/tigernuts.jpg 720w" sizes="(max-width: 720px) 100vw, 720px" /></p>
+<p><a href="http://www.organicgemini.com?rfsn=131091.6879">TigerNuts</a> are often soaked in warm water before being eaten, and they have a sweet, nutty flavor. In Spain they are used to make horchata, a sugary, milky drink. In fact, it can make for a good milk substitute for those who are lactose intolerant or vegan. <a href="http://www.organicgemini.com?rfsn=131091.6879">TigerNuts</a> can also be ground into a flour or eaten raw. They have a deliciously sweet, nutty taste.</p>
+<h3>3 reasons YOU should include <a href="http://www.organicgemini.com?rfsn=131091.6879">TigerNuts</a> in your diet:</h3>
+<ol>
+<li><strong>Resistant Starch: <a href="http://www.organicgemini.com?rfsn=131091.6879">TigerNuts</a></strong> are the #1 source of <a href="http://www.marksdailyapple.com/the-definitive-guide-to-resistant-starch/#axzz3ntEraPrg">Resistant Starch</a>. Resistant starch is a highly beneficial pre-biotic, which means it feeds the good bacteria in your digestive tract. In addition to their delicious flavor, the resistant starch found in tiger nuts is the best reason to include them in your diet on a regular basis. One ounce of <a href="http://www.organicgemini.com?rfsn=131091.6879">TigerNuts</a> has 40% of daily recommend fiber.</li>
+<li><strong>Healthy Fats: </strong>Unlike other starchy vegetable tubers (like potatoes), <a href="http://www.organicgemini.com?rfsn=131091.6879">TigerNuts</a> are an excellent source of healthy fats. <a href="http://www.organicgemini.com?rfsn=131091.6879">TigerNuts</a> have a fatty acid composition similar to olive oil, with the fat composition being about 73% monounsaturated fat, 18% saturated fat and 9% polyunsaturated fat.</li>
+<li>Allergen free: <a href="http://www.organicgemini.com?rfsn=131091.6879">TigerNuts</a> allergies are probably one of the rarest food allergies/intolerences, EVER. Since they are a tuber, tigernuts are completely soy, dairy, grain, nut, seed free.</li>
+</ol>
+<h2>Why choose <a href="http://www.organicgemini.com?rfsn=131091.6879">Organic Gemini TigerNuts</a>??</h2>
+<p>First of all <a href="http://www.organicgemini.com?rfsn=131091.6879">Organic Gemini</a> is the only USDA-Organic Certified <a href="http://www.organicgemini.com?rfsn=131091.6879">TigerNu</a>t Company in the USA, which is pretty freaking awesome on it&#8217;s own&#8230;.but they are also certified GMO-Free, Kosher, Vegan. Further, <a href="http://www.organicgemini.com?rfsn=131091.6879">Organic Gemini</a> has a dedicated gluten-free, peanut-free and tree nut-free facility to prevent cross-contamination.</p>
+<h2><img class="alignnone size-full wp-image-7509" src="http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/Screen-Shot-2015-10-07-at-10.41.21-AM.png" alt="WE ARE THE ONLY USDA-ORGANIC CERTIFIED TIGERNUT COMPANY IN THE USA" width="972" height="206" srcset="http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/Screen-Shot-2015-10-07-at-10.41.21-AM-150x32.png 150w, http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/Screen-Shot-2015-10-07-at-10.41.21-AM-600x127.png 600w, http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/Screen-Shot-2015-10-07-at-10.41.21-AM-300x64.png 300w, http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/Screen-Shot-2015-10-07-at-10.41.21-AM.png 972w" sizes="(max-width: 972px) 100vw, 972px" />How to eat <a href="http://www.organicgemini.com?rfsn=131091.6879">TigerNuts</a>:</h2>
+<p><a href="http://www.organicgemini.com?rfsn=131091.6879">TigerNuts</a> can be eaten whole, raw (their texture is like as if a nut and a gummy bear had a baby, not hard but not soft, pleasantly chewy) or soaked for 12+ hours in water then drained and eaten rehydrated.  I keep a jar of them on the counter and snack on them in the morning while I&#8217;m making my coffee or tea.</p>
+<p><a href="http://www.organicgemini.com?rfsn=131091.6879">Organic Gemini</a> also makes<a href="http://www.organicgemini.com?rfsn=131091.6879"> TigerNut Granola </a>and <a href="http://www.organicgemini.com?rfsn=131091.6879">TigerNut Snacks</a> to make <a href="http://www.organicgemini.com?rfsn=131091.6879">TigerNut</a> eating even easier!</p>
+<p><img class="alignnone wp-image-7508 size-full" src="http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/Screen-Shot-2015-10-07-at-10.37.36-AM.png" alt="Grain-Free Breaded Shrimp {Made with TigerNut Flour}" width="1746" height="680" srcset="http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/Screen-Shot-2015-10-07-at-10.37.36-AM-1024x399.png 1024w, http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/Screen-Shot-2015-10-07-at-10.37.36-AM-600x234.png 600w, http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/Screen-Shot-2015-10-07-at-10.37.36-AM-300x117.png 300w, http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/Screen-Shot-2015-10-07-at-10.37.36-AM.png 1746w" sizes="(max-width: 1746px) 100vw, 1746px" /></p>
+<p>You can also prepare a traditional beverage called <strong>Horchata</strong>. After soaking, the tigernuts are blended with water and a dash of sweetener to create a creamy and dairy-free drink (think of it as tiger nut milk) It’s a creamy, dreamy treat… you’ll be hooked once you try it!  The <em>Unsweetened</em> version is just tigernuts and filtered water. The <em>Original</em> gets a touch of sweetness from organic date, but my favorite is the Strawberry!</p>
+<p><img class="alignnone wp-image-7507 size-full" src="http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/12068465_889062151188689_1134955536528376131_o-2.jpg" alt="Grain-Free Breaded Shrimp {Made with TigerNut Flour}" width="2048" height="1428" srcset="http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/12068465_889062151188689_1134955536528376131_o-2-1024x714.jpg 1024w, http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/12068465_889062151188689_1134955536528376131_o-2-600x418.jpg 600w, http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/12068465_889062151188689_1134955536528376131_o-2-300x209.jpg 300w, http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/12068465_889062151188689_1134955536528376131_o-2.jpg 2048w" sizes="(max-width: 2048px) 100vw, 2048px" /></p>
+<p><span class="a-list-item">Recently, <a href="http://www.organicgemini.com?rfsn=131091.6879">Organic Gemini</a> has started offering<a href="http://www.organicgemini.com?rfsn=131091.6879"> TigerNut Oil</a>. (I have not tired it.. YET!) This high quality oil is extracted by a cold, virgin process in order to ensure that it retains all the unique nutritious qualities of the TigerNut itself. The oil is golden brown in color and has a slight nutty taste. <a href="http://www.organicgemini.com?rfsn=131091.6879">TigerNut Oil</a> was first used by Egyptians 4,000 years ago and is generally considered a healthier alternative. Highly recommended for cooking above other oils because it is more resistant to chemical decomposition at high temperatures.</span> TigerNut oil is also a fantastic component of beauty products. It has a high oleic acid content and low acidity and is excellent for the skin!</p>
+<p>And while I love to snack on tiger nuts often, my favorite way to get them into my diet is with <a href="http://www.organicgemini.com?rfsn=131091.6879">Organic Gemini&#8217;s TigerNut Flour</a>!</p>
+<p>Whole, raw TigerNuts can also be finely ground into a grain-free Flour that can be used 1:1 in place of regular white flour. It&#8217;s one of the BEST all around healthy grain-free flours available!</p>
+<p><strong>&#8230;and <a href="http://www.organicgemini.com?rfsn=131091.6879">TigerNut Flour</a> is my current OBSESSION!</strong><a href="http://www.organicgemini.com?rfsn=131091.6879"><img class="alignnone size-full wp-image-7505" src="http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/Screen-Shot-2015-10-07-at-10.27.28-AM.png" alt="Grain-Free Breaded Shrimp {Made with TigerNut Flour}" width="780" height="1060" srcset="http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/Screen-Shot-2015-10-07-at-10.27.28-AM-754x1024.png 754w, http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/Screen-Shot-2015-10-07-at-10.27.28-AM-150x204.png 150w, http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/Screen-Shot-2015-10-07-at-10.27.28-AM-600x815.png 600w, http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/Screen-Shot-2015-10-07-at-10.27.28-AM-300x408.png 300w, http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/Screen-Shot-2015-10-07-at-10.27.28-AM.png 780w" sizes="(max-width: 780px) 100vw, 780px" /></a></p>
+<p>The main reason I&#8217;m so in LOVE with<a href="http://www.organicgemini.com?rfsn=131091.6879"> TigerNut flour</a> is that it&#8217;s so widely tolerated by so many ways of eating! So often I get comments about readers wanting recipes that are nut-free, or coconut-free or even low-carb/diabetic friendly, <a href="http://www.organicgemini.com?rfsn=131091.6879">TigerNut Flou</a>r covers all bases!</p>
+<p>Recently, I found out that it&#8217;s best that I also avoid almond flour so I&#8217;m personally on a crusade to switch to a healthier alternative flour for my own personal paleo template!</p>
+<p>While <a href="http://www.organicgemini.com?rfsn=131091.6879http://www.organicgemini.com?rfsn=131091.6879">TigerNuts</a> are technically a starch, remember that they are full of fiber &amp; resistant starch which prevents them from having a negative impact on your blood sugar and the carbohydrates are indigestible.</p>
+<h3><strong>What do TigerNuts Taste like?</strong></h3>
+<p>TigerNuts have a delicious, sweet flavor.. with the texture of a nut and a hit of vanilla. Most often when searching for TigerNut Flour recipes you&#8217;ll find them used in sweet dishes, but don&#8217;t let the sweetness scare you away from using them in savory dishes like these Breaded Shrimp!</p>
+<p><img class="alignnone size-full wp-image-7481" src="http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/breaded-shrimp-3.jpg" alt="Grain-Free Breaded Shrimp {Made with Tiger Nut Flour}" width="720" height="1080" srcset="http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/breaded-shrimp-3-683x1024.jpg 683w, http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/breaded-shrimp-3-150x225.jpg 150w, http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/breaded-shrimp-3-600x900.jpg 600w, http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/breaded-shrimp-3-300x450.jpg 300w, http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/breaded-shrimp-3.jpg 720w" sizes="(max-width: 720px) 100vw, 720px" /></p>
+<p>All you have to do it adequately season your <a href="http://www.organicgemini.com?rfsn=131091.6879">TigerNut flour</a> to balance out the sweetness, in The World’s Best Paleo Breaded Shrimp {Made with TigerNut Flour} <span style="line-height: 1.5;">you&#8217;ll see how beautifully the sweet flour with the savory seasonings work together!</span></p>
+<p>After enjoying The World’s Best Paleo Breaded Shrimp {Made with TigerNut Flour}, Ray and I have been obsessed with fun new ideas to test out with TigerNut Flour &#8211; this weekend I&#8217;ll be using the same breading on some Rock Fish we have in our freezer from our Cheaspeake Bay fishing trip over the summer, and I&#8217;m sure it will be just as delicious.</p>
+<p><img class="alignnone size-full wp-image-7482" src="http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/breaded-shrimp-2.jpg" alt="Grain-Free Breaded Shrimp {Made with Tiger Nut Flour}" width="720" height="1080" srcset="http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/breaded-shrimp-2-683x1024.jpg 683w, http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/breaded-shrimp-2-150x225.jpg 150w, http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/breaded-shrimp-2-600x900.jpg 600w, http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/breaded-shrimp-2-300x450.jpg 300w, http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/breaded-shrimp-2.jpg 720w" sizes="(max-width: 720px) 100vw, 720px" /></p>
+<p>To purchase Organic Gemini TigerNut flour and other TigerNut products you can visit their website <a href="http://www.organicgemini.com?rfsn=131091.6879">HERE</a> or on <a href="http://amzn.to/1OY5kPo">Amazon.com</a></p>
+<p>Oh and whatever you do, please DON&#8217;T use bottled cocktail to serve with The World’s Best Paleo Breaded Shrimp {Made with TigerNut Flour}!!  <a href="http://www.healthstartsinthekitchen.com/2012/12/25/gram-elsies-cocktail-sauce/">Click HERE to get my Gram Elsie&#8217;s Homemade Cocktail Sauce Recipe</a> and/or get the recipe for my <a href="http://amzn.to/1Q7I5A2">Fermented Cocktail Sauce HERE</a>.</p>
+<p><div itemscope itemtype="http://schema.org/Recipe" id="wpurp-container-recipe-7480" data-servings-original="4" class="wpurp-container" style="margin:0 auto;padding-top:10px;padding-bottom:10px;padding-left:10px;padding-right:10px;max-width:600px;position:static;border-width:1px 1px 1px 1px;border-color:#bbbbbb;border-style:solid;vertical-align:inherit;font-size:14px;color:#444444;font-family:Open Sans, sans-serif;background:url(http://www.healthstartsinthekitchen.com/wp-content/plugins/wp-ultimate-recipe-premium/core/addons/custom-templates/img/default.png);">
+    <meta itemprop="author" content="Hayley Ryczek">
+    <meta itemprop="datePublished" content="2015-10-07 11:21:08">
+    <meta itemprop="image" content="http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/breaded-shrimp.jpg">
+    <meta itemprop="name" content="Grain-Free Breaded Shrimp {Made with TigerNut Flour}">
+    <meta itemprop="description" content="">
+    <meta itemprop="recipeYield" content=" ">
+        
+    <meta itemprop="ingredients" content="1/2 cup potato starch (or arrowroot/tapioca)"><meta itemprop="ingredients" content="1 teaspoon sea salt"><meta itemprop="ingredients" content="2 large  eggs (beaten)"><meta itemprop="ingredients" content="1 cup TigerNut Flour"><meta itemprop="ingredients" content="1 tablespoon seasoned salt"><meta itemprop="ingredients" content="1 pound frozen wild caught shrimp, 16-20 count (peeled &amp; deveined)"><meta itemprop="ingredients" content="--  lard (or other fat for frying)"><meta itemprop="ingredients" content="--  cocktail sauce (optional, for serving)"><meta itemprop="recipeInstructions" content="Create a breading station, using 3 bowls. "><meta itemprop="recipeInstructions" content="In bowl #1 combine potato starch and 1 teaspoon sea salt. "><meta itemprop="recipeInstructions" content="In bowl #2 gently whisk eggs with a splash of water"><meta itemprop="recipeInstructions" content="In bowl #3 combine tigernut flour with seasoned salt"><meta itemprop="recipeInstructions" content="Dip each shrimp first in the starch, then the egg, then the tigernut flour.  Making sure the shrimp are completely coated."><meta itemprop="recipeInstructions" content="Arrange each breaded shrimp in a single layer on a wax paper lined plate. "><meta itemprop="recipeInstructions" content="After all shrimp are breaded, FREEZE them for 30 minutes. (this ensures the breaded stays completely adhered to the food, use this trick for all breaded meats/seafood)"><meta itemprop="recipeInstructions" content="While your shrimp are in the freezer, prepare your fat for frying. I suggest using about 3/4 of an inch of lard in a cast iron skillet. "><meta itemprop="recipeInstructions" content="Heat your fat to roughly 325 degrees, then working batches, fry your shrimp until golden brown and crisp, roughly 2 minutes. Do not over cook your shrimp, they will become dry and chewy. "><meta itemprop="recipeInstructions" content="Drain fried shrimp on a paper towel lined and season with additional sea salt. Serve with cocktail sauce, if desired.">
+    <div itemprop="nutrition" itemscope itemtype="http://schema.org/NutritionInformation"></div>
+    <div class="wpurp-rows" style="position:static;text-align:inherit;vertical-align:inherit;">
+            <div class="wpurp-rows-row" style="height:auto;">
+        <div class="wpurp-responsive-mobile">
+    <div class="wpurp-columns" style="position:static;text-align:inherit;vertical-align:inherit;">
+                                                        <div class="wpurp-rows-row">
+                        <div class="wpurp-rows" style="margin:0 auto;margin-bottom:10px;position:static;text-align:center;vertical-align:inherit;">
+            <div class="wpurp-rows-row" style="height:auto;">
+        <div>
+        <img src="http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/breaded-shrimp-150x150.jpg" alt="Grain-Free Breaded Shrimp {Made with Tiger Nut Flour}" title="breaded shrimp" class="wpurp-recipe-image" style="padding-top:5px;padding-bottom:5px;padding-left:5px;padding-right:5px;width:150px;height:150px;position:static;background-color:#ffffff;border-width:1px 1px 1px 1px;border-color:#666666;border-style:solid;-webkit-box-shadow:2px 2px 2px  rgba(50,50,50,0.5) ;-moz-box-shadow:2px 2px 2px  rgba(50,50,50,0.5) ;box-shadow:2px 2px 2px  rgba(50,50,50,0.5) ;text-align:inherit;vertical-align:inherit;" />
+    </div>
+    </div>
+        </div>
+                    </div>
+                                                                <div class="wpurp-rows-row">
+                                            </div>
+                                                                <div class="wpurp-rows-row">
+                        <div class="wpurp-rows" style="position:static;text-align:inherit;vertical-align:inherit;">
+            <div class="wpurp-rows-row" style="height:auto;">
+        <span class="wpurp-recipe-title" style="margin-bottom:10px;padding-bottom:0px;position:static;text-align:inherit;vertical-align:inherit;font-weight:bold;font-size:1.4em;line-height:1.4em;">Grain-Free Breaded Shrimp {Made with TigerNut Flour}</span><span class="wpurp-box" style="float:right;position:static;text-align:inherit;vertical-align:inherit;">
+    <table class="wpurp-columns" style="position:static;text-align:inherit;vertical-align:inherit;">
+    <tbody>
+    <tr>
+                        <td style="vertical-align:top;text-align:inherit;width:auto;">
+            <span class="wpurp-recipe-stars" style="margin-right:0px;position:static;text-align:inherit;vertical-align:inherit;"></span>        </td>
+                                <td style="vertical-align:top;text-align:inherit;width:auto;">
+            <a href="#" class="wpurp-recipe-print-button" style="color: #9bbd35;margin-left:5px;position:static;text-align:inherit;vertical-align:inherit;" data-recipe-id="7480"><img src="http://www.healthstartsinthekitchen.com/wp-content/plugins/wp-ultimate-recipe-premium/core/img/printer.png"></a>
+        </td>
+                    </tr>
+    </tbody>
+</table>
+</span>
+    </div>
+                <div class="wpurp-rows-row" style="height:auto;">
+        <span class="wpurp-recipe-description" style="margin-bottom:20px;position:static;text-align:inherit;vertical-align:inherit;line-height:1.4em;"></span>    </div>
+                <div class="wpurp-rows-row" style="height:auto;">
+        <ul class="wpurp-recipe-tags" style="position:static;text-align:inherit;vertical-align:inherit;">
+    </ul>
+    </div>
+                <div class="wpurp-rows-row" style="height:auto;">
+        <div class="wpurp-responsive-mobile">
+    <div class="wpurp-columns" style="position:static;text-align:inherit;vertical-align:inherit;">
+                                                        <div class="wpurp-rows-row">
+                        <table class="wpurp-table" style="width:100%;margin-top:20px;position:static;text-align:inherit;vertical-align:inherit;">
+    <tbody>
+                        <tr>
+                                                                                                    </tr>
+                                <tr>
+                                                                                                    </tr>
+                </tbody>
+</table>
+                    </div>
+                                                                <div class="wpurp-rows-row">
+                        <table class="wpurp-table" style="width:100%;margin-top:20px;position:static;text-align:inherit;vertical-align:inherit;">
+    <tbody>
+                        <tr>
+                                                                                                    </tr>
+                                <tr>
+                                                                                                    </tr>
+                </tbody>
+</table>
+                    </div>
+                                        </div>
+</div>
+<div class="wpurp-responsive-desktop">
+<table class="wpurp-columns" style="position:static;text-align:inherit;vertical-align:inherit;">
+    <tbody>
+    <tr>
+                        <td style="vertical-align:top;text-align:inherit;width:50%;">
+            <table class="wpurp-table" style="width:100%;margin-top:20px;position:static;text-align:inherit;vertical-align:inherit;">
+    <tbody>
+                        <tr>
+                                                                                                    </tr>
+                                <tr>
+                                                                                                    </tr>
+                </tbody>
+</table>
+        </td>
+                                <td style="vertical-align:top;text-align:inherit;width:auto;">
+            <table class="wpurp-table" style="width:100%;margin-top:20px;position:static;text-align:inherit;vertical-align:inherit;">
+    <tbody>
+                        <tr>
+                                                                                                    </tr>
+                                <tr>
+                                                                                                    </tr>
+                </tbody>
+</table>
+        </td>
+                    </tr>
+    </tbody>
+</table>
+</div>    </div>
+        </div>
+                    </div>
+                                        </div>
+</div>
+<div class="wpurp-responsive-desktop">
+<table class="wpurp-columns" style="position:static;text-align:inherit;vertical-align:inherit;">
+    <tbody>
+    <tr>
+                        <td style="vertical-align:top;text-align:inherit;width:150px;">
+            <div class="wpurp-rows" style="margin:0 auto;margin-bottom:10px;position:static;text-align:center;vertical-align:inherit;">
+            <div class="wpurp-rows-row" style="height:auto;">
+        <div>
+        <img src="http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/breaded-shrimp-150x150.jpg" alt="Grain-Free Breaded Shrimp {Made with Tiger Nut Flour}" title="breaded shrimp" class="wpurp-recipe-image" style="padding-top:5px;padding-bottom:5px;padding-left:5px;padding-right:5px;width:150px;height:150px;position:static;background-color:#ffffff;border-width:1px 1px 1px 1px;border-color:#666666;border-style:solid;-webkit-box-shadow:2px 2px 2px  rgba(50,50,50,0.5) ;-moz-box-shadow:2px 2px 2px  rgba(50,50,50,0.5) ;box-shadow:2px 2px 2px  rgba(50,50,50,0.5) ;text-align:inherit;vertical-align:inherit;" />
+    </div>
+    </div>
+        </div>
+        </td>
+                                <td style="vertical-align:top;text-align:inherit;width:20px;">
+                    </td>
+                                <td style="vertical-align:top;text-align:inherit;width:auto;">
+            <div class="wpurp-rows" style="position:static;text-align:inherit;vertical-align:inherit;">
+            <div class="wpurp-rows-row" style="height:auto;">
+        <span class="wpurp-recipe-title" style="margin-bottom:10px;padding-bottom:0px;position:static;text-align:inherit;vertical-align:inherit;font-weight:bold;font-size:1.4em;line-height:1.4em;">Grain-Free Breaded Shrimp {Made with TigerNut Flour}</span><span class="wpurp-box" style="float:right;position:static;text-align:inherit;vertical-align:inherit;">
+    <table class="wpurp-columns" style="position:static;text-align:inherit;vertical-align:inherit;">
+    <tbody>
+    <tr>
+                        <td style="vertical-align:top;text-align:inherit;width:auto;">
+            <span class="wpurp-recipe-stars" style="margin-right:0px;position:static;text-align:inherit;vertical-align:inherit;"></span>        </td>
+                                <td style="vertical-align:top;text-align:inherit;width:auto;">
+            <a href="#" class="wpurp-recipe-print-button" style="color: #9bbd35;margin-left:5px;position:static;text-align:inherit;vertical-align:inherit;" data-recipe-id="7480"><img src="http://www.healthstartsinthekitchen.com/wp-content/plugins/wp-ultimate-recipe-premium/core/img/printer.png"></a>
+        </td>
+                    </tr>
+    </tbody>
+</table>
+</span>
+    </div>
+                <div class="wpurp-rows-row" style="height:auto;">
+        <span class="wpurp-recipe-description" style="margin-bottom:20px;position:static;text-align:inherit;vertical-align:inherit;line-height:1.4em;"></span>    </div>
+                <div class="wpurp-rows-row" style="height:auto;">
+        <ul class="wpurp-recipe-tags" style="position:static;text-align:inherit;vertical-align:inherit;">
+    </ul>
+    </div>
+                <div class="wpurp-rows-row" style="height:auto;">
+        <div class="wpurp-responsive-mobile">
+    <div class="wpurp-columns" style="position:static;text-align:inherit;vertical-align:inherit;">
+                                                        <div class="wpurp-rows-row">
+                        <table class="wpurp-table" style="width:100%;margin-top:20px;position:static;text-align:inherit;vertical-align:inherit;">
+    <tbody>
+                        <tr>
+                                                                                                    </tr>
+                                <tr>
+                                                                                                    </tr>
+                </tbody>
+</table>
+                    </div>
+                                                                <div class="wpurp-rows-row">
+                        <table class="wpurp-table" style="width:100%;margin-top:20px;position:static;text-align:inherit;vertical-align:inherit;">
+    <tbody>
+                        <tr>
+                                                                                                    </tr>
+                                <tr>
+                                                                                                    </tr>
+                </tbody>
+</table>
+                    </div>
+                                        </div>
+</div>
+<div class="wpurp-responsive-desktop">
+<table class="wpurp-columns" style="position:static;text-align:inherit;vertical-align:inherit;">
+    <tbody>
+    <tr>
+                        <td style="vertical-align:top;text-align:inherit;width:50%;">
+            <table class="wpurp-table" style="width:100%;margin-top:20px;position:static;text-align:inherit;vertical-align:inherit;">
+    <tbody>
+                        <tr>
+                                                                                                    </tr>
+                                <tr>
+                                                                                                    </tr>
+                </tbody>
+</table>
+        </td>
+                                <td style="vertical-align:top;text-align:inherit;width:auto;">
+            <table class="wpurp-table" style="width:100%;margin-top:20px;position:static;text-align:inherit;vertical-align:inherit;">
+    <tbody>
+                        <tr>
+                                                                                                    </tr>
+                                <tr>
+                                                                                                    </tr>
+                </tbody>
+</table>
+        </td>
+                    </tr>
+    </tbody>
+</table>
+</div>    </div>
+        </div>
+        </td>
+                    </tr>
+    </tbody>
+</table>
+</div>    </div>
+                <div class="wpurp-rows-row" style="height:auto;">
+        <div class="wpurp-rows" style="position:static;text-align:inherit;vertical-align:inherit;">
+            <div class="wpurp-rows-row" style="height:auto;">
+        <span class="wpurp-title" style="margin-top:20px;margin-bottom:10px;position:static;text-align:inherit;vertical-align:inherit;font-weight:bold;font-size:1.2em;line-height:1.2em;">Ingredients</span>    </div>
+                <div class="wpurp-rows-row" style="height:auto;">
+        <div data-servings="4" class="wpurp-recipe-ingredients" style="margin-bottom:10px;margin-left:0px;margin-right:0px;width:100%;position:static;text-align:inherit;vertical-align:inherit;">
+    <div><div class="wpurp-rows" style="position:static;text-align:inherit;vertical-align:inherit;">
+            <div class="wpurp-rows-row" style="height:auto;">
+            </div>
+                <div class="wpurp-rows-row" style="height:auto;">
+        <ul class="wpurp-recipe-ingredient-container" style="margin-left:23px;margin-right:23px;position:static;text-align:inherit;vertical-align:inherit;">
+    <li class="wpurp-recipe-ingredient" style="list-style:square;"><span class="wpurp-box" style="margin-right:5px;min-width:105px;position:static;text-align:inherit;vertical-align:inherit;">
+    <span data-normalized="0.5" data-fraction="1" data-original="1/2" class="wpurp-recipe-ingredient-quantity" style="margin-right:0px;position:static;text-align:inherit;vertical-align:inherit;line-height:1.6em;">1/2</span><span data-original="cup" class="wpurp-recipe-ingredient-unit" style="margin-left:5px;position:static;text-align:inherit;vertical-align:inherit;font-size:0.9em;line-height:1.6em;color:#666666;">cup</span></span>
+<span class="wpurp-box" style="position:static;text-align:inherit;vertical-align:inherit;">
+    <span class="wpurp-recipe-ingredient-name" style="position:static;text-align:inherit;vertical-align:inherit;line-height:1.6em;"><a style="color: #9bbd35;" href="http://amzn.to/1MAHeE4" class="custom-ingredient-link" target="_blank">organic potato starch</a></span><span class="wpurp-recipe-ingredient-notes" style="margin-left:5px;position:static;text-align:inherit;vertical-align:inherit;font-size:0.9em;line-height:1.6em;color:#666666;">or arrowroot/tapioca</span></span>
+</li><li class="wpurp-recipe-ingredient" style="list-style:square;"><span class="wpurp-box" style="margin-right:5px;min-width:105px;position:static;text-align:inherit;vertical-align:inherit;">
+    <span data-normalized="1" data-fraction="" data-original="1" class="wpurp-recipe-ingredient-quantity" style="margin-right:0px;position:static;text-align:inherit;vertical-align:inherit;line-height:1.6em;">1</span><span data-original="teaspoon" class="wpurp-recipe-ingredient-unit" style="margin-left:5px;position:static;text-align:inherit;vertical-align:inherit;font-size:0.9em;line-height:1.6em;color:#666666;">teaspoon</span></span>
+<span class="wpurp-box" style="position:static;text-align:inherit;vertical-align:inherit;">
+    <span class="wpurp-recipe-ingredient-name" style="position:static;text-align:inherit;vertical-align:inherit;line-height:1.6em;"><a style="color: #9bbd35;" href="http://amzn.to/1MAzSRh" class="custom-ingredient-link" target="_blank">sea salt (real salt)</a></span><span class="wpurp-recipe-ingredient-notes" style="margin-left:5px;position:static;text-align:inherit;vertical-align:inherit;font-size:0.9em;line-height:1.6em;color:#666666;"></span></span>
+</li><li class="wpurp-recipe-ingredient" style="list-style:square;"><span class="wpurp-box" style="margin-right:5px;min-width:105px;position:static;text-align:inherit;vertical-align:inherit;">
+    <span data-normalized="2" data-fraction="" data-original="2" class="wpurp-recipe-ingredient-quantity" style="margin-right:0px;position:static;text-align:inherit;vertical-align:inherit;line-height:1.6em;">2</span><span data-original="large " class="wpurp-recipe-ingredient-unit" style="margin-left:5px;position:static;text-align:inherit;vertical-align:inherit;font-size:0.9em;line-height:1.6em;color:#666666;">large </span></span>
+<span class="wpurp-box" style="position:static;text-align:inherit;vertical-align:inherit;">
+    <span class="wpurp-recipe-ingredient-name" style="position:static;text-align:inherit;vertical-align:inherit;line-height:1.6em;"><a style="color: #9bbd35;" href="http://www.healthstartsinthekitchen.com/ingredient/eggs/">eggs</a></span><span class="wpurp-recipe-ingredient-notes" style="margin-left:5px;position:static;text-align:inherit;vertical-align:inherit;font-size:0.9em;line-height:1.6em;color:#666666;">beaten</span></span>
+</li><li class="wpurp-recipe-ingredient" style="list-style:square;"><span class="wpurp-box" style="margin-right:5px;min-width:105px;position:static;text-align:inherit;vertical-align:inherit;">
+    <span data-normalized="1" data-fraction="" data-original="1" class="wpurp-recipe-ingredient-quantity" style="margin-right:0px;position:static;text-align:inherit;vertical-align:inherit;line-height:1.6em;">1</span><span data-original="cup" class="wpurp-recipe-ingredient-unit" style="margin-left:5px;position:static;text-align:inherit;vertical-align:inherit;font-size:0.9em;line-height:1.6em;color:#666666;">cup</span></span>
+<span class="wpurp-box" style="position:static;text-align:inherit;vertical-align:inherit;">
+    <span class="wpurp-recipe-ingredient-name" style="position:static;text-align:inherit;vertical-align:inherit;line-height:1.6em;"><a style="color: #9bbd35;" href="http://amzn.to/1RwsdYj" class="custom-ingredient-link" target="_blank">TigerNut Flour</a></span><span class="wpurp-recipe-ingredient-notes" style="margin-left:5px;position:static;text-align:inherit;vertical-align:inherit;font-size:0.9em;line-height:1.6em;color:#666666;"></span></span>
+</li><li class="wpurp-recipe-ingredient" style="list-style:square;"><span class="wpurp-box" style="margin-right:5px;min-width:105px;position:static;text-align:inherit;vertical-align:inherit;">
+    <span data-normalized="1" data-fraction="" data-original="1" class="wpurp-recipe-ingredient-quantity" style="margin-right:0px;position:static;text-align:inherit;vertical-align:inherit;line-height:1.6em;">1</span><span data-original="tablespoon" class="wpurp-recipe-ingredient-unit" style="margin-left:5px;position:static;text-align:inherit;vertical-align:inherit;font-size:0.9em;line-height:1.6em;color:#666666;">tablespoon</span></span>
+<span class="wpurp-box" style="position:static;text-align:inherit;vertical-align:inherit;">
+    <span class="wpurp-recipe-ingredient-name" style="position:static;text-align:inherit;vertical-align:inherit;line-height:1.6em;"><a style="color: #9bbd35;" href="http://www.healthstartsinthekitchen.com/2013/04/16/homemade-seasoned-salt/" class="custom-ingredient-link" target="_blank">seasoned salt</a></span><span class="wpurp-recipe-ingredient-notes" style="margin-left:5px;position:static;text-align:inherit;vertical-align:inherit;font-size:0.9em;line-height:1.6em;color:#666666;"></span></span>
+</li><li class="wpurp-recipe-ingredient" style="list-style:square;"><span class="wpurp-box" style="margin-right:5px;min-width:105px;position:static;text-align:inherit;vertical-align:inherit;">
+    <span data-normalized="1" data-fraction="" data-original="1" class="wpurp-recipe-ingredient-quantity" style="margin-right:0px;position:static;text-align:inherit;vertical-align:inherit;line-height:1.6em;">1</span><span data-original="pound" class="wpurp-recipe-ingredient-unit" style="margin-left:5px;position:static;text-align:inherit;vertical-align:inherit;font-size:0.9em;line-height:1.6em;color:#666666;">pound</span></span>
+<span class="wpurp-box" style="position:static;text-align:inherit;vertical-align:inherit;">
+    <span class="wpurp-recipe-ingredient-name" style="position:static;text-align:inherit;vertical-align:inherit;line-height:1.6em;"><a style="color: #9bbd35;" href="http://www.vitalchoice.com/shop/pc/home.asp?idaffiliate=3828" class="custom-ingredient-link" target="_blank">frozen wild caught shrimp, 16-20 count</a></span><span class="wpurp-recipe-ingredient-notes" style="margin-left:5px;position:static;text-align:inherit;vertical-align:inherit;font-size:0.9em;line-height:1.6em;color:#666666;">peeled & deveined</span></span>
+</li><li class="wpurp-recipe-ingredient" style="list-style:square;"><span class="wpurp-box" style="margin-right:5px;min-width:105px;position:static;text-align:inherit;vertical-align:inherit;">
+    <span data-normalized="0" data-fraction="" data-original="--" class="wpurp-recipe-ingredient-quantity" style="margin-right:0px;position:static;text-align:inherit;vertical-align:inherit;line-height:1.6em;">--</span><span data-original="" class="wpurp-recipe-ingredient-unit" style="margin-left:5px;position:static;text-align:inherit;vertical-align:inherit;font-size:0.9em;line-height:1.6em;color:#666666;"></span></span>
+<span class="wpurp-box" style="position:static;text-align:inherit;vertical-align:inherit;">
+    <span class="wpurp-recipe-ingredient-name" style="position:static;text-align:inherit;vertical-align:inherit;line-height:1.6em;"><a style="color: #9bbd35;" href="http://www.healthstartsinthekitchen.com/ingredient/lard/">lard</a></span><span class="wpurp-recipe-ingredient-notes" style="margin-left:5px;position:static;text-align:inherit;vertical-align:inherit;font-size:0.9em;line-height:1.6em;color:#666666;">or other fat for frying</span></span>
+</li><li class="wpurp-recipe-ingredient" style="list-style:square;"><span class="wpurp-box" style="margin-right:5px;min-width:105px;position:static;text-align:inherit;vertical-align:inherit;">
+    <span data-normalized="0" data-fraction="" data-original="--" class="wpurp-recipe-ingredient-quantity" style="margin-right:0px;position:static;text-align:inherit;vertical-align:inherit;line-height:1.6em;">--</span><span data-original="" class="wpurp-recipe-ingredient-unit" style="margin-left:5px;position:static;text-align:inherit;vertical-align:inherit;font-size:0.9em;line-height:1.6em;color:#666666;"></span></span>
+<span class="wpurp-box" style="position:static;text-align:inherit;vertical-align:inherit;">
+    <span class="wpurp-recipe-ingredient-name" style="position:static;text-align:inherit;vertical-align:inherit;line-height:1.6em;"><a style="color: #9bbd35;" href="http://www.healthstartsinthekitchen.com/2012/12/25/gram-elsies-cocktail-sauce/" class="custom-ingredient-link" target="_blank">cocktail sauce</a></span><span class="wpurp-recipe-ingredient-notes" style="margin-left:5px;position:static;text-align:inherit;vertical-align:inherit;font-size:0.9em;line-height:1.6em;color:#666666;">optional, for serving</span></span>
+</li></ul>
+    </div>
+        </div>
+</div></div>
+    </div>
+                <div class="wpurp-rows-row" style="height:auto;">
+            </div>
+                <div class="wpurp-rows-row" style="height:auto;">
+        <span class="wpurp-box" style="margin-top:5px;position:static;text-align:inherit;vertical-align:inherit;">
+    <span class="wpurp-title" style="margin-right:5px;position:static;text-align:inherit;vertical-align:inherit;">Units:</span><span class="wpurp-recipe-unit-changer" style="position:static;text-align:inherit;vertical-align:inherit;"><select onchange="RecipeUnitConversion.recalculate(this)" class="adjust-recipe-unit" style="background:white;border:1px solid #bbbbbb;"><option value="0">Metric</option><option value="1">US Imperial</option></select></span></span>
+    </div>
+        </div>
+    </div>
+                <div class="wpurp-rows-row" style="height:auto;">
+        <div class="wpurp-rows" style="position:static;text-align:inherit;vertical-align:inherit;">
+            <div class="wpurp-rows-row" style="height:auto;">
+        <span class="wpurp-title" style="margin-top:20px;margin-bottom:10px;position:static;text-align:inherit;vertical-align:inherit;font-weight:bold;font-size:1.2em;line-height:1.2em;">Instructions</span>    </div>
+                <div class="wpurp-rows-row" style="height:auto;">
+        <div class="wpurp-recipe-instructions" style="width:100%;position:static;text-align:inherit;vertical-align:inherit;">
+    <div><div class="wpurp-rows" style="position:static;text-align:inherit;vertical-align:inherit;">
+            <div class="wpurp-rows-row" style="height:auto;">
+        <span class="wpurp-recipe-instruction-group" style="margin-bottom:10px;padding-bottom:10px;width:100%;position:static;border-width:0 0 1px 0;border-color:#999999;border-style:dashed;text-align:inherit;vertical-align:inherit;font-weight:bold;"></span>    </div>
+                <div class="wpurp-rows-row" style="height:auto;">
+        <ol class="wpurp-recipe-instruction-container" style="margin-left:23px;margin-right:23px;position:static;text-align:inherit;vertical-align:inherit;">
+    <li class="wpurp-recipe-instruction" style="list-style:decimal;border-bottom: 1px dashed #999999 !important;margin-bottom: 10px !important;"><div class="wpurp-rows" style="margin-bottom:15px;padding-top:5px;position:static;text-align:inherit;vertical-align:inherit;">
+            <div class="wpurp-rows-row" style="height:auto;">
+        <span class="wpurp-recipe-instruction-text" style="position:static;text-align:inherit;vertical-align:top;">Create a breading station, using 3 bowls. </span>    </div>
+                <div class="wpurp-rows-row" style="height:auto;">
+            </div>
+        </div>
+</li><li class="wpurp-recipe-instruction" style="list-style:decimal;border-bottom: 1px dashed #999999 !important;margin-bottom: 10px !important;"><div class="wpurp-rows" style="margin-bottom:15px;padding-top:5px;position:static;text-align:inherit;vertical-align:inherit;">
+            <div class="wpurp-rows-row" style="height:auto;">
+        <span class="wpurp-recipe-instruction-text" style="position:static;text-align:inherit;vertical-align:top;">In bowl #1 combine potato starch and 1 teaspoon sea salt. </span>    </div>
+                <div class="wpurp-rows-row" style="height:auto;">
+            </div>
+        </div>
+</li><li class="wpurp-recipe-instruction" style="list-style:decimal;border-bottom: 1px dashed #999999 !important;margin-bottom: 10px !important;"><div class="wpurp-rows" style="margin-bottom:15px;padding-top:5px;position:static;text-align:inherit;vertical-align:inherit;">
+            <div class="wpurp-rows-row" style="height:auto;">
+        <span class="wpurp-recipe-instruction-text" style="position:static;text-align:inherit;vertical-align:top;">In bowl #2 gently whisk eggs with a splash of water</span>    </div>
+                <div class="wpurp-rows-row" style="height:auto;">
+            </div>
+        </div>
+</li><li class="wpurp-recipe-instruction" style="list-style:decimal;border-bottom: 1px dashed #999999 !important;margin-bottom: 10px !important;"><div class="wpurp-rows" style="margin-bottom:15px;padding-top:5px;position:static;text-align:inherit;vertical-align:inherit;">
+            <div class="wpurp-rows-row" style="height:auto;">
+        <span class="wpurp-recipe-instruction-text" style="position:static;text-align:inherit;vertical-align:top;">In bowl #3 combine tigernut flour with seasoned salt</span>    </div>
+                <div class="wpurp-rows-row" style="height:auto;">
+            </div>
+        </div>
+</li><li class="wpurp-recipe-instruction" style="list-style:decimal;border-bottom: 1px dashed #999999 !important;margin-bottom: 10px !important;"><div class="wpurp-rows" style="margin-bottom:15px;padding-top:5px;position:static;text-align:inherit;vertical-align:inherit;">
+            <div class="wpurp-rows-row" style="height:auto;">
+        <span class="wpurp-recipe-instruction-text" style="position:static;text-align:inherit;vertical-align:top;">Dip each shrimp first in the starch, then the egg, then the tigernut flour.  Making sure the shrimp are completely coated.</span>    </div>
+                <div class="wpurp-rows-row" style="height:auto;">
+            </div>
+        </div>
+</li><li class="wpurp-recipe-instruction" style="list-style:decimal;border-bottom: 1px dashed #999999 !important;margin-bottom: 10px !important;"><div class="wpurp-rows" style="margin-bottom:15px;padding-top:5px;position:static;text-align:inherit;vertical-align:inherit;">
+            <div class="wpurp-rows-row" style="height:auto;">
+        <span class="wpurp-recipe-instruction-text" style="position:static;text-align:inherit;vertical-align:top;">Arrange each breaded shrimp in a single layer on a wax paper lined plate. </span>    </div>
+                <div class="wpurp-rows-row" style="height:auto;">
+            </div>
+        </div>
+</li><li class="wpurp-recipe-instruction" style="list-style:decimal;border-bottom: 1px dashed #999999 !important;margin-bottom: 10px !important;"><div class="wpurp-rows" style="margin-bottom:15px;padding-top:5px;position:static;text-align:inherit;vertical-align:inherit;">
+            <div class="wpurp-rows-row" style="height:auto;">
+        <span class="wpurp-recipe-instruction-text" style="position:static;text-align:inherit;vertical-align:top;">After all shrimp are breaded, FREEZE them for 30 minutes. (this ensures the breaded stays completely adhered to the food, use this trick for all breaded meats/seafood)</span>    </div>
+                <div class="wpurp-rows-row" style="height:auto;">
+            </div>
+        </div>
+</li><li class="wpurp-recipe-instruction" style="list-style:decimal;border-bottom: 1px dashed #999999 !important;margin-bottom: 10px !important;"><div class="wpurp-rows" style="margin-bottom:15px;padding-top:5px;position:static;text-align:inherit;vertical-align:inherit;">
+            <div class="wpurp-rows-row" style="height:auto;">
+        <span class="wpurp-recipe-instruction-text" style="position:static;text-align:inherit;vertical-align:top;">While your shrimp are in the freezer, prepare your fat for frying. I suggest using about 3/4 of an inch of lard in a cast iron skillet. </span>    </div>
+                <div class="wpurp-rows-row" style="height:auto;">
+            </div>
+        </div>
+</li><li class="wpurp-recipe-instruction" style="list-style:decimal;border-bottom: 1px dashed #999999 !important;margin-bottom: 10px !important;"><div class="wpurp-rows" style="margin-bottom:15px;padding-top:5px;position:static;text-align:inherit;vertical-align:inherit;">
+            <div class="wpurp-rows-row" style="height:auto;">
+        <span class="wpurp-recipe-instruction-text" style="position:static;text-align:inherit;vertical-align:top;">Heat your fat to roughly 325 degrees, then working batches, fry your shrimp until golden brown and crisp, roughly 2 minutes. Do not over cook your shrimp, they will become dry and chewy. </span>    </div>
+                <div class="wpurp-rows-row" style="height:auto;">
+            </div>
+        </div>
+</li><li class="wpurp-recipe-instruction" style="list-style:decimal;border-bottom: 1px dashed #999999 !important;margin-bottom: 10px !important;border-bottom: 0 !important;"><div class="wpurp-rows" style="margin-bottom:15px;padding-top:5px;position:static;text-align:inherit;vertical-align:inherit;">
+            <div class="wpurp-rows-row" style="height:auto;">
+        <span class="wpurp-recipe-instruction-text" style="position:static;text-align:inherit;vertical-align:top;">Drain fried shrimp on a paper towel lined and season with additional sea salt. Serve with cocktail sauce, if desired.</span>    </div>
+                <div class="wpurp-rows-row" style="height:auto;">
+            </div>
+        </div>
+</li></ol>
+    </div>
+        </div>
+</div></div>
+    </div>
+        </div>
+    </div>
+                <div class="wpurp-rows-row" style="height:auto;">
+            </div>
+                <div class="wpurp-rows-row" style="height:auto;">
+            </div>
+                <div class="wpurp-rows-row" style="height:auto;">
+            </div>
+        </div>
+</div>
+</p>
+<p><em>This post and recipe were sponsored by my friends at <a href="http://www.organicgemini.com?rfsn=131091.6879">Organic Gemini</a>, but all opinions expressed are 100% mine. Affiliate links are used in this post, thank you for your support.</em></p>
+<div id="adthrive_ad_widget-2" class="widget_adthrive_ad_widget"><div style="text-align: center;">
+<div class="adthrive-ad" id="HealthStartsintheKitchen_Below_Post_300x250_600x250">
+<!-- STRIPPED SCRIPT TAG -->
+</div></div></div><div class='shareaholic-canvas' data-app-id='20703016' data-app='share_buttons' data-title='The World&#039;s Best Paleo Breaded Shrimp {Made with TigerNut Flour}' data-link='http://www.healthstartsinthekitchen.com/recipe/the-worlds-best-paleo-breaded-shrimp-made-with-tigernut-flour/' data-summary=''></div><div class='shareaholic-canvas' data-app-id='20703024' data-app='recommendations' data-title='The World&#039;s Best Paleo Breaded Shrimp {Made with TigerNut Flour}' data-link='http://www.healthstartsinthekitchen.com/recipe/the-worlds-best-paleo-breaded-shrimp-made-with-tigernut-flour/' data-summary=''></div></div><footer class="entry-footer"><p class="entry-meta"><span class="entry-categories"><a href="http://www.healthstartsinthekitchen.com/category/recipes/main-dish/" rel="category tag">Main Dish</a>, <a href="http://www.healthstartsinthekitchen.com/category/recipes/" rel="category tag">Recipes</a></span> <span class="entry-tags"><a href="http://www.healthstartsinthekitchen.com/tag/diary-fee/" rel="tag">diary fee</a>, <a href="http://www.healthstartsinthekitchen.com/tag/gluten-free-2/" rel="tag">gluten free</a>, <a href="http://www.healthstartsinthekitchen.com/tag/grain-free/" rel="tag">grain free</a>, <a href="http://www.healthstartsinthekitchen.com/tag/low-carb/" rel="tag">low carb</a>, <a href="http://www.healthstartsinthekitchen.com/tag/nut-free/" rel="tag">nut free</a>, <a href="http://www.healthstartsinthekitchen.com/tag/paleo/" rel="tag">paleo</a>, <a href="http://www.healthstartsinthekitchen.com/tag/primal/" rel="tag">primal</a>, <a href="http://www.healthstartsinthekitchen.com/tag/seed-free/" rel="tag">seed free</a>, <a href="http://www.healthstartsinthekitchen.com/tag/soy-free-2/" rel="tag">soy free</a>, <a href="http://www.healthstartsinthekitchen.com/tag/tiger-nuts/" rel="tag">tiger nuts</a>, <a href="http://www.healthstartsinthekitchen.com/tag/tigernut/" rel="tag">tigernut</a></span></p></footer></article>				<div id="respond" class="comment-respond">
+			<h3 id="reply-title" class="comment-reply-title">Leave a Reply <small><a rel="nofollow" id="cancel-comment-reply-link" href="/recipe/the-worlds-best-paleo-breaded-shrimp-made-with-tigernut-flour/#respond" style="display:none;">Cancel reply</a></small></h3>				<form action="http://www.healthstartsinthekitchen.com/wp-comments-post.php" method="post" id="commentform" class="comment-form" novalidate>
+					<p class="comment-notes"><span id="email-notes">Your email address will not be published.</span> Required fields are marked <span class="required">*</span></p><p class="comment-form-comment"><label for="comment">Comment</label> <textarea id="comment" name="comment" cols="45" rows="8"  aria-required="true" required="required"></textarea></p><p class="comment-form-author"><label for="author">Name <span class="required">*</span></label> <input id="author" name="author" type="text" value="" size="30" aria-required='true' required='required' /></p>
+<p class="comment-form-email"><label for="email">Email <span class="required">*</span></label> <input id="email" name="email" type="email" value="" size="30" aria-describedby="email-notes" aria-required='true' required='required' /></p>
+<p class="comment-form-url"><label for="url">Website</label> <input id="url" name="url" type="url" value="" size="30" /></p>
+		<!-- MailChimp for WordPress v3.1 - https://mc4wp.com/ -->
+
+				
+		<p class="mc4wp-checkbox mc4wp-checkbox-wp-comment-form">
+			<label>
+								<input type="hidden" name="_mc4wp_subscribe_wp-comment-form" value="0" />
+				<input type="checkbox" name="_mc4wp_subscribe_wp-comment-form" value="1" checked="checked" />
+				<span>Sign me up for the newsletter!</span>
+			</label>
+		</p>
+
+				
+		<!-- / MailChimp for WordPress -->
+		<p class="form-submit"><input name="submit" type="submit" id="submit" class="submit" value="Post Comment" /> <input type='hidden' name='comment_post_ID' value='7480' id='comment_post_ID' />
+<input type='hidden' name='comment_parent' id='comment_parent' value='0' />
+</p><p style="display: none;"><input type="hidden" id="akismet_comment_nonce" name="akismet_comment_nonce" value="f832138b96" /></p><p style="display: none;"><input type="hidden" id="ak_js" name="ak_js" value="194"/></p>				</form>
+					</div><!-- #respond -->
+		</main><aside class="sidebar sidebar-primary widget-area" role="complementary" aria-label="Primary Sidebar" itemscope itemtype="http://schema.org/WPSideBar"><section id="widget_sp_image-12" class="widget widget_sp_image"><div class="widget-wrap"><a href="http://www.healthstartsinthekitchen.com/2016/01/02/best-paleo-recipes-of-2015/" id="" target="_blank" class="widget_sp_image-image-link" title="" rel=""><img width="300" height="312" alt="" class="attachment-300x312 aligncenter" style="max-width: 100%;" src="http://www.healthstartsinthekitchen.com/wp-content/uploads/2016/01/BOP-promo-16-white.png" /></a></div></section>
+<section id="enews-ext-1" class="widget enews-widget"><div class="widget-wrap"><div class="enews"><p>Sign up for my weekly newsletter<br />
+<img src="http://www.healthstartsinthekitchen.com/wp-content/themes/daily-dish-pro/images/subscribe.png"></p>
+			<form id="subscribeenews-ext-1" action="//healthstartsinthekitchen.us3.list-manage.com/subscribe/post?u=d9408c049ef752dd606265c73&amp;id=48b9e4b9dd" method="post"  target="_blank" onsubmit="if ( subbox1.value == 'First Name') { subbox1.value = ''; } if ( subbox2.value == 'Last Name') { subbox2.value = ''; }" name="enews-ext-1">
+												<label for="subbox" class="screenread">Enter Your E-Mail Address</label><input type="email" value="" id="subbox" placeholder="Enter Your E-Mail Address" name="EMAIL" required="required" />
+								<input type="submit" value="Submit" id="subbutton" />
+			</form>
+		</div></div></section>
+<section id="text-35" class="widget widget_text"><div class="widget-wrap">			<div class="textwidget"><!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+</div>
+		</div></section>
+<section id="text-38" class="widget widget_text"><div class="widget-wrap">			<div class="textwidget"><center><img src="http://www.healthstartsinthekitchen.com/wp-content/themes/daily-dish-pro/images/Hayley.png"></br>
+Hey There! I'm Hayley. I'm so excited you stopped by, welcome to my kitchen!
+<a href="http://www.healthstartsinthekitchen.com/about/">[Read more...]</a>
+</center></div>
+		</div></section>
+<section id="nav_menu-3" class="widget widget_nav_menu"><div class="widget-wrap"><div class="menu-sidebar-container"><ul id="menu-sidebar" class="menu"><li id="menu-item-6092" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-6092"><a href="http://www.healthstartsinthekitchen.com/about/" itemprop="url">About</a></li>
+<li id="menu-item-6133" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-6133"><a href="http://www.hayleyryczek.com/#!my-cookbooks/cplb" itemprop="url">Cookbook Author</a></li>
+<li id="menu-item-6132" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-6132"><a href="http://www.hayleyryczek.com/#!food-photography/cm8a" itemprop="url">Food Photographer</a></li>
+<li id="menu-item-6134" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-6134"><a href="http://www.hayleyryczek.com/#!recipe-development/c9fq" itemprop="url">Recipe Development</a></li>
+<li id="menu-item-6135" class="menu-item menu-item-type-custom menu-item-object-custom menu-item-6135"><a href="http://www.hayleyryczek.com/#!contact/c1d94" itemprop="url">Contact Hayley</a></li>
+<li id="menu-item-6093" class="menu-item menu-item-type-post_type menu-item-object-page menu-item-6093"><a href="http://www.healthstartsinthekitchen.com/media-advertising/" itemprop="url">Media, PR &#038; Advertising</a></li>
+</ul></div></div></section>
+<section id="text-40" class="widget widget_text"><div class="widget-wrap">			<div class="textwidget"><!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+</div>
+		</div></section>
+<section id="adthrive_ad_widget-4" class="widget widget_adthrive_ad_widget"><div class="widget-wrap"><div style="text-align: center;">
+<div class="adthrive-ad" id="HealthStartsintheKitchen_Sidebar_3_300x250">
+<!-- STRIPPED SCRIPT TAG -->
+</div></div></div></section>
+<section id="widget_sp_image-9" class="widget widget_sp_image"><div class="widget-wrap"><h4 class="widget-title widgettitle">Purchase my Cookbooks</h4>
+<a href="http://amzn.to/1JQ4Gxb" id="" target="_blank" class="widget_sp_image-image-link" title="Purchase my Cookbooks" rel=""><img width="250" height="308" alt="Purchase my Cookbooks" class="attachment-250x308 aligncenter" style="max-width: 100%;" src="http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/01/without-grain-cover-01.png" /></a></div></section>
+<section id="widget_sp_image-13" class="widget widget_sp_image"><div class="widget-wrap"><a href="http://amzn.to/1JQ4I8n" id="" target="_self" class="widget_sp_image-image-link" title="" rel=""><img width="250" height="309" alt="" class="attachment-250x309 aligncenter" style="max-width: 100%;" src="http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/10/611yl33QQbL._SX403_BO1204203200_.jpg" /></a></div></section>
+<section id="widget_sp_image-15" class="widget widget_sp_image"><div class="widget-wrap"><a href="http://amzn.to/1MN8hvZ" id="" target="_blank" class="widget_sp_image-image-link" title="" rel=""><img width="350" height="462" alt="" class="attachment-350x462 aligncenter" style="max-width: 100%;" src="http://www.healthstartsinthekitchen.com/wp-content/uploads/2015/07/salads-without-grain.png" /></a></div></section>
+<section id="adthrive_ad_widget-5" class="widget widget_adthrive_ad_widget"><div class="widget-wrap"><div style="text-align: center;">
+<div class="adthrive-ad" id="HealthStartsintheKitchen_Sidebar_4_300x250">
+<!-- STRIPPED SCRIPT TAG -->
+</div></div></div></section>
+<section id="text-34" class="widget widget_text"><div class="widget-wrap">			<div class="textwidget"><a href="http://www.lifestylecollective.com/"><img  src="http://o.aolcdn.com/os/style_me_pretty/lifestylecollective/footerlogo_black"></a></div>
+		</div></section>
+</aside></div></div><div id="adthrive_ad_widget-3" class="widget_adthrive_ad_widget"><div style="text-align: center;">
+<div class="adthrive-ad" id="HealthStartsintheKitchen_Above_Footer_728x90">
+<!-- STRIPPED SCRIPT TAG -->
+</div></div></div><footer class="site-footer" itemscope itemtype="http://schema.org/WPFooter"><div class="wrap"><p><center>Copyright &#x000A9; 2016 <p style="color: #f4d7cc; margin: 0;"> <img src="http://www.healthstartsinthekitchen.com/wp-content/themes/daily-dish-pro/images/cutlery.png"></p> Design by <a href="http://www.deluxe-designs.com/" target="_blank">Deluxe Designs</a></center></p></div></footer></div><!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED SCRIPT TAG -->
+<!-- This site converts visitors into subscribers and customers with the OptinMonster WordPress plugin v2.1.7 - http://optinmonster.com/ -->
+<div id="om-vzp4cv0q8u-lightbox" class="optin-monster-overlay" style="display:none;"><!-- STRIPPED SCRIPT TAG --><style type="text/css" class="om-theme-target-styles">.optin-monster-success-message {font-size: 21px;font-family: "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;color: #282828;font-weight: 300;text-align: center;margin: 0 auto;}.optin-monster-success-overlay .om-success-close {font-size: 32px !important;font-family: "HelveticaNeue-Light", "Helvetica Neue Light", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif !important;color: #282828 !important;font-weight: 300 !important;position: absolute !important;top: 0px !important;right: 10px !important;background: none !important;text-decoration: none !important;width: auto !important;height: auto !important;display: block !important;line-height: 32px !important;padding: 0 !important;}.om-helper-field {display: none !important;visibility: hidden !important;opacity: 0 !important;height: 0 !important;line-height: 0 !important;}html div#om-vzp4cv0q8u-lightbox * {box-sizing:border-box;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;}html div#om-vzp4cv0q8u-lightbox {background:none;border:0;border-radius:0;-webkit-border-radius:0;-moz-border-radius:0;float:none;-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing: grayscale;height:auto;letter-spacing:normal;outline:none;position:static;text-decoration:none;text-indent:0;text-shadow:none;text-transform:none;width:auto;visibility:visible;overflow:visible;margin:0;padding:0;line-height:1;box-sizing:border-box;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;-webkit-box-shadow:none;-moz-box-shadow:none;-ms-box-shadow:none;-o-box-shadow:none;box-shadow:none;-webkit-appearance:none;}html div#om-vzp4cv0q8u-lightbox {background: rgb(0, 0, 0);background: rgba(0, 0, 0, .7);-webkit-font-smoothing: antialiased;line-height: 1;width: 100%;height: 100%;}html div#om-vzp4cv0q8u-lightbox .om-clearfix {clear: both;}html div#om-vzp4cv0q8u-lightbox .om-clearfix:after {clear: both;content: ".";display: block;height: 0;line-height: 0;overflow: auto;visibility: hidden;zoom: 1;}html div#om-vzp4cv0q8u-lightbox #om-lightbox-target-optin {background: url(http://www.healthstartsinthekitchen.com/wp-content/plugins/optin-monster/includes/themes/target/images/target-background.png);background-color: #fff;display: none;position: absolute;top: 50%;left: 50%;min-height: 175px;width: 714px;}html div#om-vzp4cv0q8u-lightbox #om-lightbox-target-optin-wrap {position: relative;height: 100%;border-left: 9px solid #58ce55;}html div#om-vzp4cv0q8u-lightbox .om-close {position: absolute;top: 4px;right: 10px;display: block;font-family: "Verdana", Arial, sans-serif;font-size: 28px;font-weight: bold;color: #58ce55;text-decoration: none !important;}html div#om-vzp4cv0q8u-lightbox #om-lightbox-target-header {min-height: 30px;padding: 40px 32px 15px;width: 100%;margin-left: -4px;}html div#om-vzp4cv0q8u-lightbox #om-lightbox-target-optin-title {font-family: "Lato", Arial, sans-serif;font-size: 28px;font-weight: 700;color: #5a6870;width: 100%;text-align: center;}html div#om-vzp4cv0q8u-lightbox #om-lightbox-target-content {padding: 15px 32px 0;}html div#om-vzp4cv0q8u-lightbox #om-lightbox-target-content-clear {min-height: 0;}html div#om-vzp4cv0q8u-lightbox #om-lightbox-target-left {float: left;width: 410px;position: relative;}html div#om-vzp4cv0q8u-lightbox #om-lightbox-target-optin-tagline {font-family: "Lato", Arial, sans-serif;font-size: 18px;text-align: center;line-height: 1.25;color: #8d9aa1;}html div#om-vzp4cv0q8u-lightbox #om-lightbox-target-right {float: right;width: 230px;}html div#om-vzp4cv0q8u-lightbox #om-lightbox-target-optin-image-container {position: relative;width: 230px;height: 195px;margin: 0 auto;}html div#om-vzp4cv0q8u-lightbox #om-lightbox-target-optin-image-container img {display: block;margin: 0 auto;text-align: center;height: auto;max-width: 100%;}html div#om-vzp4cv0q8u-lightbox #om-lightbox-target-footer {padding: 35px 32px 45px;}html div#om-vzp4cv0q8u-lightbox label {color: #333;}html div#om-vzp4cv0q8u-lightbox input,html div#om-vzp4cv0q8u-lightbox #om-lightbox-target-optin-name,html div#om-vzp4cv0q8u-lightbox #om-lightbox-target-optin-email {background-color: #fff;width: 248px;height: 48px;border: 1px solid #ccc;-webkit-box-shadow: 0 0 6px -3px rgba(0,0,0,0.8) inset;-moz-box-shadow: 0 0 6px -3px rgba(0,0,0,0.8) inset;box-shadow: 0 0 6px -3px rgba(0,0,0,0.8) inset;border-radius: 2px;font-size: 18px;line-height: 38px;padding: 4px 6px;overflow: hidden;outline: none;margin: 0 10px 0 0;vertical-align: middle;display: inline;}html div#om-vzp4cv0q8u-lightbox .om-has-email #om-lightbox-target-optin-email {width: 506px;}html div#om-vzp4cv0q8u-lightbox input[type=submit],html div#om-vzp4cv0q8u-lightbox button,html div#om-vzp4cv0q8u-lightbox #om-lightbox-target-optin-submit {background: #58ce55;border: 1px solid #49ae46;-webkit-box-shadow: 0 1px 1px -1px #fff inset;-moz-box-shadow: 0 1px 1px -1px #fff inset;box-shadow: 0 1px 1px -1px #fff inset;-webkit-text-shadow: #888 -0 0 1px;-moz-text-shadow: #888 -0 0 1px;text-shadow: #888 -0 0 1px;width: 125px;color: #fff;font-size: 16px;font-weight: 700;padding: 4px 6px;line-height: 24px;text-align: center;vertical-align: middle;cursor: pointer;display: inline;margin: 0;}html div#om-vzp4cv0q8u-lightbox input[type=checkbox],html div#om-vzp4cv0q8u-lightbox input[type=radio] {-webkit-appearance: checkbox;width: auto;outline: invert none medium;padding: 0;margin: 0;}@media (max-width: 700px) {html div#om-vzp4cv0q8u-lightbox #om-lightbox-target-optin[style] {width: 100%;position: relative;}html div#om-vzp4cv0q8u-lightbox #om-lightbox-target-optin-wrap {padding: 10px;}html div#om-vzp4cv0q8u-lightbox #om-lightbox-target-left,html div#om-vzp4cv0q8u-lightbox #om-lightbox-target-right,html div#om-vzp4cv0q8u-lightbox #om-lightbox-target-optin-name,html div#om-vzp4cv0q8u-lightbox #om-lightbox-target-optin-email,html div#om-vzp4cv0q8u-lightbox #om-lightbox-target-optin-submit,html div#om-vzp4cv0q8u-lightbox .om-has-email #om-lightbox-target-optin-email {float: none;width: 100%;}html div#om-vzp4cv0q8u-lightbox #om-lightbox-target-left {margin-bottom: 15px;}}</style><div id="om-lightbox-target-optin" class="om-lightbox-target om-clearfix om-theme-target "><div id="om-lightbox-target-optin-wrap" class="om-clearfix" data-om-action="selectable" data-om-target="#optin-monster-field-border_left" style="border-left-color:#9da83b;"><a href="#" class="om-close" title="Close" style="color:#9da83b;">&times;</a><div id="om-lightbox-target-header" class="om-clearfix"><div id="om-lightbox-target-optin-title" data-om-action="editable" data-om-field="title" style="color:#5a6870;font-family:Abril Fatface;font-size:40;font-weight:bold;font-style:normal;text-decoration:none;text-align:left;"><div style="text-align: center;"><span style="color:#504D50;"><span style="font-family: playfair display;">Sign up for my Weekly Newsletter</span></span></div>
+</div></div><div id="om-lightbox-target-content" class="om-clearfix"><div id="om-lightbox-target-optin-tagline" data-om-action="editable" data-om-field="tagline" style="color:#a9c11f;font-family:Cookie;font-size:36;font-weight:bold;font-style:italic;text-decoration:none;text-align:center;"><span style="font-size:20px;"><span style="font-family: cookie;"><span style="color: rgb(255, 172, 162);">Get my recipes delivered right to your inbox!</span></span></span></div></div><div id="om-lightbox-target-footer" class="om-clearfix om-has-name-email" data-om-action="selectable" data-om-target="#optin-monster-field-footer_bg"><input id="om-lightbox-target-optin-name" type="text" value="" data-om-action="selectable" data-om-target="#optin-monster-field-name_field" placeholder="Name" style="font-family:Vollkorn;font-weight:normal;font-style:normal;text-decoration:none;text-align:left;" /><input id="om-lightbox-target-optin-email" type="email" value="" data-om-action="selectable" data-om-target="#optin-monster-field-email_field" placeholder="Email Address" style="font-family:Vollkorn;font-weight:normal;font-style:normal;text-decoration:none;text-align:left;" /><input id="om-lightbox-target-optin-submit" type="submit" data-om-action="selectable" data-om-target="#optin-monster-field-submit_field" value="Sign Up!" style="color:#ffffff;background-color:#9da83b;border-color:rgb(159,170,60);font-family:Playfair Display;font-size:24;font-weight:normal;font-style:normal;text-decoration:none;text-align:center;" /></div></div><input type="email" name="email" value="" class="om-helper-field" /><input type="text" name="website" value="" class="om-helper-field" /></div><!-- STRIPPED SCRIPT TAG --></div>
+<!-- STRIPPED SCRIPT TAG -->
+<!-- STRIPPED CONDITIONAL COMMENT --><!-- / OptinMonster WordPress plugin. -->
+</body>
+</html>

--- a/tests/data/schema_example_com_unknown_title_curl.html
+++ b/tests/data/schema_example_com_unknown_title_curl.html
@@ -1,0 +1,6 @@
+<!--
+ONETSP_URL: http://schema.example.com/schema-spec
+ONETSP_USER_AGENT: curl
+ONETSP_TIME: Mon, 01 Feb 2016 21:00:53 +0000
+-->
+

--- a/tests/data/wholefoodsmarket_com_mushroom_kale_noodle_kugel_whole_foods_curl.html
+++ b/tests/data/wholefoodsmarket_com_mushroom_kale_noodle_kugel_whole_foods_curl.html
@@ -1,11 +1,11 @@
 <!--
 ONETSP_URL: http://www.wholefoodsmarket.com/recipes/3112
 ONETSP_USER_AGENT: curl
-ONETSP_TIME: Tue, 09 Oct 2012 18:59:48 -0700
+ONETSP_TIME: Mon, 01 Feb 2016 21:01:02 +0000
 -->
 
 <!DOCTYPE html>
-<html class="no-js" lang="en" version="HTML+RDFa 1.0" dir="ltr" 
+<html class="no-js wholefoods-theme" xmlns:fb="http://ogp.me/ns/fb#" lang="en" version="HTML+RDFa 1.0" dir="ltr" 
   xmlns:content="http://purl.org/rss/1.0/modules/content/"
   xmlns:dc="http://purl.org/dc/terms/"
   xmlns:foaf="http://xmlns.com/foaf/0.1/"
@@ -17,38 +17,24 @@ ONETSP_TIME: Tue, 09 Oct 2012 18:59:48 -0700
   xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
 
 <head profile="http://www.w3.org/1999/xhtml/vocab">
-  <meta charset="utf-8" />
-<!-- STRIPPED SCRIPT TAG -->
-<meta property="og:title" content="Mushroom Kale Noodle Kugel" /><link rel="shortcut icon" href="http://d1kg9jbrq423rq.cloudfront.net/sites/all/themes/wholefoods/favicon.ico" />
-<meta property="og:url" content="http://www.wholefoodsmarket.com/recipes/3112" /><meta property="og:description" content="This hearty dish features mushrooms, kale and egg noodles, bound with cottage cheese and sour cream for richness. Use a variety of mushrooms in place of the button mushrooms, if you like." /><meta property="og:image:secure_url" content="https://d1kg9jbrq423rq.cloudfront.net/sites/default/files/3112.jpg" /><meta property="og:image" content="http://d1kg9jbrq423rq.cloudfront.net/sites/default/files/3112.jpg" /><meta about="/recipes/3112" property="sioc:num_replies" content="0" datatype="xsd:integer" />
+  <!-- STRIPPED CONDITIONAL COMMENT -->
+<meta charset="utf-8" />
+<meta property="fb:app_id" content="189541064455755"/><meta property="og:site_name" content="Whole Foods Market"/><meta property="og:url" content="http://www.wholefoodsmarket.com/recipe/mushroom-kale-noodle-kugel"/><meta property="og:description" content="This hearty dish features mushrooms, kale and egg noodles, bound with cottage cheese and sour cream for richness. Use a variety of mushrooms in place of the button mushrooms, if you like."/><meta property="og:type" content="food"/><meta property="og:image:secure_url" content="https://www.wholefoodsmarket.com/sites/default/files/media/3112.jpg"/><meta property="og:image" content="http://www.wholefoodsmarket.com/sites/default/files/media/3112.jpg"/><meta property="og:title" content="Mushroom Kale Noodle Kugel"/><meta name="apple-itunes-app" content="app-id=320029256" app-argument="http://www.wholefoodsmarket.com/recipe/mushroom-kale-noodle-kugel" />
 <meta name="generator" content="Drupal 7 (http://drupal.org)" />
-<link rel="dns-prefetch" href="//d1kg9jbrq423rq.cloudfront.net" />
-<meta http-equiv="x-dns-prefetch-control" content="on" />
-
-<![if !IE]>
-<!-- STRIPPED SCRIPT TAG -->
-<![endif]><link rel="canonical" href="/recipes/3112" />
-<link rel="shortlink" href="/node/21467" />
-<meta content="Mushroom Kale Noodle Kugel" about="/recipes/3112" property="dc:title" />
-  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no">
+<!-- STRIPPED SCRIPT TAG --><link rel="shortlink" href="/node/103491" />
+<meta name="description" content="This hearty dish features mushrooms, kale and egg noodles, bound with cottage cheese and sour cream for richness. Use a variety of mushrooms in place of the button mushrooms, if you like." />
+<link rel="shortcut icon" href="http://www.wholefoodsmarket.com/sites/all/themes/wholefoods/favicon.ico" />
+<link rel="canonical" href="/recipe/mushroom-kale-noodle-kugel" />
+<!-- STRIPPED SCRIPT TAG --><!-- STRIPPED SCRIPT TAG -->  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=10, minimum-scale=1, user-scalable=yes">
   <title>Mushroom Kale Noodle Kugel | Whole Foods Market</title>
-  <link rel="stylesheet" href="http://d1kg9jbrq423rq.cloudfront.net/sites/default/files/css/cdn_css_HVdysb8HmLe7RNuLbsXkp79j8ANthorGId-q8PJJSqE.css" media="all" />
-<link rel="stylesheet" href="http://d1kg9jbrq423rq.cloudfront.net/sites/default/files/css/cdn_css_jbIXjr8dSVCuK8z4xfugzE1YnEPug3rn88EOthgcfDg.css" media="all" />
-<link rel="stylesheet" href="http://d1kg9jbrq423rq.cloudfront.net/sites/default/files/css/cdn_css_s6m1UMCuVLWOWelgeiB1Bpx5uF7pJwU6MjgjJxvYEI4.css" media="all" />
-<link rel="stylesheet" href="http://www.wholefoodsmarket.com/sites/default/files/css/cdn_css_I4IAS4KB5ivVwJJ_7dAJDbhxeD-PmQ4Zr4DNmpCGSKk.css" media="all" />
+  <link rel="stylesheet" href="//www.wholefoodsmarket.com/sites/default/files/advagg_css/css__MUr3jKVxyg5qLfL41xJ5bQ3AJhQOSADmPrNPun0fFlg__AyUTfAPGpg8H_7fgyfioJV9d9GGgXAv5nRSjQY4hTak__iNB0KIl5uuwF7QmCW1ekdYw-JBEBP3F6KQbSZyTd1gY.css" media="all" />
 
-<!--[if lte IE 6]>
-<link rel="stylesheet" href="http://d1kg9jbrq423rq.cloudfront.net/sites/default/files/css/cdn_css_47DEQpj8HBSa-_TImW-5JCeuQeRkm5NMpJWZG3hSuFU_ie6.css.css" media="all" />
-<![endif]-->
+<!-- STRIPPED CONDITIONAL COMMENT -->
 
-<!--[if IE 7]>
-<link rel="stylesheet" href="http://d1kg9jbrq423rq.cloudfront.net/sites/default/files/css/cdn_css_YkQhMqj-503KjRadQOSgI3EK1XDEIjs-RHVnvmnquaE_ie7.css.css" media="all" />
-<![endif]-->
+<!-- STRIPPED CONDITIONAL COMMENT -->
 
-<!--[if IE 8]>
-<link rel="stylesheet" href="http://d1kg9jbrq423rq.cloudfront.net/sites/default/files/css/cdn_css_sLiR7uoJymnSbEAZ49SH6OLK430RKN4CumlSm8MP4wY_ie8.css.css" media="all" />
-<![endif]-->
+<!-- STRIPPED CONDITIONAL COMMENT -->
 	<!-- STRIPPED SCRIPT TAG -->
 <!-- STRIPPED SCRIPT TAG -->
 <!-- STRIPPED SCRIPT TAG -->
@@ -69,15 +55,12 @@ ONETSP_TIME: Tue, 09 Oct 2012 18:59:48 -0700
 <!-- STRIPPED SCRIPT TAG -->
 <!-- STRIPPED SCRIPT TAG -->
 <!-- STRIPPED SCRIPT TAG -->
-<!-- STRIPPED SCRIPT TAG -->
-<!-- STRIPPED SCRIPT TAG -->
-<!-- STRIPPED SCRIPT TAG -->
-  <!-- css3-mediaqueries.js for IE less than 9 -->
-  <!--[if lt IE 9]>
-    <!-- STRIPPED SCRIPT TAG -->
-  <![endif]-->
 </head>
-<body id="body" class="html not-front not-logged-in no-sidebars page-node page-node- page-node-21467 node-type-recipe" >
+<body id="body" class="html not-front not-logged-in one-sidebar sidebar-second page-node page-node- page-node-103491 node-type-recipe" >
+  
+<!-- Google Tag Manager -->
+<noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-2HH6"height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><!-- STRIPPED SCRIPT TAG -->
+<!-- End Google Tag Manager -->
   <div id="skip-link">
     <a href="#main-content" class="element-invisible element-focusable">Skip to main content</a>
   </div>
@@ -98,26 +81,28 @@ ONETSP_TIME: Tue, 09 Oct 2012 18:59:48 -0700
                   </div> <!-- /#name-and-slogan -->
       
         <div class="region region-header">
-    <div id="block-block-1" class="block block-block">
+    <div id="block-wfm-welcome-block-wfm-welcome-block" class="block block-wfm-welcome-block">
 
     
   <div class="content">
-    <div id="block-block-1-ajax-content" class="ajaxblocks-wrapper"><!-- STRIPPED SCRIPT TAG --><noscript><div class="welcome-box">
-     Welcome 
-  <div class="store-box">
-     (<a href="/modals/nojs/find_store" class="ctools-use-modal">find a store</a>)
-  </div>
-</div></noscript></div>  </div>
+      <div class="welcome-box">
+    Welcome
+    <div class="store-box">
+       (<a href="/stores/list">find a store</a>)
+    </div>
+  </div>  </div>
 </div>
 <div id="block-system-user-menu" class="block block-system block-menu">
 
     <h2>User menu</h2>
   
   <div class="content">
-    <ul class="menu"><li class="first leaf"><a href="/user/janrain_register" class="iframe fancy create_account">Create Account</a></li>
-<li class="leaf"><a href="/user/janrain_register" class="iframe fancy create_account">Sign In</a></li>
-<li class="leaf"><a href="/stores/list">Store Locations</a></li>
-<li class="last leaf"><a href="/customer-service">Customer Service</a></li>
+    <ul class="menu"><li class="first leaf"><a href="/stores/list">Find a Store</a></li>
+<li class="leaf"><a href="/sales-flyer">On Sale</a></li>
+<li class="leaf"><a href="/recipes">Recipes</a></li>
+<li class="leaf"><a href="/online-ordering">Shop</a></li>
+<li class="leaf"><a href="/customer-service">Contact Us</a></li>
+<li class="last leaf"><a href="/signin" id="capture_signin_link" class="capture_modal_open menu_link_signin">Sign In / Register</a></li>
 </ul>  </div>
 </div>
 <div id="block-search-api-page-global-search" class="block block-search-api-page">
@@ -125,11 +110,12 @@ ONETSP_TIME: Tue, 09 Oct 2012 18:59:48 -0700
     <h2>Global Search</h2>
   
   <div class="content">
-    <form action="/recipes/3112" method="post" id="search-api-page-search-form-global-search" accept-charset="UTF-8"><div><div class="form-item form-type-textfield form-item-keys-16">
-  <input type="text" id="edit-keys-16" name="keys_16" value="" size="15" maxlength="250" class="form-text" />
+    <form action="/recipe/slow-cooker-split-pea-soup" method="post" id="search-api-page-search-form-global-search" accept-charset="UTF-8"><div><div class="form-item form-type-textfield form-item-keys-56">
+  <label class="element-invisible" for="edit-keys-56">Enter your keywords </label>
+ <input placeholder="Enter your keywords" class="auto_submit form-text form-autocomplete" type="text" id="edit-keys-56" name="keys_56" value="" size="15" maxlength="250" /><input type="hidden" id="edit-keys-56-autocomplete" value="http://www.wholefoodsmarket.com/?q=search_api_autocomplete/search_api_page_global_search/-" disabled="disabled" class="autocomplete" />
 </div>
-<input type="hidden" name="id" value="16" />
-<input type="submit" id="edit-submit-16" name="op" value="Search" class="form-submit" /><input type="hidden" name="form_build_id" value="form-SuIfSrIFxXgKdaTKmmBPd-wz0ASfzU_O64VJmTAiqwk" />
+<input type="hidden" name="id" value="56" />
+<input type="submit" id="edit-submit-56" name="op" value="Search" class="form-submit" /><input type="hidden" name="form_build_id" value="form-qre1DtTSzpvHzDi6rxNYXeo5T9RIcmiLel3ud8U_ECE" />
 <input type="hidden" name="form_id" value="search_api_page_search_form_global_search" />
 </div></form>  </div>
 </div>
@@ -140,797 +126,165 @@ ONETSP_TIME: Tue, 09 Oct 2012 18:59:48 -0700
     <div id="navigation" class="nav">
       <div class="nav-tab"><div class="nav-tab-copy"></div><div class="nav-tab-arrow"></div></div>
                <!-- <a href="/" title="Home" rel="home" id="logo">
-            <img src="http://d1kg9jbrq423rq.cloudfront.net/sites/default/files/wfm-logo.png" alt="Home" />
+            <img src="http://www.wholefoodsmarket.com/sites/default/files/wfm-logo.png" alt="Home" />
           </a>-->
                 <div class="region region-navigation">
-    <div id="block-views-monster-nav-top" class="block block-views">
+    <div id="block-wfm-monster-nav-wfm-monster-navigation" class="block block-wfm-monster-nav">
 
     
   <div class="content">
-    <div id="block-views-monster_nav-top-ajax-content" class="ajaxblocks-wrapper"><!-- STRIPPED SCRIPT TAG --><noscript><div class="view view-monster-nav view-id-monster_nav view-display-id-top view-dom-id-5d7db0a50f374a11845554b79594a54b">
-        
-  
-  
-      <div class="view-content">
-      <div class="item-list">    <ul>          <li class="views-row views-row-1 views-row-odd views-row-first views-row-last">  
-  <div class="views-field views-field-title nav-wholefoods">        <span class="field-content"><a href="/whole-foods-market">Whole Foods Market</a></span>  </div>  
-  <div class="views-field views-field-php">        <span class="field-content"><div class="view view-monster-nav view-id-monster_nav view-display-id-primary view-dom-id-c42e6d4506d1367e2000b6e712d6d0b8">
-        
-  
-  
-      <div class="view-content">
-      <div class="item-list">    <ul>          <li class="views-row views-row-1 views-row-odd views-row-first">  
-  <div class="views-field views-field-php-2 nav-healthy-eating">        <span class="field-content"><a href="/healthy-eating">Healthy Eating</a></span>  </div>  
-  <div class="views-field views-field-php">        <span class="field-content"><div class="view view-monster-nav view-id-monster_nav view-display-id-level_2 view-dom-id-5f8e5f6a8d1289e55bedd65b60ae5912">
-        
-  
-  
-      <div class="view-content">
-           <div class="views-row views-row-1 views-row-odd views-row-first">
-      
-  <div class="views-field views-field-php-1">        <span class="field-content"><a href="/healthy-eating/health-starts-here">Health Starts Here®</a></span>  </div>  
-  <div class="views-field views-field-php">        <span class="field-content"><div class="view view-monster-nav view-id-monster_nav view-display-id-level_3 view-dom-id-43e53bea62228266a23c5fde4ab85e3a">
-        
-  
-  
-      <div class="view-content">
-      <div class="item-list">    <ul>          <li class="views-row views-row-1 views-row-odd views-row-first">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/healthy-eating/health-starts-here/make-fresh-start">Make a Fresh Start</a></span>  </div></li>
-          <li class="views-row views-row-2 views-row-even">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/healthy-eating/health-starts-here/meal-planning-cooking">Meal Planning &amp; Cooking</a></span>  </div></li>
-          <li class="views-row views-row-3 views-row-odd">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/healthy-eating/health-starts-here/resources-tools">Resources &amp; Tools</a></span>  </div></li>
-          <li class="views-row views-row-4 views-row-even views-row-last">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/healthy-eating/health-starts-here/28-day-challenge">28-Day Challenge</a></span>  </div></li>
-      </ul></div>    </div>
-  
-  
-  
-  
-  
-  
-</div></span>  </div>  </div>
-     <div class="views-row views-row-2 views-row-even">
-      
-  <div class="views-field views-field-php-1">        <span class="field-content"><a href="/healthy-eating/parents-kids">Parents & Kids</a></span>  </div>  
-  <div class="views-field views-field-php">        <span class="field-content"><div class="view view-monster-nav view-id-monster_nav view-display-id-level_3 view-dom-id-3907409e462721666c03b502999eba82">
-        
-  
-  
-      <div class="view-content">
-      <div class="item-list">    <ul>          <li class="views-row views-row-1 views-row-odd views-row-first">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/healthy-eating/parents-and-kids/tips-fun-healthy-lunch">Tips for a Fun &amp; Healthy Lunch</a></span>  </div></li>
-          <li class="views-row views-row-2 views-row-even">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/healthy-eating/parents-and-kids/build-nutrition-packed-breakfast">Build a Nutrition-Packed Breakfast</a></span>  </div></li>
-          <li class="views-row views-row-3 views-row-odd">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/healthy-eating/parents-and-kids/make-dinnertime-dynamic">Make Dinnertime Dynamic</a></span>  </div></li>
-          <li class="views-row views-row-4 views-row-even">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/healthy-eating/parents-and-kids/nutrition-tips-kids-and-teens">Nutrition Tips for Kids &amp; Teens</a></span>  </div></li>
-          <li class="views-row views-row-5 views-row-odd">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/healthy-eating/parents-and-kids/building-blocks-good-nutrition">Building Blocks for Good Nutrition</a></span>  </div></li>
-      </ul></div>    </div>
-  
-  
-  
-  
-      <div class="view-footer">
-      <a href="/healthy-eating/parents-kids">More</a>    </div>
-  
-  
-</div></span>  </div>  </div>
-     <div class="views-row views-row-3 views-row-odd">
-      
-  <div class="views-field views-field-php-1">        <span class="field-content"><a href="/healthy-eating/special-diets">Special Diets</a></span>  </div>  
-  <div class="views-field views-field-php">        <span class="field-content"><div class="view view-monster-nav view-id-monster_nav view-display-id-level_3 view-dom-id-082204cf4b2cc882f62138d592552c37">
-        
-  
-  
-      <div class="view-content">
-      <div class="item-list">    <ul>          <li class="views-row views-row-1 views-row-odd views-row-first">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/healthy-eating/special-diets/dairy-free">Dairy Free</a></span>  </div></li>
-          <li class="views-row views-row-2 views-row-even">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/healthy-eating/special-diets/gluten-free">Gluten Free</a></span>  </div></li>
-          <li class="views-row views-row-3 views-row-odd">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/healthy-eating/special-diets/low-fat">Low Fat</a></span>  </div></li>
-          <li class="views-row views-row-4 views-row-even">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/healthy-eating/special-diets/low-sodium">Low Sodium</a></span>  </div></li>
-          <li class="views-row views-row-5 views-row-odd">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/healthy-eating/special-diets/vegetarian">Vegetarian</a></span>  </div></li>
-      </ul></div>    </div>
-  
-  
-  
-  
-      <div class="view-footer">
-      <a href="/healthy-eating/special-diets">More</a>    </div>
-  
-  
-</div></span>  </div>  </div>
-     <div class="views-row views-row-4 views-row-even views-row-last">
-      
-  <div class="views-field views-field-php-1">        <span class="field-content"><a href="/wellness-clubs">Wellness Clubs</a></span>  </div>  
-  <div class="views-field views-field-php">        <span class="field-content"><div class="view view-monster-nav view-id-monster_nav view-display-id-level_3 view-dom-id-8c83acda9059f41a8e36e960ca785280">
-        
-  
-  
-      <div class="view-content">
-      <div class="item-list">    <ul>          <li class="views-row views-row-1 views-row-odd views-row-first">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/find-wellness-club">Find a Wellness Club</a></span>  </div></li>
-          <li class="views-row views-row-2 views-row-even">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/services">Services</a></span>  </div></li>
-          <li class="views-row views-row-3 views-row-odd">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/our-wellness-experts">Our Wellness Experts</a></span>  </div></li>
-          <li class="views-row views-row-4 views-row-even views-row-last">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/our-philosophy">Our Philosophy</a></span>  </div></li>
-      </ul></div>    </div>
-  
-  
-  
-  
-  
-  
-</div></span>  </div>  </div>
-    </div>
-  
-  
-  
-  
-  
-  
-</div></span>  </div></li>
-          <li class="views-row views-row-2 views-row-even">  
-  <div class="views-field views-field-php-2 nav-about-our-products">        <span class="field-content"><a href="/about-our-products">About Our Products</a></span>  </div>  
-  <div class="views-field views-field-php">        <span class="field-content"><div class="view view-monster-nav view-id-monster_nav view-display-id-level_2 view-dom-id-d5cb4c89ad4b3bad2262c98af1d42ce3">
-        
-  
-  
-      <div class="view-content">
-           <div class="views-row views-row-1 views-row-odd views-row-first">
-      
-  <div class="views-field views-field-php-1">        <span class="field-content"><a href="/about-our-products/quality-standards">Quality Standards</a></span>  </div>  
-  <div class="views-field views-field-php">        <span class="field-content"><div class="view view-monster-nav view-id-monster_nav view-display-id-level_3 view-dom-id-5be4ab3ec7cf7ef888a7a7a9b71a6e76">
-        
-  
-  
-      <div class="view-content">
-      <div class="item-list">    <ul>          <li class="views-row views-row-1 views-row-odd views-row-first">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/about-our-products/organic-food">Organic Food</a></span>  </div></li>
-          <li class="views-row views-row-2 views-row-even">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/about-our-products/quality-standards/unacceptable-ingredients-food">Unacceptable Ingredients for Food</a></span>  </div></li>
-          <li class="views-row views-row-3 views-row-odd">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/about-our-products/quality-standards/animal-welfare-standards">Animal Welfare Standards</a></span>  </div></li>
-          <li class="views-row views-row-4 views-row-even">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/department/article/whole-body-quality-standards">Whole Body Quality Standards</a></span>  </div></li>
-          <li class="views-row views-row-5 views-row-odd">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/premium-body-care-standards">Premium Body Care Standards</a></span>  </div></li>
-      </ul></div>    </div>
-  
-  
-  
-  
-      <div class="view-footer">
-      <a href="/about-our-products/quality-standards">More</a>    </div>
-  
-  
-</div></span>  </div>  </div>
-     <div class="views-row views-row-2 views-row-even">
-      
-  <div class="views-field views-field-php-1">        <span class="field-content"><a href="/about-our-products/product-faq">Product Ingredient FAQs</a></span>  </div>  
-  <div class="views-field views-field-php">        <span class="field-content"><div class="view view-monster-nav view-id-monster_nav view-display-id-level_3 view-dom-id-155126f05651a7bcb6f0192a63add14a">
-        
-  
-  
-      <div class="view-content">
-      <div class="item-list">    <ul>          <li class="views-row views-row-1 views-row-odd views-row-first">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/about-our-products/product-faq/quality">Product FAQs: Quality</a></span>  </div></li>
-          <li class="views-row views-row-2 views-row-even">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/about-our-products/product-faq/ingredients">Product FAQs: Ingredients</a></span>  </div></li>
-          <li class="views-row views-row-3 views-row-odd">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/about-our-products/product-faq/product-selection">Product FAQs: Product Selection</a></span>  </div></li>
-          <li class="views-row views-row-4 views-row-even">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/about-our-products/product-faq/food-allergies">Product FAQs: Food Allergies</a></span>  </div></li>
-          <li class="views-row views-row-5 views-row-odd">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/about-our-products/product-faq/milk-and-eggs">Product FAQs: Milk &amp; Eggs</a></span>  </div></li>
-      </ul></div>    </div>
-  
-  
-  
-  
-      <div class="view-footer">
-      <a href="/about-our-products/product-faq">More</a>    </div>
-  
-  
-</div></span>  </div>  </div>
-     <div class="views-row views-row-3 views-row-odd">
-      
-  <div class="views-field views-field-php-1">        <span class="field-content"><a href="/about-our-products/food-safety">Food Safety</a></span>  </div>  
-  <div class="views-field views-field-php">        <span class="field-content"><div class="view view-monster-nav view-id-monster_nav view-display-id-level_3 view-dom-id-3a34f56706a0a9d77e1d4209a9148e8f">
-        
-  
-  
-      <div class="view-content">
-      <div class="item-list">    <ul>          <li class="views-row views-row-1 views-row-odd views-row-first">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/product-recalls">Product Recalls</a></span>  </div></li>
-          <li class="views-row views-row-2 views-row-even">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/about-our-products/food-safety/irradiation-us-and-canada">Irradiation (US and Canada)</a></span>  </div></li>
-          <li class="views-row views-row-3 views-row-odd">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/about-our-products/food-safety/methylmercury-seafood">Methylmercury in Seafood</a></span>  </div></li>
-          <li class="views-row views-row-4 views-row-even">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/about-our-products/food-safety/bisphenol">Bisphenol-A</a></span>  </div></li>
-          <li class="views-row views-row-5 views-row-odd">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/about-our-products/food-safety/cold-storage-chart">Cold Storage Chart</a></span>  </div></li>
-      </ul></div>    </div>
-  
-  
-  
-  
-      <div class="view-footer">
-      <a href="/about-our-products/food-safety">More</a>    </div>
-  
-  
-</div></span>  </div>  </div>
-     <div class="views-row views-row-4 views-row-even">
-      
-  <div class="views-field views-field-php-1">        <span class="field-content"><a href="/locally-grown">Locally Grown</a></span>  </div>  
-  <div class="views-field views-field-php">        <span class="field-content"><div class="view view-monster-nav view-id-monster_nav view-display-id-level_3 view-dom-id-13d70975a9c293fa6a1b67f0ed9e62f1">
-        
-  
-  
-      <div class="view-content">
-      <div class="item-list">    <ul>          <li class="views-row views-row-1 views-row-odd views-row-first">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/local-vendor-profiles">Local Vendor Profiles</a></span>  </div></li>
-          <li class="views-row views-row-2 views-row-even views-row-last">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/local-growers-map">Local Growers Map</a></span>  </div></li>
-      </ul></div>    </div>
-  
-  
-  
-  
-  
-  
-</div></span>  </div>  </div>
-     <div class="views-row views-row-5 views-row-odd">
-      
-  <div class="views-field views-field-php-1">        <span class="field-content"><a href="/about-our-products/our-product-lines">Our Product Lines</a></span>  </div>  
-  <div class="views-field views-field-php">        <span class="field-content"><div class="view view-monster-nav view-id-monster_nav view-display-id-level_3 view-dom-id-d8a754fa24a9f1b15e87d6c992abf1d1">
-        
-  
-  
-      <div class="view-content">
-      <div class="item-list">    <ul>          <li class="views-row views-row-1 views-row-odd views-row-first">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/about-our-products/product-lines/365-everyday-value">365 Everyday Value</a></span>  </div></li>
-          <li class="views-row views-row-2 views-row-even">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/about-our-products/product-lines/exclusive-products">Exclusive Products</a></span>  </div></li>
-          <li class="views-row views-row-3 views-row-odd">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/about-our-products/product-lines/premium-body-care">Premium Body Care</a></span>  </div></li>
-          <li class="views-row views-row-4 views-row-even">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/about-our-products/product-lines/whole-foods-market-brand">Whole Foods Market</a></span>  </div></li>
-          <li class="views-row views-row-5 views-row-odd views-row-last">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/about-our-products/product-lines/whole-trade">Whole Trade® </a></span>  </div></li>
-      </ul></div>    </div>
-  
-  
-  
-  
-  
-  
-</div></span>  </div>  </div>
-     <div class="views-row views-row-6 views-row-even views-row-last">
-      
-  <div class="views-field views-field-php-1">        <span class="field-content"><a href="/about-our-products/whole-deal">The Whole Deal®</a></span>  </div>  
-  <div class="views-field views-field-php">        <span class="field-content"><div class="view view-monster-nav view-id-monster_nav view-display-id-level_3 view-dom-id-019fe4db63d0802edaa8b70c97fc013c">
-        
-  
-  
-      <div class="view-content">
-      <div class="item-list">    <ul>          <li class="views-row views-row-1 views-row-odd views-row-first">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/about-our-products/whole-deal/sure-deals">Sure Deals</a></span>  </div></li>
-          <li class="views-row views-row-2 views-row-even">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/about-our-products/whole-deal/budget-recipes">Budget-Friendly Recipes</a></span>  </div></li>
-          <li class="views-row views-row-3 views-row-odd">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/about-our-products/whole-deal/meal-planner">Daily Meal Planner</a></span>  </div></li>
-          <li class="views-row views-row-4 views-row-even views-row-last">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/about-our-products/whole-deal/money-saving-tips">Money-Saving Tips</a></span>  </div></li>
-      </ul></div>    </div>
-  
-  
-  
-  
-  
-  
-</div></span>  </div>  </div>
-    </div>
-  
-  
-  
-  
-  
-  
-</div></span>  </div></li>
-          <li class="views-row views-row-3 views-row-odd">  
-  <div class="views-field views-field-php-2 nav-recipes">        <span class="field-content"><a href="/recipes">Recipes</a></span>  </div>  
-  <div class="views-field views-field-php">        <span class="field-content"><div class="view view-monster-nav view-id-monster_nav view-display-id-level_2 view-dom-id-bfcc4d52d22a5870136be73a87345c1b">
-        
-  
-  
-      <div class="view-content">
-           <div class="views-row views-row-1 views-row-odd views-row-first">
-      
-  <div class="views-field views-field-php-1">        <span class="field-content"><a href="/recipe-landing">Recipes</a></span>  </div>  
-  <div class="views-field views-field-php">        <span class="field-content"><div class="view view-monster-nav view-id-monster_nav view-display-id-level_3 view-dom-id-224260e879fdeec879f1414a0924d254">
-        
-  
-  
-      <div class="view-content">
-      <div class="item-list">    <ul>          <li class="views-row views-row-1 views-row-odd views-row-first">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/recipe-landing-featured">Featured</a></span>  </div></li>
-          <li class="views-row views-row-2 views-row-even">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/recipe-landing-toprated">Top Rated</a></span>  </div></li>
-          <li class="views-row views-row-3 views-row-odd views-row-last">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/recipe-landing-newest">Newest</a></span>  </div></li>
-      </ul></div>    </div>
-  
-  
-  
-  
-  
-  
-</div></span>  </div>  </div>
-        		        <div class="views-row views-row-3 views-row-odd">
-      
-  <div class="views-field views-field-php-1">        <span class="field-content"><a href="/recipes/cooking-entertainment-guides">Cooking & Entertaining Guides</a></span>  </div>  
-  <div class="views-field views-field-php">        <span class="field-content"><div class="view view-monster-nav view-id-monster_nav view-display-id-level_3 view-dom-id-f32faa5b66c50b9fe8c9ca6257e6c893">
-        
-  
-  
-      <div class="view-content">
-      <div class="item-list">    <ul>          <li class="views-row views-row-1 views-row-odd views-row-first">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/recipes/cooking-entertainment-guides/summer-foods-go">Summer Foods on the Go</a></span>  </div></li>
-          <li class="views-row views-row-2 views-row-even">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/recipes/cooking-entertainment-guides/complete-grilling-guide">Complete Grilling Guide</a></span>  </div></li>
-          <li class="views-row views-row-3 views-row-odd">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/recipes/cooking-entertainment-guides/perfect-antipasto-plate">The Perfect Antipasto Plate</a></span>  </div></li>
-          <li class="views-row views-row-4 views-row-even views-row-last">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/recipes/cooking-entertainment-guides/tapas-tiny-treasures-spain">Tapas: Tiny Treasures of Spain</a></span>  </div></li>
-      </ul></div>    </div>
-  
-  
-  
-  
-  
-  
-</div></span>  </div>  </div>
-     <div class="views-row views-row-4 views-row-even">
-      
-  <div class="views-field views-field-php-1">        <span class="field-content"><a href="/recipes/food-guides">Food Guides</a></span>  </div>  
-  <div class="views-field views-field-php">        <span class="field-content"><div class="view view-monster-nav view-id-monster_nav view-display-id-level_3 view-dom-id-6fdbef039acdd89be407d4a69782a7c3">
-        
-  
-  
-      <div class="view-content">
-      <div class="item-list">    <ul>          <li class="views-row views-row-1 views-row-odd views-row-first">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/recipes/food-guides/beans">Beans</a></span>  </div></li>
-          <li class="views-row views-row-2 views-row-even">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/recipes/food-guides/chocolate">Chocolate</a></span>  </div></li>
-          <li class="views-row views-row-3 views-row-odd">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/recipes/food-guides/cooking-oils">Cooking Oils</a></span>  </div></li>
-          <li class="views-row views-row-4 views-row-even">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/recipes/food-guides/dairy-products">Dairy Products</a></span>  </div></li>
-          <li class="views-row views-row-5 views-row-odd">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/recipes/food-guides/eggs">Eggs</a></span>  </div></li>
-      </ul></div>    </div>
-  
-  
-  
-  
-      <div class="view-footer">
-      <a href="/recipes/food-guides">More</a>    </div>
-  
-  
-</div></span>  </div>  </div>
-     <div class="views-row views-row-5 views-row-odd views-row-last">
-      
-  <div class="views-field views-field-php-1">        <span class="field-content"><a href="/recipe-forums">Recipe Forums</a></span>  </div>  
-  <div class="views-field views-field-php">        <span class="field-content"><div class="view view-monster-nav view-id-monster_nav view-display-id-level_3 view-dom-id-af30dd1511414b79b12abfd977f6d049">
-        
-  
-  
-      <div class="view-content">
-      <div class="item-list">    <ul>          <li class="views-row views-row-1 views-row-odd views-row-first">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/our-forum-guidelines">Our Forum Guidelines</a></span>  </div></li>
-          <li class="views-row views-row-2 views-row-even views-row-last">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/getting-started">Getting Started</a></span>  </div></li>
-      </ul></div>    </div>
-  
-  
-  
-  
-  
-  
-</div></span>  </div>  </div>
-    </div>
-  
-  
-  
-  
-  
-  
-</div></span>  </div></li>
-          <li class="views-row views-row-4 views-row-even">  
-  <div class="views-field views-field-php-2 nav-online-ordering">        <span class="field-content"><a href="/online-ordering">Online Ordering</a></span>  </div>  
-  <div class="views-field views-field-php">        <span class="field-content"><div class="view view-monster-nav view-id-monster_nav view-display-id-level_2 view-dom-id-96dcc915345fbd9cea17de67d5b9e7e2">
-        
-  
-  
-      <div class="view-content">
-                   <div class="views-row views-row-1 views-row-odd views-row-first">
-      
-  <div class="views-field views-field-php-1">        <span class="field-content"><a href="/online-ordering-available-your-store">Available at your store</a></span>  </div>  
-  <div class="views-field views-field-php">        <span class="field-content"><div class="view view-monster-nav-sub-views view-id-monster_nav_sub_views view-display-id-online_ordering view-dom-id-8474b3fc289c615dadab6e7094cead33">
-        
-  
-  
-      <div class="view-empty">
-      <a href="/online-ordering">Catering and Holiday Ordering</a>    </div>
-  
-  
-  
-  
-  
-  
-</div></span>  </div>  </div>
-     <div class="views-row views-row-2 views-row-even views-row-last">
-      
-  <div class="views-field views-field-php-1">        <span class="field-content"><a href="/nationwide">Nationwide</a></span>  </div>  
-  <div class="views-field views-field-php">        <span class="field-content"><div class="view view-monster-nav view-id-monster_nav view-display-id-level_3 view-dom-id-38c839b60d12709602d484828f5a4a5c">
-        
-  
-  
-      <div class="view-content">
-      <div class="item-list">    <ul>          <li class="views-row views-row-1 views-row-odd views-row-first views-row-last">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/gift-cards">Buy Gift Cards</a></span>  </div></li>
-      </ul></div>    </div>
-  
-  
-  
-  
-  
-  
-</div></span>  </div>  </div>
-    </div>
-  
-  
-  
-  
-  
-  
-</div></span>  </div></li>
-          <li class="views-row views-row-5 views-row-odd">  
-  <div class="views-field views-field-php-2 nav-mission--values">        <span class="field-content"><a href="/mission-values">Mission & Values</a></span>  </div>  
-  <div class="views-field views-field-php">        <span class="field-content"><div class="view view-monster-nav view-id-monster_nav view-display-id-level_2 view-dom-id-a9aec4d84097937913884fe38a322338">
-        
-  
-  
-      <div class="view-content">
-                          <div class="views-row views-row-2 views-row-even">
-      
-  <div class="views-field views-field-php-1">        <span class="field-content"><a href="/mission-values/core-values">Core Values</a></span>  </div>  
-  <div class="views-field views-field-php">        <span class="field-content"><div class="view view-monster-nav view-id-monster_nav view-display-id-level_3 view-dom-id-9e6d678eeb2abd2533734c1fa8d5a3d4">
-        
-  
-  
-      <div class="view-content">
-      <div class="item-list">    <ul>          <li class="views-row views-row-1 views-row-odd views-row-first">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/mission-values/core-values/declaration-interdependence">Declaration of Interdependence</a></span>  </div></li>
-          <li class="views-row views-row-2 views-row-even">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/mission-values/core-values/selling-highest-quality-natural-and-organic-products-available">Selling the Highest Quality Natural and Organic Products Available</a></span>  </div></li>
-          <li class="views-row views-row-3 views-row-odd">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/mission-values/core-values/satisfying-and-delighting-our-customers">Satisfying and Delighting Our Customers</a></span>  </div></li>
-          <li class="views-row views-row-4 views-row-even">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/mission-values/core-values/supporting-team-member-excellence-and-happiness">Supporting Team Member Excellence and Happiness</a></span>  </div></li>
-          <li class="views-row views-row-5 views-row-odd">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/mission-values/core-values/creating-wealth-through-profits-growth">Creating Wealth Through Profits &amp; Growth </a></span>  </div></li>
-      </ul></div>    </div>
-  
-  
-  
-  
-      <div class="view-footer">
-      <a href="/mission-values/core-values">More</a>    </div>
-  
-  
-</div></span>  </div>  </div>
-     <div class="views-row views-row-3 views-row-odd">
-      
-  <div class="views-field views-field-php-1">        <span class="field-content"><a href="/mission-values/environmental-stewardship">Environmental Stewardship</a></span>  </div>  
-  <div class="views-field views-field-php">        <span class="field-content"><div class="view view-monster-nav view-id-monster_nav view-display-id-level_3 view-dom-id-6e4c498d40e71ca6444dfae45cc05ce5">
-        
-  
-  
-      <div class="view-content">
-      <div class="item-list">    <ul>          <li class="views-row views-row-1 views-row-odd views-row-first">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/mission-values/environmental-stewardship/green-mission">Green Mission</a></span>  </div></li>
-          <li class="views-row views-row-2 views-row-even">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/mission-values/environmental-stewardship/doing-green-thing">Doing The Green Thing</a></span>  </div></li>
-          <li class="views-row views-row-3 views-row-odd">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/mission-values/environmental-stewardship/better-bag">A Better Bag™</a></span>  </div></li>
-          <li class="views-row views-row-4 views-row-even">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/mission-values/environmental-stewardship/eco-scale">Eco-Scale / Our Commitment</a></span>  </div></li>
-          <li class="views-row views-row-5 views-row-odd">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/mission-values/environmental-stewardship/genetically-engineered-foods">Genetically Engineered Foods</a></span>  </div></li>
-      </ul></div>    </div>
-  
-  
-  
-  
-      <div class="view-footer">
-      <a href="/mission-values/environmental-stewardship">More</a>    </div>
-  
-  
-</div></span>  </div>  </div>
-     <div class="views-row views-row-4 views-row-even">
-      
-  <div class="views-field views-field-php-1">        <span class="field-content"><a href="/mission-values/caring-communities">Caring for Communities</a></span>  </div>  
-  <div class="views-field views-field-php">        <span class="field-content"><div class="view view-monster-nav view-id-monster_nav view-display-id-level_3 view-dom-id-d312adeceac2cc710f1bbec48c278ea2">
-        
-  
-  
-      <div class="view-content">
-      <div class="item-list">    <ul>          <li class="views-row views-row-1 views-row-odd views-row-first">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/mission-values/caring-communities/whole-kids-foundation">Whole Kids Foundation</a></span>  </div></li>
-          <li class="views-row views-row-2 views-row-even">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/mission-values/caring-communities/local-producer-loan-program">Local Producer Loan Program</a></span>  </div></li>
-          <li class="views-row views-row-3 views-row-odd">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/mission-values/caring-communities/whole-planet-foundation">Whole Planet Foundation®</a></span>  </div></li>
-          <li class="views-row views-row-4 views-row-even views-row-last">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/mission-values/caring-communities/community-giving">Community Giving</a></span>  </div></li>
-      </ul></div>    </div>
-  
-  
-  
-  
-  
-  
-</div></span>  </div>  </div>
-     <div class="views-row views-row-5 views-row-odd">
-      
-  <div class="views-field views-field-php-1">        <span class="field-content"><a href="/mission-values/organic-farming">Organic Farming</a></span>  </div>  
-  <div class="views-field views-field-php">        <span class="field-content"><div class="view view-monster-nav view-id-monster_nav view-display-id-level_3 view-dom-id-3b78750b0b385fd8cdf5bde9221b690a">
-        
-  
-  
-      <div class="view-content">
-      <div class="item-list">    <ul>          <li class="views-row views-row-1 views-row-odd views-row-first">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/mission-values/organic-farming/farming-organically">Farming Organically</a></span>  </div></li>
-          <li class="views-row views-row-2 views-row-even">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/mission-values/organic-farming/principles-organic-farming">Principles of Organic Farming</a></span>  </div></li>
-          <li class="views-row views-row-3 views-row-odd views-row-last">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/mission-values/organic-farming/organic-industry-timeline">Organic Industry Timeline</a></span>  </div></li>
-      </ul></div>    </div>
-  
-  
-  
-  
-  
-  
-</div></span>  </div>  </div>
-                    <div class="views-row views-row-7 views-row-odd">
-      
-  <div class="views-field views-field-php-1">        <span class="field-content"><a href="/mission-values/seafood-sustainability">Seafood Sustainability</a></span>  </div>  
-  <div class="views-field views-field-php">        <span class="field-content"><div class="view view-monster-nav view-id-monster_nav view-display-id-level_3 view-dom-id-48d517bcfabbafaf7c09161f615667fd">
-        
-  
-  
-      <div class="view-content">
-      <div class="item-list">    <ul>          <li class="views-row views-row-1 views-row-odd views-row-first">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/mission-values/seafood-sustainability/wild-caught-seafood-sustainability-ratings">Wild-Caught Seafood Sustainability Ratings</a></span>  </div></li>
-          <li class="views-row views-row-2 views-row-even">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/mission-values/seafood-sustainability/seafood-sustainability-faq">Seafood Sustainability FAQ</a></span>  </div></li>
-          <li class="views-row views-row-3 views-row-odd">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/mission-values/seafood-sustainability/aquaculture">Aquaculture</a></span>  </div></li>
-          <li class="views-row views-row-4 views-row-even">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/mission-values/seafood-sustainability/our-speech-marine-stewardship-council-press-conference">Our Speech at Marine Stewardship Council Press Conference</a></span>  </div></li>
-          <li class="views-row views-row-5 views-row-odd">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/mission-values/seafood-sustainability/whole-foods-market-introduces-certified-sustainable-seafood">Certified Sustainable Seafood</a></span>  </div></li>
-      </ul></div>    </div>
-  
-  
-  
-  
-      <div class="view-footer">
-      <a href="/mission-values/seafood-sustainability">More</a>    </div>
-  
-  
-</div></span>  </div>  </div>
-     <div class="views-row views-row-8 views-row-even views-row-last">
-      
-  <div class="views-field views-field-php-1">        <span class="field-content"><a href="/mission-values/whole-trade-program">Whole Trade®</a></span>  </div>  
-  <div class="views-field views-field-php">        <span class="field-content"><div class="view view-monster-nav view-id-monster_nav view-display-id-level_3 view-dom-id-31f605338b7c5546dd81b2d73ead7c2f">
-        
-  
-  
-      <div class="view-content">
-      <div class="item-list">    <ul>          <li class="views-row views-row-1 views-row-odd views-row-first">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/mission-values/whole-trade-program/certifier-partners">Certifier Partners</a></span>  </div></li>
-          <li class="views-row views-row-2 views-row-even views-row-last">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/mission-values/whole-trade-program/whole-trade-producers">Whole Trade® Producers</a></span>  </div></li>
-      </ul></div>    </div>
-  
-  
-  
-  
-  
-  
-</div></span>  </div>  </div>
-    </div>
-  
-  
-  
-  
-  
-  
-</div></span>  </div></li>
-          <li class="views-row views-row-6 views-row-even">  
-  <div class="views-field views-field-php-2 nav-blogs">        <span class="field-content"><a href="/blogs">Blogs</a></span>  </div>  
-  <div class="views-field views-field-php">        <span class="field-content"><div class="view view-monster-nav view-id-monster_nav view-display-id-level_2 view-dom-id-3ae1ed993691cc9b2a93265e38db4c0d">
-        
-  
-  
-      <div class="view-content">
-           <div class="views-row views-row-1 views-row-odd views-row-first">
-      
-  <div class="views-field views-field-php-1">        <span class="field-content"><a href="/whole-story">Whole Story</a></span>  </div>  
-  <div class="views-field views-field-php">        <span class="field-content"><div class="view view-monster-nav view-id-monster_nav view-display-id-level_3 view-dom-id-4d7fc0c09199c23e3776dd27d8ed7ec0">
-        
-  
-  
-      <div class="view-content">
-      <div class="item-list">    <ul>          <li class="views-row views-row-1 views-row-odd views-row-first views-row-last">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/blog/whole-story">Whole Story</a></span>  </div></li>
-      </ul></div>    </div>
-  
-  
-  
-  
-  
-  
-</div></span>  </div>  </div>
-     <div class="views-row views-row-2 views-row-even views-row-last">
-      
-  <div class="views-field views-field-php-1">        <span class="field-content"><a href="/ceo-blogs">CEO Blogs</a></span>  </div>  
-  <div class="views-field views-field-php">        <span class="field-content"><div class="view view-monster-nav view-id-monster_nav view-display-id-level_3 view-dom-id-1003e4d66dadc93f14a17313606be037">
-        
-  
-  
-      <div class="view-content">
-      <div class="item-list">    <ul>          <li class="views-row views-row-1 views-row-odd views-row-first">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/blog/john-mackeys-blog">John Mackey&#039;s Blog</a></span>  </div></li>
-          <li class="views-row views-row-2 views-row-even views-row-last">  
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/blog/walter-robbs-blog">Walter Robb&#039;s Blog</a></span>  </div></li>
-      </ul></div>    </div>
-  
-  
-  
-  
-  
-  
-</div></span>  </div>  </div>
-    </div>
-  
-  
-  
-  
-  
-  
-</div></span>  </div></li>
-          <li class="views-row views-row-7 views-row-odd views-row-last">  
-  <div class="views-field views-field-php-2 nav-store-departments">        <span class="field-content"><a href="/store-departments-0">Store Departments</a></span>  </div>  
-  <div class="views-field views-field-php">        <span class="field-content"><div class="view view-monster-nav view-id-monster_nav view-display-id-level_2 view-dom-id-a8071e7ee7135c84460b18f3cd40ef65">
-        
-  
-  
-      <div class="view-content">
-                   <div class="views-row views-row-1 views-row-odd views-row-first">
-      
-  <div class="views-field views-field-php-1">        <span class="field-content"><a href="/unique-to-your-store">Unique to <em class="placeholder">Your Store</em></a></span>  </div>  
-  <div class="views-field views-field-php">        <span class="field-content"><div class="view view-monster-nav-sub-views view-id-monster_nav_sub_views view-display-id-store_services view-dom-id-295d2f87ca99b9071660ed8c0d631639">
-            <div class="view-header">
-      <a href="/events">Events Calendar</a>
-    </div>
-  
-  
-  
-      <div class="view-empty">
-      <a href="/modals/nojs/find_store" class="ctools-use-modal">Find Your Store</a>    </div>
-  
-  
-  
-  
-  
-  
-</div></span>  </div>  </div>
-     <div class="views-row views-row-2 views-row-even views-row-last">
-      
-  <div class="views-field views-field-php-1">        <span class="field-content"><a href="/store-departments">Store Departments</a></span>  </div>  
-  <div class="views-field views-field-php">        <span class="field-content"><div class="view view-monster-nav-sub-views view-id-monster_nav_sub_views view-display-id-store_departments view-dom-id-d279d7cc1545be08bcb3cd284d3e466a">
-        
-  
-  
-      <div class="view-content">
-        <div class="views-row views-row-1 views-row-odd views-row-first">
-      
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/department/bakery">Bakery</a></span>  </div>  </div>
-  <div class="views-row views-row-2 views-row-even">
-      
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/department/beer">Beer</a></span>  </div>  </div>
-  <div class="views-row views-row-3 views-row-odd">
-      
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/department/bulk">Bulk</a></span>  </div>  </div>
-  <div class="views-row views-row-4 views-row-even">
-      
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/department/cheese">Cheese</a></span>  </div>  </div>
-  <div class="views-row views-row-5 views-row-odd">
-      
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/department/coffee-tea">Coffee &amp; Tea</a></span>  </div>  </div>
-  <div class="views-row views-row-6 views-row-even">
-      
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/department/floral">Floral</a></span>  </div>  </div>
-  <div class="views-row views-row-7 views-row-odd">
-      
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/department/grocery">Grocery</a></span>  </div>  </div>
-  <div class="views-row views-row-8 views-row-even">
-      
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/department/meat-poultry">Meat &amp; Poultry</a></span>  </div>  </div>
-  <div class="views-row views-row-9 views-row-odd">
-      
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/department/pets">Pets</a></span>  </div>  </div>
-  <div class="views-row views-row-10 views-row-even">
-      
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/department/prepared-foods">Prepared Foods</a></span>  </div>  </div>
-  <div class="views-row views-row-11 views-row-odd">
-      
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/department/produce">Produce</a></span>  </div>  </div>
-  <div class="views-row views-row-12 views-row-even">
-      
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/department/seafood">Seafood</a></span>  </div>  </div>
-  <div class="views-row views-row-13 views-row-odd">
-      
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/department/whole-body">Whole Body</a></span>  </div>  </div>
-  <div class="views-row views-row-14 views-row-even views-row-last">
-      
-  <div class="views-field views-field-title">        <span class="field-content"><a href="/department/wine">Wine</a></span>  </div>  </div>
-    </div>
-  
-  
-  
-  
-  
-  
-</div></span>  </div>  </div>
-    </div>
-  
-  
-  
-  
-  
-  
-</div></span>  </div></li>
-      </ul></div>    </div>
-  
-  
-  
-  
-  
-  
-</div></span>  </div></li>
-      </ul></div>    </div>
-  
-  
-  
-  
-  
-  
-</div></noscript></div>  </div>
+    <a href="/" class="home-link">Whole Foods Market</a><div class="nav-tab"><div class="nav-tab-copy1"></div><div class="nav-tab-arrow"></div></div><div class="main-links-container desktop"><ul class="menu"><li class="first expanded"><a href="/healthy-eating" class="primary-link healthy-eating">Healthy Eating</a><div class="menu-drop-container" id="monster-nav-healthy-eating"><ul class="menu"><li class="first expanded"><a href="/healthy-eating/getting-started" class="secondary-link">Getting Started</a><div class="sub-menu-drop-container" id="monster-sub-nav-getting-started"><ul class="menu"><li class="first leaf"><a href="/healthy-eating/four-pillars-healthy-eating">4 Ways to a Healthier You</a></li>
+<li class="collapsed"><a href="/health-starts-here%C2%AE">Health Starts Here</a></li>
+<li class="leaf"><a href="/healthy-eating/simple-changes-lifelong-health">Simple Changes for Lifelong Health</a></li>
+<li class="last collapsed"><a href="/healthy-eating/resources">Resources</a></li>
+</ul></div></li>
+<li class="expanded"><a href="/healthy-eating/what-to-eat" class="secondary-link">What to Eat</a><div class="sub-menu-drop-container" id="monster-sub-nav-what-to-eat"><ul class="menu"><li class="first leaf"><a href="/healthy-eating/healthy-recipes">Healthy Recipes</a></li>
+<li class="collapsed"><a href="/healthy-eating/meal-plans">Weekly Meal Plans</a></li>
+<li class="last leaf"><a href="/healthy-eating/engine-2">The Engine 2® Diet</a></li>
+</ul></div></li>
+<li class="expanded"><a href="/healthy-eating/healthy-cooking" class="secondary-link">Healthy Cooking</a><div class="sub-menu-drop-container" id="monster-sub-nav-healthy-cooking"><ul class="menu"><li class="first leaf"><a href="/healthy-eating/healthy-pantry-makeover">Healthy Pantry Makeover</a></li>
+<li class="leaf"><a href="/healthy-eating/healthy-cooking-videos">Healthy Cooking Videos</a></li>
+<li class="leaf"><a href="/healthy-eating/cooking-whole-grains">Cooking with Whole Grains</a></li>
+<li class="leaf"><a href="/healthy-eating/add-flavor-naturally">Add Flavor, Naturally</a></li>
+<li class="last leaf"><a href="/healthy-eating/andi-guide">ANDI Guide</a></li>
+</ul></div></li>
+<li class="last expanded"><a href="/healthy-eating/family-and-special-diets" class="secondary-link">Family and Special Diets</a><div class="sub-menu-drop-container" id="monster-sub-nav-family-and-special-diets"><ul class="menu"><li class="first collapsed"><a href="/healthy-eating/healthy-eating-for-whole-family">Parents &amp; Kids</a></li>
+<li class="last collapsed"><a href="/healthy-eating/special-diets">Special Diets</a></li>
+</ul></div></li>
+</ul></div></li>
+<li class="expanded"><a href="/about-our-products" class="primary-link about-our-products">About Our Products</a><div class="menu-drop-container" id="monster-nav-about-our-products"><ul class="menu"><li class="first expanded"><a href="/quality-standards" class="secondary-link">Our Quality Standards</a><div class="sub-menu-drop-container" id="monster-sub-nav-our-quality-standards"><ul class="menu"><li class="first leaf"><a href="/about-our-products/organic-food">Organic Food</a></li>
+<li class="leaf"><a href="/about-our-products/quality-standards/food-ingredient">Food Ingredient Quality Standards</a></li>
+<li class="leaf"><a href="/mission-values/animal-welfare/animal-welfare-basics">Meat Animal Welfare Standards</a></li>
+<li class="collapsed"><a href="/premium-body-care-standards">Premium Body Care Standards</a></li>
+<li class="collapsed"><a href="/responsibly-grown">Responsibly Grown</a></li>
+<li class="first expanded"><a href="/quality-standards">More</a></li>
+</ul></div></li>
+<li class="expanded"><a href="/product-ingredient-faq" class="secondary-link">Product Ingredient FAQs</a><div class="sub-menu-drop-container" id="monster-sub-nav-product-ingredient-faqs"><ul class="menu"><li class="first leaf"><a href="/about-our-products/product-faq/gmos">Product FAQs: GMOs</a></li>
+<li class="leaf"><a href="/about-our-products/product-faq/food-allergies">Food Allergies</a></li>
+<li class="leaf"><a href="/about-our-products/product-faq/ingredients">Ingredients</a></li>
+<li class="leaf"><a href="/about-our-products/product-faq/milk-and-eggs">Milk and Eggs</a></li>
+<li class="leaf"><a href="/about-our-products/product-faq/olive-oil">Olive Oil</a></li>
+<li class="expanded"><a href="/product-ingredient-faq">More</a></li>
+</ul></div></li>
+<li class="expanded"><a href="/about-our-products/food-safety" class="secondary-link">Food Safety</a><div class="sub-menu-drop-container" id="monster-sub-nav-food-safety"><ul class="menu"><li class="first leaf"><a href="/about-our-products/food-safety/bisphenol">Bisphenol-A</a></li>
+<li class="leaf"><a href="/about-our-products/food-safety/cold-storage-chart">Cold Storage Chart</a></li>
+<li class="leaf"><a href="/about-our-products/food-safety/handling-meat-poultry-safely">Handling Meat &amp; Poultry Safely</a></li>
+<li class="leaf"><a href="/about-our-products/food-safety/handling-seafood-safely">Handling Seafood Safely</a></li>
+<li class="leaf"><a href="/about-our-products/food-safety/irradiation-us-and-canada">Irradiation (US and Canada)</a></li>
+<li class="expanded"><a href="/about-our-products/food-safety">More</a></li>
+</ul></div></li>
+<li class="expanded"><a href="/gmo-your-right-know" class="secondary-link">GMOs: Your Right to Know</a><div class="sub-menu-drop-container" id="monster-sub-nav-gmos-your-right-to-know"><ul class="menu"><li class="first leaf"><a href="/gmo-quick-facts-what-why-where">GMO Quick Facts: What, Why, Where</a></li>
+<li class="leaf"><a href="/how-shop-if-youre-avoiding-gmos">How To Shop if You’re Avoiding GMOs</a></li>
+<li class="leaf"><a href="/our-commitment-gmo-transparency">Our Commitment to GMO Labeling</a></li>
+<li class="last leaf"><a href="/faqs-gmos">FAQs on GMOs</a></li>
+</ul></div></li>
+<li class="expanded"><a href="/about-our-products/our-product-lines" class="secondary-link">Our Product Lines</a><div class="sub-menu-drop-container" id="monster-sub-nav-our-product-lines"><ul class="menu"><li class="first leaf"><a href="/about-our-products/product-lines/365-everyday-value">365 Everyday Value</a></li>
+<li class="leaf"><a href="/about-our-products/product-lines/engine-2">Engine 2® Plant-Strong®</a></li>
+<li class="leaf"><a href="/about-our-products/product-lines/whole-foods-market-brand">Whole Foods Market Brand</a></li>
+<li class="last leaf"><a href="/about-our-products/product-lines/whole-trade">Whole Trade</a></li>
+</ul></div></li>
+<li class="last expanded"><a href="/local" class="secondary-link">Locally Grown</a><div class="sub-menu-drop-container" id="monster-sub-nav-locally-grown"><ul class="menu"><li class="first leaf"><a href="/locally-grown">Local Growers Map</a></li>
+<li class="last leaf"><a href="/local-vendor-profiles">Local Vendor Profiles</a></li>
+</ul></div></li>
+</ul></div></li>
+<li class="expanded"><a href="/recipes" class="primary-link recipes">Recipes</a><div class="menu-drop-container" id="monster-nav-recipes"><ul class="menu"><li class="first expanded"><a href="/recipe-landing" class="secondary-link">Recipes</a><div class="sub-menu-drop-container" id="monster-sub-nav-recipes"><ul class="menu"><li class="first leaf"><a href="/recipe-landing-featured">Featured</a></li>
+<li class="leaf"><a href="/recipe-landing-newest">Newest</a></li>
+<li class="last leaf"><a href="/recipe-landing-toprated">Top Rated</a></li>
+</ul></div></li>
+<li class="expanded"><a href="/recipes/cooking-entertainment-guides" class="secondary-link">Cooking &amp; Entertainment Guides</a><div class="sub-menu-drop-container" id="monster-sub-nav-cooking--entertainment-guides"><ul class="menu"><li class="first collapsed"><a href="/holidays">Holiday Guide</a></li>
+<li class="leaf"><a href="/recipes/cooking-entertainment-guides/perfect-antipasto-plate">The Perfect Antipasto Plate</a></li>
+<li class="leaf"><a href="/recipes/cooking-entertainment-guides/tapas-tiny-treasures-spain">Tapas: Tiny Treasures of Spain</a></li>
+<li class="leaf"><a href="/cooking-tips">Cooking Tips</a></li>
+<li class="leaf"><a href="/hosting-tips">Hosting Tips</a></li>
+<li class="expanded"><a href="/recipes/cooking-entertainment-guides">More</a></li>
+</ul></div></li>
+<li class="expanded"><a href="/recipes/food-guides" class="secondary-link">Food Guides</a><div class="sub-menu-drop-container" id="monster-sub-nav-food-guides"><ul class="menu"><li class="first leaf"><a href="/recipes/food-guides/beans">Beans</a></li>
+<li class="leaf"><a href="/recipes/food-guides/chocolate">Chocolate</a></li>
+<li class="leaf"><a href="/recipes/food-guides/cooking-oils">Cooking Oils</a></li>
+<li class="leaf"><a href="/recipes/food-guides/dairy-products">Dairy Products</a></li>
+<li class="leaf"><a href="/recipes/food-guides/eggs">Eggs</a></li>
+<li class="expanded"><a href="/recipes/food-guides">More</a></li>
+</ul></div></li>
+<li class="last expanded"><a href="/seasonal-recipe-collections" class="secondary-link">Seasonal Recipe Collections</a><div class="sub-menu-drop-container" id="monster-sub-nav-seasonal-recipe-collections"><ul class="menu"><li class="first leaf"><a href="/recipes/engine-2">ENGINE 2® RECIPES</a></li>
+<li class="leaf"><a href="/recipes/broccoli">Brilliant Broccoli Recipes</a></li>
+<li class="leaf"><a href="/recipes/healthy-snacks">Healthy Snack Recipes</a></li>
+<li class="leaf"><a href="/recipes/pancakes">Perfect Pancake Recipes</a></li>
+<li class="leaf"><a href="/recipes/protein-packed">Protein-Packed Recipes</a></li>
+<li class="last expanded"><a href="/seasonal-recipe-collections">More</a></li>
+</ul></div></li>
+</ul></div></li>
+<li class="expanded"><a href="/online-ordering" class="primary-link online-ordering">Online Ordering</a><div class="menu-drop-container" id="monster-nav-online-ordering"><ul class="menu"><li class="first leaf"><a href="/online-ordering-available-your-store" rel="online_ordering" class="dynamic ajax-load secondary-link">Available At Your Store</a><div class="sub-menu-drop-container" id="monster-sub-nav-available-at-your-store"><ul class="links"><li class="0 first last"><a href="/online-ordering">Catering &amp; Holiday Ordering</a></li>
+</ul></div></li>
+<li class="last expanded"><a href="/nationwide" class="secondary-link">Nationwide</a><div class="sub-menu-drop-container" id="monster-sub-nav-nationwide"><ul class="menu"><li class="first leaf"><a href="https://www.wholefoodsmarket.com/buy-gift-cards">Gift Cards</a></li>
+<li class="leaf"><a href="/gift-cards/gift-cards-terms-and-conditions">Gift Card(s) Terms and Conditions</a></li>
+<li class="last leaf"><a href="/gift-cards/gift-cards-faq">Gift Cards FAQ</a></li>
+</ul></div></li>
+</ul></div></li>
+<li class="expanded"><a href="/mission-values" class="primary-link mission-values">Mission &amp; Values</a><div class="menu-drop-container" id="monster-nav-mission--values"><ul class="menu"><li class="first expanded"><a href="/our-values" class="secondary-link">Our Values</a><div class="sub-menu-drop-container" id="monster-sub-nav-our-values"><ul class="menu"><li class="first last collapsed"><a href="/mission-values/core-values">Core Values</a></li>
+</ul></div></li>
+<li class="expanded"><a href="/mission-values/caring-communities" class="secondary-link">Commitment to Society</a><div class="sub-menu-drop-container" id="monster-sub-nav-commitment-to-society"><ul class="menu"><li class="first leaf"><a href="/mission-values/caring-communities/community-giving">Community Giving</a></li>
+<li class="collapsed"><a href="/mission-values/caring-communities/local-producer-loan-program">Local Producer Loan Program</a></li>
+<li class="leaf"><a href="/mission-values/caring-communities/whole-kids-foundation">Whole Kids Foundation</a></li>
+<li class="leaf"><a href="/mission-values/caring-communities/whole-planet-foundation">Whole Planet Foundation</a></li>
+<li class="last leaf"><a href="/whole-cities-foundation">Whole Cities Foundation</a></li>
+</ul></div></li>
+<li class="expanded"><a href="/mission-values/environmental-stewardship" class="secondary-link">Environmental Stewardship</a><div class="sub-menu-drop-container" id="monster-sub-nav-environmental-stewardship"><ul class="menu"><li class="first leaf"><a href="/mission-values/environmental-stewardship/better-bag">A Better Bag</a></li>
+<li class="leaf"><a href="/mission-values/environmental-stewardship/cloned-meat-qa">Cloned Meat Q&amp;A</a></li>
+<li class="leaf"><a href="/mission-values/environmental-stewardship/doing-green-thing">Doing The Green Thing</a></li>
+<li class="collapsed"><a href="/mission-values/environmental-stewardship/eco-scale">Eco Scale</a></li>
+<li class="last leaf"><a href="/mission-values/environmental-stewardship/green-mission">Green Mission</a></li>
+</ul></div></li>
+<li class="expanded"><a href="/organic" class="secondary-link">Organic Farming</a><div class="sub-menu-drop-container" id="monster-sub-nav-organic-farming"><ul class="menu"><li class="first leaf"><a href="/mission-values/organic/basics-organic">The Basics of Organic</a></li>
+<li class="leaf"><a href="/mission-values/organic/growth-organics-industry">Growth of the Organics Industry</a></li>
+<li class="leaf"><a href="/mission-values/organic/about-organic-farming">About Organic Farming</a></li>
+<li class="leaf"><a href="/mission-values/organic-farming/farming-organically">Farming Organically</a></li>
+<li class="leaf"><a href="/mission-values/organic/how-does-biodynamic-farming-fit">How Does Biodynamic Farming Fit In?</a></li>
+<li class="expanded"><a href="/organic">More</a></li>
+</ul></div></li>
+<li class="expanded"><a href="/mission-values/seafood-sustainability" class="secondary-link">Seafood Sustainability</a><div class="sub-menu-drop-container" id="monster-sub-nav-seafood-sustainability"><ul class="menu"><li class="first leaf"><a href="/seafood-sustainability-basics">Seafood Sustainability Basics</a></li>
+<li class="leaf"><a href="/missions-values/seafood-sustainability/our-collaboration-marine-stewardship-council">Our Collaboration with the Marine Stewardship Council</a></li>
+<li class="collapsed"><a href="/mission-values/seafood-sustainability/wild-caught-seafood-sustainability-ratings">Wild-Caught Seafood Sustainability Ratings</a></li>
+<li class="leaf"><a href="/mission-values/seafood-sustainability/aquaculture">Aquaculture</a></li>
+<li class="leaf"><a href="/mission-values/seafood-sustainability/seafood-sustainability-faq">Seafood Sustainability FAQ</a></li>
+<li class="expanded"><a href="/mission-values/seafood-sustainability">More</a></li>
+</ul></div></li>
+<li class="expanded"><a href="/mission-values/whole-trade-program" class="secondary-link">Whole Trade</a><div class="sub-menu-drop-container" id="monster-sub-nav-whole-trade"><ul class="menu"><li class="first leaf"><a href="/whole-trade/whole-trade-helps-real-people">Whole Trade Helps Real People</a></li>
+<li class="leaf"><a href="/whole-trade/whole-trade-videos">Whole Trade Videos</a></li>
+<li class="leaf"><a href="/whole-trade/whole-trade-products">Whole Trade Products</a></li>
+<li class="last leaf"><a href="/mission-values/whole-trade-program/certifier-partners">Our Certifier Partners</a></li>
+</ul></div></li>
+<li class="last expanded"><a href="/mission-values/animal-welfare" class="secondary-link">Animal Welfare</a><div class="sub-menu-drop-container" id="monster-sub-nav-animal-welfare"><ul class="menu"><li class="first leaf"><a href="/mission-values/animal-welfare/5-step-animal-welfare-rating">5-Step™ Animal Welfare Rating</a></li>
+<li class="leaf"><a href="/mission-values/animal-welfare/animal-welfare-basics">Animal Welfare Basics</a></li>
+<li class="leaf"><a href="/mission-values/animal-welfare/collaboration-global-animal-partnership">Collaboration with Global Animal Partnership</a></li>
+<li class="last leaf"><a href="/mission-values/animal-welfare/meet-farmers-ranchers">Meet the Farmers &amp; Ranchers</a></li>
+</ul></div></li>
+</ul></div></li>
+<li class="expanded"><a href="/blogs" class="primary-link blogs">Blogs</a><div class="menu-drop-container" id="monster-nav-blogs"><ul class="menu"><li class="first expanded"><a href="/whole-story" class="secondary-link">Whole Story</a><div class="sub-menu-drop-container" id="monster-sub-nav-whole-story"><ul class="menu"><li class="first last leaf"><a href="/blog/whole-story">Whole Story Blog</a></li>
+</ul></div></li>
+<li class="last expanded"><a href="/ceo-blogs" class="secondary-link">CEO Blogs</a><div class="sub-menu-drop-container" id="monster-sub-nav-ceo-blogs"><ul class="menu"><li class="first leaf"><a href="/blog/john-mackeys-blog">John Mackey&#039;s Blog</a></li>
+<li class="last leaf"><a href="/blog/walter-robbs-blog">Walter Robb&#039;s Blog</a></li>
+</ul></div></li>
+</ul></div></li>
+<li class="last expanded"><a href="/store-departments" class="primary-link store-departments">Store Departments</a><div class="menu-drop-container" id="monster-nav-store-departments"><ul class="menu"><li class="first expanded"><a href="/unique-to-your-store" rel="store_services" class="dynamic ajax-load secondary-link">Unique To Your Store</a><div class="sub-menu-drop-container" id="monster-sub-nav-unique-to-your-store"><ul class="links"><li class="0 first"><a href="/events">Events Calendar</a></li>
+<li class="1 last"><a href="/stores/list">Find Your Store</a></li>
+</ul></div></li>
+<li class="last expanded"><a href="/store-departments" rel="store_departments" class="dynamic ajax-load two-cols secondary-link">Store Departments</a><div class="sub-menu-drop-container" id="monster-sub-nav-store-departments"><ul class="links"><li class="0 first"><a href="/department/bakery">Bakery</a></li>
+<li class="1"><a href="/department/beer">Beer</a></li>
+<li class="2"><a href="/department/bulk">Bulk</a></li>
+<li class="3"><a href="/department/cheese">Cheese</a></li>
+<li class="4"><a href="/department/coffee-tea">Coffee &amp; Tea</a></li>
+<li class="5"><a href="/department/floral">Floral</a></li>
+<li class="6"><a href="/department/grocery">Grocery</a></li>
+<li class="7"><a href="/department/meat-poultry">Meat &amp; Poultry</a></li>
+<li class="8"><a href="/department/prepared-foods">Prepared Foods</a></li>
+<li class="9"><a href="/department/produce">Produce</a></li>
+<li class="10"><a href="/department/seafood">Seafood</a></li>
+<li class="11"><a href="/department/wine">Wine</a></li>
+<li class="12"><a href="/department/whole-body">Whole Body</a></li>
+<li class="13 last"><a href="/department/pets">Pets</a></li>
+</ul></div></li>
+</ul></div></li>
+</ul></div>  </div>
 </div>
   </div>
     </div>
@@ -941,22 +295,27 @@ ONETSP_TIME: Tue, 09 Oct 2012 18:59:48 -0700
     
   <div class="content">
     <div class="marquee-left"><div class="marquee-right">
-     <div class="view view-marquee-page view-id-marquee_page view-display-id-block view-dom-id-c27e1c62606e59ba559505167c848b82">
+     <div class="view view-marquee-page view-id-marquee_page view-display-id-block view-dom-id-038598ae564d01fb4de27e2b8332590e">
+        
+  
+  
+      <div class="view-content">
+        <div class="views-row views-row-1 views-row-odd views-row-first views-row-last">
+      </div>
+    </div>
+  
+  
+  
+  
+      <div class="view-footer">
+       <div class="view view-marquee-page view-id-marquee_page view-display-id-heading_image view-dom-id-e68846628c5577b72d3636c5bf637dad">
         
   
   
       <div class="view-content">
         <div class="views-row views-row-1 views-row-odd views-row-first views-row-last">
       
-  <div class="views-field views-field-field-heading-copy">        <div class="field-content"></div>  </div>  
-  <div class="views-field views-field-php">        <span class="field-content"><div class="view view-marquee-page view-id-marquee_page view-display-id-heading_image view-dom-id-d220c09d6011dc2f0b182ef8b5c4c720">
-        
-  
-  
-      <div class="view-content">
-        <div class="views-row views-row-1 views-row-odd views-row-first views-row-last">
-      
-  <div class="views-field views-field-field-heading-background">        <div class="field-content"><img typeof="foaf:Image" src="http://d1kg9jbrq423rq.cloudfront.net/sites/default/files/styles/marquee_other/public/media/Global/Recipes/recipes-121003-marquee2_0.jpg" width="1680" height="521" /></div>  </div>  </div>
+  <div class="views-field views-field-field-heading-background">        <div class="field-content"><img src="http://www.wholefoodsmarket.com/sites/all/themes/wholefoods/images/blank-marquee.gif" width="1680" height="521" /></div>  </div>  </div>
     </div>
   
   
@@ -964,12 +323,7 @@ ONETSP_TIME: Tue, 09 Oct 2012 18:59:48 -0700
   
   
   
-</div></span>  </div>  </div>
-    </div>
-  
-  
-  
-  
+</div>     </div>
   
   
 </div>    </div></div>
@@ -983,74 +337,71 @@ ONETSP_TIME: Tue, 09 Oct 2012 18:59:48 -0700
         
                 <div class="tabs"></div>                
            <div id="content-top">  <div class="region region-content-top">
-    <div id="block-views-promo-blocks-block" class="block block-views">
-<div class="torn-pod-header"></div>
-  <div class="torn-pod-content">
-    
-  <div class="content">
-    <div class="view view-promo-blocks view-id-promo_blocks view-display-id-block view-dom-id-d2a9709740b2f572c47c2740251d09c5">
-        
-  
-  
-  
-  
-  
-  
-  
-  
-</div>  </div>
-</div>
-<div class="torn-pod-footer"></div>
-</div>
-<div id="block-views-recipe-header-recipe-header" class="block block-views">
+    <div id="block-healthy-eating-recipe-individual-page-header" class="block block-healthy-eating">
 
     
   <div class="content">
     <div class="torn-pod-top"></div>
-<div class="torn-pod-content test">
-<div id="breadcrumb"><h2 class="element-invisible">You are here</h2><div class="breadcrumb"><a href="/%3Cfont%3E">Home</a> » <a href="/recipes">Recipes</a> » Mushroom Kale Noodle Kugel</div></div><div class="view view-recipe-header view-id-recipe_header view-display-id-recipe_header view-dom-id-6930199fde7bc3dc07513cf9c54666eb">
+<div class="torn-pod-content test clearfix outer">
+<div id="breadcrumb"><div class="breadcrumb"><a href="/">Home</a> » <a href="/recipes">Recipes</a> » Mushroom Kale Noodle Kugel</div></div><div class="view view-recipe-header view-id-recipe_header view-display-id-recipe_header view-dom-id-f183f38cf0dfb4a6578cd6e4e8a4dc0e">
         
   
   
       <div class="view-content">
         <div class="views-row views-row-1 views-row-odd views-row-first views-row-last">
     <div class="torn-pod-header"></div>
-<div class="torn-pod-content" itemscope itemtype="http://schema.org/Recipe">
-        
-     
-  <div>        <div class="field-content recipe-image"><img ref="Whatever" typeof="foaf:Image" src="http://d1kg9jbrq423rq.cloudfront.net/sites/default/files/styles/product_hero/public/3112.jpg" width="425" height="285" alt="" /></div>  </div>     
-  <div class="views-field views-field-title">        <span class="field-content"><h2 itemprop="name">Mushroom Kale Noodle Kugel</h2></span>  </div>     
-  <div class="views-field views-field-php-1">        <span class="field-content"><div id="user-ratings">
-<p>
-<!-- STRIPPED SCRIPT TAG --></p>
+<div class="torn-pod-content">
+  
+  <div>        <div class="field-content recipe-image"><div class="field field-name-field-hero-image field-type-image field-label-hidden">
+<img typeof="foaf:Image" src="http://www.wholefoodsmarket.com/sites/default/files/styles/header_recipe/public/media/3112.jpg?itok=Fr9HAs9k" width="425" height="268" alt="Mushroom Kale Noodle Kugel" title="Mushroom Kale Noodle Kugel" /></div> </div>  </div>  
+  <div class="views-field views-field-title">        <span class="field-content"><h1>Mushroom Kale Noodle Kugel</h1></span>  </div>  
+  <div class="views-field views-field-nothing user-ratings">        <span class="field-content"><a class="recipe-featured-in-802 recipe-featured-in-8476" href="/healthy-eating/health-starts-here"></a>
+<div id="user-ratings">
+  <!-- STRIPPED SCRIPT TAG -->
 </div>
 <!--user-ratings -->
+</span>  </div>  
+  <div class="views-field views-field-nothing-1 share-links">        <span class="field-content"><div class="social-links clearfix">
+<div id="fb-root"></div>
+<!-- STRIPPED SCRIPT TAG -->
 
-<!-- STRIPPED SCRIPT TAG -->
-<div class="addthis_toolbox addthis_default_style addthis:url="http%3A%2F%2Fwww.wholefoodsmarket.com%2Frecipes%2F3112" addthis:title="Mushroom Kale Noodle Kugel" addthis:description="">
-<a class="addthis_button_compact">Share</a>
+<div class="recipe-fb socfl">
+  <fb:like send="false" layout="button_count" width="450" show_faces="false";></fb:like>
 </div>
-<!-- STRIPPED SCRIPT TAG -->
-<!-- AddThis Button END --></span>  </div>     
-  <div class="views-field views-field-field-serves">    <span class="views-label views-label-field-serves">Serves: </span>    <div class="field-content">8</div>  </div>     
-  <div class="views-field views-field-body">        <div class="field-content"><span itemprop="description"> <p>This hearty dish features mushrooms, kale and egg noodles, bound with cottage cheese and sour cream for richness. Use a variety of mushrooms in place of the button mushrooms, if you like.</p> </span></div>  </div>     
-  <div class="views-field views-field-php">        <span class="field-content links">
+
+<div class="recipe-twitter socfl">
+  <a href="https://twitter.com/share" class="twitter-share-button">Tweet</a>
+  <!-- STRIPPED SCRIPT TAG -->
+</div>
+
+<!-- added a Google+ button -->
+<div class="socfl google-plus">
+ <div class="g-plusone" data-size="medium"></div>
+ <!-- STRIPPED SCRIPT TAG -->
+</div>
+
+<div class="pinit socfl">
+  <a data-pin-config="beside"
+     href="//pinterest.com/pin/create/button/?url=http%3A%2F%2Fwww.wholefoodsmarket.com%2Frecipe%2Fmushroom-kale-noodle-kugel&media=http%3A%2F%2Fwww.wholefoodsmarket.com%2Fsites%2Fdefault%2Ffiles%2Fmedia%2F3112.jpg&description=This+hearty+dish+features+mushrooms%2C+kale+and+egg+noodles%2C+bound+with+cottage+cheese+and+sour+cream+for+richness.+Use+a+variety+of+mushrooms+in+place+of+the+button+mushrooms%2C+if+you+like."
+     data-pin-do="buttonPin" ><img src="//assets.pinterest.com/images/pidgets/pin_it_button.png" /></a>
+</div>
+</div>
+
+</span>  </div>  
+  <div class="views-field views-field-field-serves">        <div class="field-content">Serves 8</div>  </div>  
+  <div class="views-field views-field-body">        <div class="field-content"> This hearty dish features mushrooms, kale and egg noodles, bound with cottage cheese and sour cream for richness. Use a variety of mushrooms in place of the button mushrooms, if you like. </div>  </div>  
+  <div class="views-field views-field-nothing-2 recipe-links">        <span class="field-content">
 <ul>
-  <li>
-      <a href="/user/janrain_register" class="add-to-shopping-list fancy iframe">add to recipe box</a>    </li>
-  <li>
-    <a href="/modals/nojs/print/21467" class="print ctools-use-modal recipe-print" data-title="Mushroom Kale Noodle Kugel" rid="3112">print</a>  </li>
-  <li>
-  <a href="/user?qt-user_profile_self=2" class="view-saved-recipes">view saved recipes</a>  </li>
-  <li>
-    <a href="mailto:?subject=Mushroom+Kale+Noodle+Kugel&body=http%3A%2F%2Fwww.wholefoodsmarket.com%2Frecipes%2F3112">
-    email</a>
-  </li>
+  <li class="user_recipe_links">
+    <a href="/signin" class="shopping-list-login capture_modal_open">Log in or create an account to save favorite recipes to your Recipe Box</a>    </li>
+  <li class="user_recipe_print">
+    <a href="/modals/nojs/print/103491" class="print ctools-use-modal recipe-print" data-title="Mushroom Kale Noodle Kugel" title="Print recipe" rid="3112">print</a>  </li>
+  <li class="user_recipe_email">
+  <a href="mailto:?subject=A%20recipe%20for%20you%3A%20Mushroom%20Kale%20Noodle%20Kugel%20%7C%20WholeFoodsMarket.com&amp;body=I%20thought%20you%20might%20like%20this%20recipe%20from%20Whole%20Foods%20Market%20at%20http%3A//www.wholefoodsmarket.com/recipe/mushroom-kale-noodle-kugel%0A%0ASign%20up%20for%20our%20newsletters%20for%20even%20more%20Whole%20Foods%20Market%20recipes%3A%20http%3A//www.wholefoodsmarket.com/newsletters/%3Fpromo%3Drecipes" class="email" title="Email recipe">email</a>  </li>
 </ul>
-</span>  </div>     
-  <div class="views-field views-field-php-2">        <span class="field-content"><a href="/" class="user-submitted-links view-photos">View user submitted photos</a><!-- STRIPPED SCRIPT TAG -->
-<ul class="ad-thumb-list" id="thumb-container"></ul>
-</span>  </div></div>
+</span>  </div>  
+  <div class="views-field views-field-nothing-3 photos">        <span class="field-content"></span>  </div>  
+  <div class="views-field views-field-nothing-4">        <span class="field-content"><p class="pin-link"><a href="/pinterest"><span></span></a><a class="text-link" href="/pinterest">Check out our top pins!</a></p></span>  </div></div>
 <div class="torn-pod-footer"></div>
   </div>
     </div>
@@ -1067,11 +418,11 @@ ONETSP_TIME: Tue, 09 Oct 2012 18:59:48 -0700
   </div>
 </div>
      
-      <div id="content" class="column "><div class="section">
+      <div id="content" class="column  with-sidebar"><div class="section">
                 <a id="main-content"></a>
         <div class="torn-pod-header"></div>
         <div class="torn-pod-content">
-                              <div id="breadcrumb"><h2 class="element-invisible">You are here</h2><div class="breadcrumb"><a href="/%3Cfont%3E">Home</a> » <a href="/recipes">Recipes</a> » Mushroom Kale Noodle Kugel</div></div>          
+                              <div id="breadcrumb"><div class="breadcrumb"><a href="/">Home</a> » <a href="/recipes">Recipes</a> » Mushroom Kale Noodle Kugel</div></div>          
           <div class="contentbox ">
             <div class="region region-content">
     <div id="block-system-main" class="block block-system">
@@ -1079,83 +430,62 @@ ONETSP_TIME: Tue, 09 Oct 2012 18:59:48 -0700
     
   <div class="content">
     
-<div id="node-21467" class="node node-recipe clearfix" about="/recipes/3112" typeof="sioc:Item foaf:Document" itemscope itemtype="http://schema.org/Recipe">
+<div id="node-103491" class="node node-recipe clearfix" about="/recipe/mushroom-kale-noodle-kugel" typeof="sioc:Item foaf:Document">
 
-      
+      <span property="dc:title" content="Mushroom Kale Noodle Kugel" class="rdf-meta element-hidden"></span><span property="sioc:num_replies" content="0" datatype="xsd:integer" class="rdf-meta element-hidden"></span>
   <div class="content">
-    <span class="print-link"></span><div class="field-group-format group_left field-group-div group-left  speed-fast effect-none">
+    <div class="field-group-format group_left field-group-div group-left  speed-fast effect-none">
 <div class="field field-name-field-ingredients field-type-text-with-summary field-label-above clearfix">
       <div class="field-label">Ingredients: </div>
-    <div itemprop="ingredients" itemscope itemtype="http://schema.org/Ingredients" class="field-items">
+    <div class="field-items">
     <ul class="ingredient_ul">
-	    	    	<li><span itemprop="ingredients">
-2  tablespoons unsalted butter, plus more for buttering</span></li>
-
-	    	    	<li><span itemprop="ingredients">
-1  package wide enriched egg noodles</span></li>
-
-	    	    	<li><span itemprop="ingredients">
-1 yellow onion, chopped</span></li>
-
-	    	    	<li><span itemprop="ingredients">
-1  pound white/button or cremini mushrooms, sliced</span></li>
-
-	    	    	<li><span itemprop="ingredients">
- 1/2 teaspoon freshly ground black pepper</span></li>
-
-	    	    	<li><span itemprop="ingredients">
-1  teaspoon fine sea salt, divided</span></li>
-
-	    	    	<li><span itemprop="ingredients">
-1  bunch kale (about 3/4 pound), stemmed and thinly sliced</span></li>
-
-	    	    	<li><span itemprop="ingredients">
-1  tablespoon finely chopped thyme</span></li>
-
-	    	    	<li><span itemprop="ingredients">
-4 eggs, beaten</span></li>
-
-	    	    	<li><span itemprop="ingredients">
-1 1/4 cup low-fat cottage cheese</span></li>
-
-	    	    	<li><span itemprop="ingredients">
- 3/4 cup low fat sour cream</span></li>
-
-	    	</ul>
+	          <li><span>
+         2 tablespoons unsalted butter, plus more for buttering       </span></li>
+           <li><span>
+         1 (16-ounce) package wide enriched egg noodles       </span></li>
+           <li><span>
+         1 yellow onion, chopped       </span></li>
+           <li><span>
+         1 pound white/button or cremini mushrooms, sliced       </span></li>
+           <li><span>
+          1/2 teaspoon freshly ground black pepper       </span></li>
+           <li><span>
+         1 teaspoon fine sea salt, divided       </span></li>
+           <li><span>
+         1 bunch kale (about 3/4 pound), stemmed and thinly sliced       </span></li>
+           <li><span>
+         1 tablespoon finely chopped thyme       </span></li>
+           <li><span>
+         4 eggs, beaten       </span></li>
+           <li><span>
+         1 1/4 cup low-fat cottage cheese       </span></li>
+           <li><span>
+          3/4 cup low fat sour cream       </span></li>
+     	  </ul>
   </div>
 </div>
-<!--
-THIS FILE IS NOT USED AND IS HERE AS A STARTING POINT FOR CUSTOMIZATION ONLY.
-See http://api.drupal.org/api/function/theme_field/7 for details.
-After copying this file to your theme's folder and customizing it, remove this
-HTML comment.
--->
-<div class="field field-name-field-recipe-directions field-type-text-with-summary field-label-above clearfix">
-      <div class="field-label">Method: </div>
-    <div itemprop="recipeInstructions" itemscope itemtype="http://schema.org/RecipeInstructions" class="field-items">
-          <p><span itemprop="recipeInstructions">Preheat oven to 350&deg;F. Butter a 9- x 13-inch dish; set aside. Cook noodles in boiling, salted water until al dente. Drain, rinse and drain again; transfer to a large bowl. Heat butter in a large skillet over medium-high heat. Add onions and cook, stirring occasionally, until golden, 8 to 10 minutes. Add mushrooms, pepper and 1/2 teaspoon salt; cook until mushrooms are very tender, 8 to 10 minutes. Stir in kale and cook until wilted, 2 to 3 minutes; add thyme. Add to noodles, toss and set aside. Whisk together eggs, cottage cheese, sour cream and remaining salt. Fold into noodles. Transfer to prepared dish, press down gently, cover with foil and bake 30 minutes. Uncover and continue to bake until lightly browned, about 10 minutes more. Serve warm or room temperature.</span></p>      </div>
-</div></div><div class="field-group-format group_right field-group-div group-right  speed-fast effect-none"><!--
-THIS FILE IS NOT USED AND IS HERE AS A STARTING POINT FOR CUSTOMIZATION ONLY.
-See http://api.drupal.org/api/function/theme_field/7 for details.
-After copying this file to your theme's folder and customizing it, remove this
-HTML comment.
--->
-<div class="field field-name-field-nutritional-info field-type-text-with-summary field-label-above clearfix">
-      <div class="field-label">Nutritional Info: </div>
-    <div itemprop="nutrition" itemscope itemtype="http://schema.org/NutritionInformation" class="field-items">
-    <h4>Per Serving:</h4>
-    <ul class="nutritional-info">
-              <li><span itemprop="calories">360 calories (90 from fat)</span></li><li><span itemprop="fatContent">10g total fat</span></li><li><span itemprop="saturatedFatContent">4.5g saturated fat</span></li><li><span itemprop="cholesterolContent">170mg cholesterol</span></li><li><span itemprop="sodiumContent">520mg sodium</span></li><li><span itemprop="carbohydrateContent">52g carbohydrate</span> (<span itemprop="fiberContent">3g dietary fiber</span>, <span itemprop="sugarContent">6g sugar)</span></li><li><span itemprop="proteinContent">19g protein</span></li>          </ul>
-  </div>
-</div>
-  <div class="field field-name-field-special-diet field-type-node-reference field-label-above clearfix">
-      <div class="field-label">Special Diets: </div>
-    <ul class="recipe_special_diets">  
-      <li class="recipe_special_diet_item"><a href="/healthy-eating/special-diets/vegetarian">Vegetarian</a></li>
-    </ul>
-  <p class="disclaimer">Note: We've provided special diet and nutritional information for educational purposes. But remember — we're cooks, not doctors! You should follow the advice of your health-care provider. And since product formulations change, check product labels for the most recent ingredient information. See our <a href="/terms-use">Terms of Service.</a></p>
-  </div>
 
+  <div class="clearfix">
+    <form class="disabled-form" action="/recipe/mushroom-kale-noodle-kugel" method="post" id="healthy-eating-add-recipe-ingredients-form" accept-charset="UTF-8"><div><input type="hidden" name="rid" value="5370fad432619a2d6d365999" />
+<input type="hidden" name="user" value="0" />
+<div class="form-item form-type-select form-item-shopping-list form-disabled">
+ <select class="disabled-form form-select" disabled="disabled" id="edit-shopping-list" name="shopping_list"><option value="0">Add ingredients to shopping list</option><option value="new">Create a new list...</option></select>
+</div>
+<input type="submit" id="edit-submit--3" name="op" value="Add" class="form-submit" /><div id="form-msg"><div id="extra-msg"></div>You must be signed in to use shopping lists. <a href="/signin" class="capture_modal_open">Sign in or create account</a></div><fieldset class="form-wrapper" id="edit-new-list"><div class="fieldset-wrapper"><div class="form-item form-type-textfield form-item-new-list-name">
+  <label for="edit-new-list-name">Create a new list: </label>
+ <input type="text" id="edit-new-list-name" name="new_list_name" value="" size="60" maxlength="128" class="form-text" />
+</div>
+<input type="submit" id="edit-new-list-button" name="op" value="Create List" class="form-submit" /><a href="" class="cancel-button">Cancel</a></div></fieldset>
+<input type="hidden" name="form_build_id" value="form-YrdCxh6wPfJx3H22sSl6r3mK2Rt-QVn-QCriB6Xi9_A" />
+<input type="hidden" name="form_id" value="healthy_eating_add_recipe_ingredients_form" />
+</div></form>  </div>
+<div class="field field-name-field-recipe-directions field-type-text-with-summary field-label-above"><div class="field-label">Method: </div><div class="field-items"><div class="field-item even"> Preheat oven to 350°F. Butter a 9- x 13-inch dish; set aside. Cook noodles in boiling, salted water until al dente. Drain, rinse and drain again; transfer to a large bowl. Heat butter in a large skillet over medium-high heat. Add onions and cook, stirring occasionally, until golden, 8 to 10 minutes. Add mushrooms, pepper and 1/2 teaspoon salt; cook until mushrooms are very tender, 8 to 10 minutes. Stir in kale and cook until wilted, 2 to 3 minutes; add thyme. Add to noodles, toss and set aside. Whisk together eggs, cottage cheese, sour cream and remaining salt. Fold into noodles. Transfer to prepared dish, press down gently, cover with foil and bake 30 minutes. Uncover and continue to bake until lightly browned, about 10 minutes more. Serve warm or room temperature. </div></div></div></div><div class="field-group-format group_right field-group-div group-right  speed-fast effect-none"><div class="field field-name-field-nutritional-info field-type-text-with-summary field-label-above"><div class="field-label">Nutritional Info: </div><div class="field-items"><div class="field-item even"> <strong>Per Serving:</strong> <span itemprop="calories">360 calories</span> (90 from fat), <span itemprop="fatContent">10g </span>total fat, <span itemprop="saturatedFatContent">4.5g</span> saturated fat, <span itemprop="cholesterolContent">170mg</span> cholesterol, <span itemprop="sodiumContent">520mg</span> sodium, <span itemprop="carbohydrateContent">52g</span> carbohydrates, (3 <span itemprop="fiberContent">g</span> dietary fiber, <span itemprop="sugarContent">6g</span> sugar), <span itemprop="proteinContent">19g</span> protein. </div></div></div>  <div class="field field-name-field-special-diet field-type-node-reference field-label-above clearfix">
+          <div class="field-label">Special Diets: </div>
+        <ul class="recipe_special_diets">
+              <li class="recipe_special_diet_item"><a href="/healthy-eating/special-diets/vegetarian">Vegetarian</a></li>
+          </ul>
+    <p class="disclaimer">Note: We've provided special diet and nutritional information for educational purposes. But remember — we're cooks, not doctors! You should follow the advice of your health-care provider. And since product formulations change, check product labels for the most recent ingredient information. See our <a href="/terms-use">Terms of Service.</a></p>
+  </div>
 </div>  </div>
 
 </div>
@@ -1170,6 +500,436 @@ HTML comment.
       </div></div> <!-- /.section, /#content -->
 
       
+              <div id="sidebar-second" class="column sidebar">
+
+           <div class="section">
+            <div class="torn-pod-header"></div>
+           <div class="torn-pod-content">
+              <div class="region region-sidebar-second">
+    <div id="block-healthy-eating-recipe-search" class="block block-healthy-eating">
+	<div class="torn-pod-header"></div>
+  <div class="torn-pod-content">
+    
+  <div class="content">
+    <form action="/recipe/mushroom-kale-noodle-kugel" method="post" id="healthy-eating-recipe-search" accept-charset="UTF-8"><div><div class="form-item form-type-textfield form-item-search-box">
+ <input type="text" id="edit-search-box" name="search_box" value="Search our 3891 recipes" size="60" maxlength="250" class="form-text" />
+</div>
+<input type="submit" id="edit-submit" name="op" value="Search" class="form-submit" /><a href="/" class="advanced-search-link" id="edit-advanced-link">Advanced Search</a><fieldset class="form-wrapper" id="edit-advanced"><legend><span class="fieldset-legend">Filter Recipes By:</span></legend><div class="fieldset-wrapper"><fieldset class="form-wrapper" id="edit-special-occasions"><div class="fieldset-wrapper"><div class="form-item form-type-checkboxes form-item-field-special-diet">
+  <label for="edit-field-special-diet">Special Diet </label>
+ <div id="edit-field-special-diet" class="form-checkboxes"><div class="form-item form-type-checkbox form-item-field-special-diet-138">
+ <input type="checkbox" id="edit-field-special-diet-138" name="field_special_diet[138]" value="138" class="form-checkbox" />  <label class="option" for="edit-field-special-diet-138">Dairy Free </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-special-diet-25068">
+ <input type="checkbox" id="edit-field-special-diet-25068" name="field_special_diet[25068]" value="25068" class="form-checkbox" />  <label class="option" for="edit-field-special-diet-25068">Fat Free </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-special-diet-139">
+ <input type="checkbox" id="edit-field-special-diet-139" name="field_special_diet[139]" value="139" class="form-checkbox" />  <label class="option" for="edit-field-special-diet-139">Gluten Free </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-special-diet-25066">
+ <input type="checkbox" id="edit-field-special-diet-25066" name="field_special_diet[25066]" value="25066" class="form-checkbox" />  <label class="option" for="edit-field-special-diet-25066">High Fiber </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-special-diet-21">
+ <input type="checkbox" id="edit-field-special-diet-21" name="field_special_diet[21]" value="21" class="form-checkbox" />  <label class="option" for="edit-field-special-diet-21">Low Fat </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-special-diet-22">
+ <input type="checkbox" id="edit-field-special-diet-22" name="field_special_diet[22]" value="22" class="form-checkbox" />  <label class="option" for="edit-field-special-diet-22">Low Sodium </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-special-diet-137">
+ <input type="checkbox" id="edit-field-special-diet-137" name="field_special_diet[137]" value="137" class="form-checkbox" />  <label class="option" for="edit-field-special-diet-137">Sugar Conscious </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-special-diet-158786">
+ <input type="checkbox" id="edit-field-special-diet-158786" name="field_special_diet[158786]" value="158786" class="form-checkbox" />  <label class="option" for="edit-field-special-diet-158786">Vegan </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-special-diet-25">
+ <input type="checkbox" id="edit-field-special-diet-25" name="field_special_diet[25]" value="25" class="form-checkbox" />  <label class="option" for="edit-field-special-diet-25">Vegetarian </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-special-diet-828">
+ <input type="checkbox" id="edit-field-special-diet-828" name="field_special_diet[828]" value="828" class="form-checkbox" />  <label class="option" for="edit-field-special-diet-828">Wheat Free </label>
+
+</div>
+</div>
+</div>
+<div class="form-item form-type-checkboxes form-item-field-recipe-occasions">
+  <label for="edit-field-recipe-occasions">Occasion </label>
+ <div id="edit-field-recipe-occasions" class="form-checkboxes"><div class="form-item form-type-checkbox form-item-field-recipe-occasions-791">
+ <input type="checkbox" id="edit-field-recipe-occasions-791" name="field_recipe_occasions[791]" value="791" class="form-checkbox" />  <label class="option" for="edit-field-recipe-occasions-791">Christmas </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-occasions-765">
+ <input type="checkbox" id="edit-field-recipe-occasions-765" name="field_recipe_occasions[765]" value="765" class="form-checkbox" />  <label class="option" for="edit-field-recipe-occasions-765">New Year's </label>
+
+</div>
+</div>
+</div>
+</div></fieldset>
+<div class="form-item form-type-checkboxes form-item-field-recipe-course">
+  <label for="edit-field-recipe-course">Type of Dish </label>
+ <div id="edit-field-recipe-course" class="form-checkboxes"><div class="form-item form-type-checkbox form-item-field-recipe-course-751">
+ <input type="checkbox" id="edit-field-recipe-course-751" name="field_recipe_course[751]" value="751" class="form-checkbox" />  <label class="option" for="edit-field-recipe-course-751">Appetizers </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-course-798">
+ <input type="checkbox" id="edit-field-recipe-course-798" name="field_recipe_course[798]" value="798" class="form-checkbox" />  <label class="option" for="edit-field-recipe-course-798">Breads and Muffins </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-course-801">
+ <input type="checkbox" id="edit-field-recipe-course-801" name="field_recipe_course[801]" value="801" class="form-checkbox" />  <label class="option" for="edit-field-recipe-course-801">Breakfast and Brunch </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-course-828">
+ <input type="checkbox" id="edit-field-recipe-course-828" name="field_recipe_course[828]" value="828" class="form-checkbox" />  <label class="option" for="edit-field-recipe-course-828">Desserts </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-course-288126">
+ <input type="checkbox" id="edit-field-recipe-course-288126" name="field_recipe_course[288126]" value="288126" class="form-checkbox" />  <label class="option" for="edit-field-recipe-course-288126">Dressings, Sauces and Condiments </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-course-827">
+ <input type="checkbox" id="edit-field-recipe-course-827" name="field_recipe_course[827]" value="827" class="form-checkbox" />  <label class="option" for="edit-field-recipe-course-827">Drinks </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-course-772">
+ <input type="checkbox" id="edit-field-recipe-course-772" name="field_recipe_course[772]" value="772" class="form-checkbox" />  <label class="option" for="edit-field-recipe-course-772">Main Dishes </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-course-793">
+ <input type="checkbox" id="edit-field-recipe-course-793" name="field_recipe_course[793]" value="793" class="form-checkbox" />  <label class="option" for="edit-field-recipe-course-793">Salads </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-course-803">
+ <input type="checkbox" id="edit-field-recipe-course-803" name="field_recipe_course[803]" value="803" class="form-checkbox" />  <label class="option" for="edit-field-recipe-course-803">Sandwiches </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-course-770">
+ <input type="checkbox" id="edit-field-recipe-course-770" name="field_recipe_course[770]" value="770" class="form-checkbox" />  <label class="option" for="edit-field-recipe-course-770">Side Dishes </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-course-776">
+ <input type="checkbox" id="edit-field-recipe-course-776" name="field_recipe_course[776]" value="776" class="form-checkbox" />  <label class="option" for="edit-field-recipe-course-776">Snacks </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-course-836">
+ <input type="checkbox" id="edit-field-recipe-course-836" name="field_recipe_course[836]" value="836" class="form-checkbox" />  <label class="option" for="edit-field-recipe-course-836">Soups and Stews </label>
+
+</div>
+</div>
+</div>
+<div class="form-item form-type-checkboxes form-item-field-recipe-main-ingredient">
+  <label for="edit-field-recipe-main-ingredient">Main Ingredient </label>
+ <div id="edit-field-recipe-main-ingredient" class="form-checkboxes"><div class="form-item form-type-checkbox form-item-field-recipe-main-ingredient-789">
+ <input type="checkbox" id="edit-field-recipe-main-ingredient-789" name="field_recipe_main_ingredient[789]" value="789" class="form-checkbox" />  <label class="option" for="edit-field-recipe-main-ingredient-789">Beans and Lentils </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-main-ingredient-783">
+ <input type="checkbox" id="edit-field-recipe-main-ingredient-783" name="field_recipe_main_ingredient[783]" value="783" class="form-checkbox" />  <label class="option" for="edit-field-recipe-main-ingredient-783">Beef </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-main-ingredient-762">
+ <input type="checkbox" id="edit-field-recipe-main-ingredient-762" name="field_recipe_main_ingredient[762]" value="762" class="form-checkbox" />  <label class="option" for="edit-field-recipe-main-ingredient-762">Cheese </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-main-ingredient-845">
+ <input type="checkbox" id="edit-field-recipe-main-ingredient-845" name="field_recipe_main_ingredient[845]" value="845" class="form-checkbox" />  <label class="option" for="edit-field-recipe-main-ingredient-845">Chocolate </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-main-ingredient-785">
+ <input type="checkbox" id="edit-field-recipe-main-ingredient-785" name="field_recipe_main_ingredient[785]" value="785" class="form-checkbox" />  <label class="option" for="edit-field-recipe-main-ingredient-785">Dairy </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-main-ingredient-795">
+ <input type="checkbox" id="edit-field-recipe-main-ingredient-795" name="field_recipe_main_ingredient[795]" value="795" class="form-checkbox" />  <label class="option" for="edit-field-recipe-main-ingredient-795">Eggs </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-main-ingredient-767">
+ <input type="checkbox" id="edit-field-recipe-main-ingredient-767" name="field_recipe_main_ingredient[767]" value="767" class="form-checkbox" />  <label class="option" for="edit-field-recipe-main-ingredient-767">Fruit </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-main-ingredient-833">
+ <input type="checkbox" id="edit-field-recipe-main-ingredient-833" name="field_recipe_main_ingredient[833]" value="833" class="form-checkbox" />  <label class="option" for="edit-field-recipe-main-ingredient-833">Grains </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-main-ingredient-839">
+ <input type="checkbox" id="edit-field-recipe-main-ingredient-839" name="field_recipe_main_ingredient[839]" value="839" class="form-checkbox" />  <label class="option" for="edit-field-recipe-main-ingredient-839">Lamb </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-main-ingredient-792">
+ <input type="checkbox" id="edit-field-recipe-main-ingredient-792" name="field_recipe_main_ingredient[792]" value="792" class="form-checkbox" />  <label class="option" for="edit-field-recipe-main-ingredient-792">Nuts </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-main-ingredient-800">
+ <input type="checkbox" id="edit-field-recipe-main-ingredient-800" name="field_recipe_main_ingredient[800]" value="800" class="form-checkbox" />  <label class="option" for="edit-field-recipe-main-ingredient-800">Pasta </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-main-ingredient-775">
+ <input type="checkbox" id="edit-field-recipe-main-ingredient-775" name="field_recipe_main_ingredient[775]" value="775" class="form-checkbox" />  <label class="option" for="edit-field-recipe-main-ingredient-775">Pork </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-main-ingredient-768">
+ <input type="checkbox" id="edit-field-recipe-main-ingredient-768" name="field_recipe_main_ingredient[768]" value="768" class="form-checkbox" />  <label class="option" for="edit-field-recipe-main-ingredient-768">Poultry </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-main-ingredient-834">
+ <input type="checkbox" id="edit-field-recipe-main-ingredient-834" name="field_recipe_main_ingredient[834]" value="834" class="form-checkbox" />  <label class="option" for="edit-field-recipe-main-ingredient-834">Rice </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-main-ingredient-771">
+ <input type="checkbox" id="edit-field-recipe-main-ingredient-771" name="field_recipe_main_ingredient[771]" value="771" class="form-checkbox" />  <label class="option" for="edit-field-recipe-main-ingredient-771">Seafood </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-main-ingredient-786">
+ <input type="checkbox" id="edit-field-recipe-main-ingredient-786" name="field_recipe_main_ingredient[786]" value="786" class="form-checkbox" />  <label class="option" for="edit-field-recipe-main-ingredient-786">Tofu/Soy </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-main-ingredient-754">
+ <input type="checkbox" id="edit-field-recipe-main-ingredient-754" name="field_recipe_main_ingredient[754]" value="754" class="form-checkbox" />  <label class="option" for="edit-field-recipe-main-ingredient-754">Vegetables </label>
+
+</div>
+</div>
+</div>
+<div class="form-item form-type-checkboxes form-item-field-recipe-cusine">
+  <label for="edit-field-recipe-cusine">Cuisine </label>
+ <div id="edit-field-recipe-cusine" class="form-checkboxes"><div class="form-item form-type-checkbox form-item-field-recipe-cusine-831">
+ <input type="checkbox" id="edit-field-recipe-cusine-831" name="field_recipe_cusine[831]" value="831" class="form-checkbox" />  <label class="option" for="edit-field-recipe-cusine-831">African </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-cusine-821">
+ <input type="checkbox" id="edit-field-recipe-cusine-821" name="field_recipe_cusine[821]" value="821" class="form-checkbox" />  <label class="option" for="edit-field-recipe-cusine-821">Asian </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-cusine-817">
+ <input type="checkbox" id="edit-field-recipe-cusine-817" name="field_recipe_cusine[817]" value="817" class="form-checkbox" />  <label class="option" for="edit-field-recipe-cusine-817">Central/South American </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-cusine-1102881">
+ <input type="checkbox" id="edit-field-recipe-cusine-1102881" name="field_recipe_cusine[1102881]" value="1102881" class="form-checkbox" />  <label class="option" for="edit-field-recipe-cusine-1102881">European </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-cusine-829">
+ <input type="checkbox" id="edit-field-recipe-cusine-829" name="field_recipe_cusine[829]" value="829" class="form-checkbox" />  <label class="option" for="edit-field-recipe-cusine-829">Indian </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-cusine-835">
+ <input type="checkbox" id="edit-field-recipe-cusine-835" name="field_recipe_cusine[835]" value="835" class="form-checkbox" />  <label class="option" for="edit-field-recipe-cusine-835">Jewish </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-cusine-777">
+ <input type="checkbox" id="edit-field-recipe-cusine-777" name="field_recipe_cusine[777]" value="777" class="form-checkbox" />  <label class="option" for="edit-field-recipe-cusine-777">Mediterranean </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-cusine-1102891">
+ <input type="checkbox" id="edit-field-recipe-cusine-1102891" name="field_recipe_cusine[1102891]" value="1102891" class="form-checkbox" />  <label class="option" for="edit-field-recipe-cusine-1102891">Mexican and Tex-Mex </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-cusine-749">
+ <input type="checkbox" id="edit-field-recipe-cusine-749" name="field_recipe_cusine[749]" value="749" class="form-checkbox" />  <label class="option" for="edit-field-recipe-cusine-749">Middle Eastern </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-cusine-1102886">
+ <input type="checkbox" id="edit-field-recipe-cusine-1102886" name="field_recipe_cusine[1102886]" value="1102886" class="form-checkbox" />  <label class="option" for="edit-field-recipe-cusine-1102886">Southern American </label>
+
+</div>
+</div>
+</div>
+<div class="form-item form-type-checkboxes form-item-field-recipe-category">
+  <label for="edit-field-recipe-category">Category </label>
+ <div id="edit-field-recipe-category" class="form-checkboxes"><div class="form-item form-type-checkbox form-item-field-recipe-category-788">
+ <input type="checkbox" id="edit-field-recipe-category-788" name="field_recipe_category[788]" value="788" class="form-checkbox" />  <label class="option" for="edit-field-recipe-category-788">Budget Friendly </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-category-779">
+ <input type="checkbox" id="edit-field-recipe-category-779" name="field_recipe_category[779]" value="779" class="form-checkbox" />  <label class="option" for="edit-field-recipe-category-779">Cooking with Kids </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-category-757">
+ <input type="checkbox" id="edit-field-recipe-category-757" name="field_recipe_category[757]" value="757" class="form-checkbox" />  <label class="option" for="edit-field-recipe-category-757">Entertaining </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-category-758">
+ <input type="checkbox" id="edit-field-recipe-category-758" name="field_recipe_category[758]" value="758" class="form-checkbox" />  <label class="option" for="edit-field-recipe-category-758">Family Friendly </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-category-806">
+ <input type="checkbox" id="edit-field-recipe-category-806" name="field_recipe_category[806]" value="806" class="form-checkbox" />  <label class="option" for="edit-field-recipe-category-806">Gifts </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-category-1102876">
+ <input type="checkbox" id="edit-field-recipe-category-1102876" name="field_recipe_category[1102876]" value="1102876" class="form-checkbox" />  <label class="option" for="edit-field-recipe-category-1102876">Learn to Cook </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-category-759">
+ <input type="checkbox" id="edit-field-recipe-category-759" name="field_recipe_category[759]" value="759" class="form-checkbox" />  <label class="option" for="edit-field-recipe-category-759">Make Ahead </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-category-760">
+ <input type="checkbox" id="edit-field-recipe-category-760" name="field_recipe_category[760]" value="760" class="form-checkbox" />  <label class="option" for="edit-field-recipe-category-760">No Cook </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-category-825">
+ <input type="checkbox" id="edit-field-recipe-category-825" name="field_recipe_category[825]" value="825" class="form-checkbox" />  <label class="option" for="edit-field-recipe-category-825">One Dish Meals </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-category-811">
+ <input type="checkbox" id="edit-field-recipe-category-811" name="field_recipe_category[811]" value="811" class="form-checkbox" />  <label class="option" for="edit-field-recipe-category-811">Picnic and Potluck </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-category-814">
+ <input type="checkbox" id="edit-field-recipe-category-814" name="field_recipe_category[814]" value="814" class="form-checkbox" />  <label class="option" for="edit-field-recipe-category-814">Quick and Easy </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-category-838">
+ <input type="checkbox" id="edit-field-recipe-category-838" name="field_recipe_category[838]" value="838" class="form-checkbox" />  <label class="option" for="edit-field-recipe-category-838">Slow Cooker </label>
+
+</div>
+</div>
+</div>
+<div class="form-item form-type-checkboxes form-item-field-recipe-featured-in">
+  <label for="edit-field-recipe-featured-in">Limit To Recipes Featured In </label>
+ <div id="edit-field-recipe-featured-in" class="form-checkboxes"><div class="form-item form-type-checkbox form-item-field-recipe-featured-in-8481">
+ <input type="checkbox" id="edit-field-recipe-featured-in-8481" name="field_recipe_featured_in[8481]" value="8481" class="form-checkbox" />  <label class="option" for="edit-field-recipe-featured-in-8481">Health Starts Here® </label>
+
+</div>
+<div class="form-item form-type-checkbox form-item-field-recipe-featured-in-8476">
+ <input type="checkbox" id="edit-field-recipe-featured-in-8476" name="field_recipe_featured_in[8476]" value="8476" class="form-checkbox" />  <label class="option" for="edit-field-recipe-featured-in-8476">The Whole Deal® </label>
+
+</div>
+</div>
+</div>
+</div></fieldset>
+<input type="hidden" name="form_build_id" value="form-M0L2qlAV1maSSPi8FnIiyMyUvCp4xuJZICMH1jaiIWo" />
+<input type="hidden" name="form_id" value="healthy_eating_recipe_search" />
+</div></form>  </div>
+</div>
+<div class="torn-pod-footer"></div>
+</div>
+<div id="block-newsletters-newsletters-sidebar-form" class="block block-newsletters">
+
+    
+  <div class="content">
+    <form class="newsletter-ajax-form" action="/recipe/mushroom-kale-noodle-kugel" method="post" id="newsletters-sidebar-subscription-form" accept-charset="UTF-8"><div><div class="newsletter-text-wrap form-wrapper" id="edit-blurb-wrap"><h3>Recipe Newsletter</h3><address>Get seasonal recipes and cooking tips delivered to your inbox!</address>
+</div><div class="newsletter-input-wrap form-wrapper" id="edit-input-wrap"><div class="form-item form-type-textfield form-item-EMAIL-ADDRESS-">
+  <label for="edit-email-address-">Email Address </label>
+ <input class="email form-text" type="text" id="edit-email-address-" name="EMAIL_ADDRESS_" value="" size="60" maxlength="128" />
+</div>
+<input type="submit" id="edit-submit--2" name="op" value="Subscribe" class="form-submit" /></div><input type="hidden" name="_ri_" value="X0Gzc2X%3DWQpglLjHJlTQGtGr3IffgP5zd4klaWza4KbC1FhKqiVwjpnpgHlpgneHmgJoXX0Gzc2X%3DWQpglLjHJlTQGhDovatpotIUdHB8Pszeo6Y9oPpzeE" />
+<input type="hidden" name="PROMO" value="WFM.com" />
+<input type="hidden" name="SUB_PROMO" value="RecipesOptIn" />
+<input type="hidden" name="EMAIL_PERMISSION_STATUS_" value="I" />
+<input type="hidden" name="form_build_id" value="form-qSH6UYjDFS7H2PNuaCElaT3aX6mnTzP4ewNHjLt_S7U" />
+<input type="hidden" name="form_id" value="newsletters_sidebar_subscription_form" />
+<input type="hidden" name="Recipes" value="1" />
+</div></form>  </div>
+</div>
+<div id="block-views-related-recipes-featured" class="block block-views">
+
+    <h2>Featured Recipes</h2>
+  
+  <div class="content">
+    <div class="view view-related-recipes view-id-related_recipes view-display-id-featured view-dom-id-606b0b6093842ee98c71f9424d784392">
+        
+  
+  
+      <div class="view-content">
+        <div class="views-row views-row-1 views-row-odd views-row-first">
+      
+  <div class="views-field views-field-title">        <span class="field-content"><a href="/recipe/superfast-guac">Superfast Guac</a></span>  </div>  </div>
+  <div class="views-row views-row-2 views-row-even">
+      
+  <div class="views-field views-field-title">        <span class="field-content"><a href="/recipe/giant-white-beans-vegetables-and-pickled-pepper-vinaigrette">Giant White Beans with Vegetables and Pickled Pepper Vinaigrette</a></span>  </div>  </div>
+  <div class="views-row views-row-3 views-row-odd">
+      
+  <div class="views-field views-field-title">        <span class="field-content"><a href="/recipe/spicy-tomato-soup-poached-eggs-and-blue-cheese">Spicy Tomato Soup with Poached Eggs and Blue Cheese</a></span>  </div>  </div>
+  <div class="views-row views-row-4 views-row-even">
+      
+  <div class="views-field views-field-title">        <span class="field-content"><a href="/recipe/creamy-spiced-pear-hot-cereal">Creamy Spiced Pear Hot Cereal</a></span>  </div>  </div>
+  <div class="views-row views-row-5 views-row-odd">
+      
+  <div class="views-field views-field-title">        <span class="field-content"><a href="/recipe/roasted-red-pepper-pasta-sauce">Roasted Red Pepper Pasta Sauce</a></span>  </div>  </div>
+  <div class="views-row views-row-6 views-row-even">
+      
+  <div class="views-field views-field-title">        <span class="field-content"><a href="/recipe/beef-and-quinoa-meatballs">Beef and Quinoa Meatballs</a></span>  </div>  </div>
+  <div class="views-row views-row-7 views-row-odd">
+      
+  <div class="views-field views-field-title">        <span class="field-content"><a href="/recipe/southwestern-baked-tilapia">Southwestern Baked Tilapia</a></span>  </div>  </div>
+  <div class="views-row views-row-8 views-row-even">
+      
+  <div class="views-field views-field-title">        <span class="field-content"><a href="/recipe/tofu-and-broccoli-quiche">Tofu and Broccoli Quiche</a></span>  </div>  </div>
+  <div class="views-row views-row-9 views-row-odd views-row-last">
+      
+  <div class="views-field views-field-title">        <span class="field-content"><a href="/recipe/indian-spiced-yogurt-marinated-chicken">Indian-Spiced Yogurt-Marinated Chicken</a></span>  </div>  </div>
+    </div>
+  
+  
+  
+  
+  
+  
+</div>  </div>
+</div>
+<div id="block-views-related-recipes-related" class="block block-views">
+
+    <h2>Related Recipes</h2>
+  
+  <div class="content">
+    <div class="view view-related-recipes view-id-related_recipes view-display-id-related view-dom-id-0022c9cae5ac92f0ce5bf5e6ada22f8c">
+        
+  
+  
+      <div class="view-content">
+        <div class="views-row views-row-1 views-row-odd views-row-first">
+      
+  <div class="views-field views-field-title">        <span class="field-content"><a href="/recipe/bay-scallop-linguine-white-wine-and-parsley">Bay Scallop Linguine with White Wine and Parsley</a></span>  </div>  </div>
+  <div class="views-row views-row-2 views-row-even">
+      
+  <div class="views-field views-field-title">        <span class="field-content"><a href="/recipe/old-fashioned-tuna-noodle-casserole">Old-Fashioned Tuna Noodle Casserole</a></span>  </div>  </div>
+  <div class="views-row views-row-3 views-row-odd">
+      
+  <div class="views-field views-field-title">        <span class="field-content"><a href="/recipe/spicy-vegetable-chow-mein">Spicy Vegetable Chow Mein</a></span>  </div>  </div>
+  <div class="views-row views-row-4 views-row-even">
+      
+  <div class="views-field views-field-title">        <span class="field-content"><a href="/recipe/roasted-vegetable-lasagna">Roasted Vegetable Lasagna</a></span>  </div>  </div>
+  <div class="views-row views-row-5 views-row-odd">
+      
+  <div class="views-field views-field-title">        <span class="field-content"><a href="/recipe/sweet-potato-and-goat-cheese-ravioli-sage-broth">Sweet Potato and Goat Cheese Ravioli in Sage Broth</a></span>  </div>  </div>
+  <div class="views-row views-row-6 views-row-even">
+      
+  <div class="views-field views-field-title">        <span class="field-content"><a href="/recipe/pad-thai-tofu">Pad Thai Tofu</a></span>  </div>  </div>
+  <div class="views-row views-row-7 views-row-odd">
+      
+  <div class="views-field views-field-title">        <span class="field-content"><a href="/recipe/butternut-squash-ravioli">Butternut Squash Ravioli</a></span>  </div>  </div>
+  <div class="views-row views-row-8 views-row-even">
+      
+  <div class="views-field views-field-title">        <span class="field-content"><a href="/recipe/penne-and-broccoli-zesty-gorgonzola-sauce">Penne and Broccoli with Zesty Gorgonzola Sauce</a></span>  </div>  </div>
+  <div class="views-row views-row-9 views-row-odd">
+      
+  <div class="views-field views-field-title">        <span class="field-content"><a href="/recipe/spaghetti-and-meatballs">Spaghetti and Meatballs</a></span>  </div>  </div>
+  <div class="views-row views-row-10 views-row-even views-row-last">
+      
+  <div class="views-field views-field-title">        <span class="field-content"><a href="/recipe/creamy-smoked-salmon-pasta-dill">Creamy Smoked Salmon Pasta with Dill</a></span>  </div>  </div>
+    </div>
+  
+  
+  
+  
+  
+  
+</div>  </div>
+</div>
+  </div>
+            </div>
+            <div class="torn-pod-footer"></div>
+          </div>
+
+      </div> <!-- /.section, /#sidebar-second -->
+      <div class="clearfix"></div>
       
            <div id="content-bottom">  <div class="region region-content-bottom">
     <div id="block-healthy-eating-recipe-comments" class="block block-healthy-eating">
@@ -1178,16 +938,13 @@ HTML comment.
   <div class="content">
     
 <h3 id="comments-section-head">Recipe Discussion</h3>
-<!-- STRIPPED SCRIPT TAG -->
+
 <a id="comments"></a>
 <div id="pluck_comments">
   <div id="pluckComments">
     <!-- STRIPPED SCRIPT TAG -->
   </div>
-</div>
-
-<div id="Paginator" class="Comments_Page"></div>
-  </div>
+</div>  </div>
 </div>
   </div>
 </div>
@@ -1199,80 +956,393 @@ HTML comment.
   </div><div class="push"></div></div> <!-- /#page, /#page-wrapper -->
 <div id="footer"><div class="section">
         <div class="region region-footer">
-    <div id="block-menu-block-3" class="block block-menu-block">
+     <div id="block-wfm-blocks-wfm-blocks-footer" class="block block-wfm-blocks">
 
     
   <div class="content">
-    <div class="menu-block-wrapper menu-block-3 menu-name-menu-footer parent-mlid-0 menu-level-1">
-  <ul class="menu"><li class="first leaf has-children menu-mlid-1109"><a href="/careers">Careers</a></li>
-<li class="leaf menu-mlid-1110"><a href="/customer-service">Contact Us</a></li>
-<li class="leaf menu-mlid-1111"><a href="/coupons">Coupons</a></li>
-<li class="leaf menu-mlid-12941"><a href="/gift-cards">Gift Cards</a></li>
-<li class="last leaf has-children menu-mlid-1112"><a href="/company-info">Company Info</a></li>
-</ul></div>
-  </div>
-</div>
-<div id="block-menu-block-4" class="block block-menu-block">
+     <style>
+<!--/*--><![CDATA[/* ><!--*/
 
-    
-  <div class="content">
-    <div class="menu-block-wrapper menu-block-4 menu-name-menu-footer-2 parent-mlid-0 menu-level-1">
-  <ul class="menu"><li class="first leaf menu-mlid-5081"><a href="/videos">Videos</a></li>
-<li class="leaf menu-mlid-5082"><a href="/forums">Forums</a></li>
-<li class="leaf menu-mlid-5083"><a href="/site-map">Site Map</a></li>
-<li class="leaf menu-mlid-5084"><a href="/privacy-policy">Privacy</a></li>
-<li class="last leaf menu-mlid-12946"><a href="/terms-use">Terms</a></li>
-</ul></div>
-  </div>
-</div>
-<div id="block-menu-block-5" class="block block-menu-block">
-
-    
-  <div class="content">
-    <div class="menu-block-wrapper menu-block-5 menu-name-menu-footer-3 parent-mlid-0 menu-level-1">
-  <ul class="menu"><li class="first last leaf menu-mlid-5085"><a href="/newsletters">Email Subscriptions</a></li>
-</ul></div>
-  </div>
-</div>
-<div id="block-menu-menu-social-media" class="block block-menu">
-
-    <h2>Connect with us:</h2>
   
-  <div class="content">
-    <ul class="menu"><li class="first leaf"><a href="/facebook" class="facebook-link">Facebook</a></li>
-<li class="leaf"><a href="/twitter" class="twitter-link">Twitter</a></li>
-<li class="leaf"><a href="https://plus.google.com/108900531664537360582/posts" class="gplus-link" target="_blank">Google Plus</a></li>
-<li class="leaf"><a href="http://pinterest.com/wholefoods/" class="pinterest-link" target="_blank">Pintrest</a></li>
-<li class="leaf"><a href="http://www.flickr.com/photos/whole_foods" class="flickr-link" target="_blank">Flickr</a></li>
-<li class="last leaf"><a href="http://www.youtube.com/wholefoods" class="youtube-link" target="_blank">YouTube</a></li>
-</ul>  </div>
+  #footer {background-color: #fff;}
+  .front .push {height: 20px;}
+  div.footer-new-container { width: 960px; margin: 0 auto; color: #454545; font-family: "Lucida Sans", "Lucida Grande", sans-serif;  line-height: 140%;}
+  div.footer-new-container p  { margin-top: 0; padding-top: 0; color: #454545; }
+  #footer #footer-user-store-selector p {color: #454545!important;}
+  div.footer-new-container ul  { margin-left: 0; padding-left: 0; list-style-type: none; }
+  div.footer-new-container h4 { margin-bottom: 0.5em; margin-top: 2em; color: #319f52; }
+  div.footer-new-container a, #block-wfm-blocks-wfm-blocks-footer a, #block-wfm-blocks-wfm-blocks-footer a, #block-wfm-blocks-wfm-blocks-footer p, #block-wfm-blocks-wfm-blocks-footer div  { text-decoration: none;  color: #2e2e2b;}
+  div.footer-new-container a:hover, #block-wfm-blocks-wfm-blocks-footer a:hover { text-decoration: underline; color: #222;} 
+  #footer #footer-user-store-selector h4 a {color: #319f52;}
+
+  div.footer-new-container div.footer-column { float: left; width: 265px; margin-right: 35px; line-height: 24px; } 
+  div.footer-new-container div#footer-right { width: 355px; margin-right: 0;} 
+  div.footer-new-container div#footer-right p.lead-in { font-size: .8em; font-style: italic; } 
+  div.footer-new-container div#footer-right h4 a { text-decoration: underline; } 
+  div.footer-new-container div.footer-new-secondary { clear: both; padding-top: 15px; text-align:center; } 
+  div.footer-new-container div.footer-new-secondary strong { padding-right: 10px; } 
+  div.footer-new-container div.footer-new-secondary a { padding: 0 10px; } 
+  div.footer-new-container ul.socmedul li {display: inline-block; float: left; margin-right: 10px;} 
+  div.footer-new-container div.footer-subscribe { clear: both; padding-top: 10px; } 
+  div.footer-new-container p.footer-store-links a { text-decoration: underline; } 
+  div.footer-new-container ul.footer-external-links a:after, .footer-external-links a:after { content: ""; display: inline-block; background: url("//assets.wholefoodsmarket.com/www/homepage/external-link.png") no-repeat top right; width: 16px; height: 10px;} 
+  p.footer-notes { color: #f00!important; }
+  .footersomed {background:url(//assets.wholefoodsmarket.com/www/homepage/social-sprite-sm.png);}
+  .footersomed img a {border:0;}
+  .socmedicon {height: 42px; }
+  .socmedfacebook, .socmedtwitter, .socmedtwitter, .socmedgoogle, .socmedinstagram {width: 42px;}
+  .socmedfacebook {background-position: 0 0;}
+  .socmedtwitter {background-position: 0 -253px;}
+  .socmedpinterest {background-position: 0 -169px; height: 43px;width: 43px;}
+  .socmedgoogle {background-position: 0 -84px;}
+  .socmedinstagram {background-position: 0 -126px;}
+  .socmedyoutube {background-position: 0 -212px; width: 41px;}
+  .footerunder {text-decoration: underline!important;}
+
+  .block-menu-block, #block-block-3, #block-block-4, #block-menu-menu-social-media, #footer-right ul.menu, #footer-right h4.user-login, .menu-depth-1 {display: none; }
+
+  @media (max-width: 999px) {
+    
+      div.footer-column, .footer-new-secondary {clear:both; float: none; width: 306px; margin: 0px 40%;}
+    }
+
+  /* iPads (portrait) ----------- */
+  @media only screen and (min-device-width : 768px) and (max-device-width : 1024px) and (orientation : portrait) {
+      div.footer-column, .footer-new-secondary {clear:both; float: none; width: 306px; margin: 0px 30%;}
+  }
+
+  /* Hide User Login for regular Desktop theme */
+  #block-wfm-blocks-wfm-blocks-footer .user-login { display: none; }
+  .page-values-matter #block-wfm-blocks-wfm-blocks-footer .user-login,
+  .node-type-bc-image #block-wfm-blocks-wfm-blocks-footer .user-login,
+  .node-type-bc-article #block-wfm-blocks-wfm-blocks-footer .user-login,
+  .node-type-bc-coupon #block-wfm-blocks-wfm-blocks-footer .user-login,
+  .node-type-bc-connect #block-wfm-blocks-wfm-blocks-footer .user-login,
+  .node-type-bc-video #block-wfm-blocks-wfm-blocks-footer .user-login,
+  .node-type-bc-ugc-image #block-wfm-blocks-wfm-blocks-footer .user-login 
+  { display: none; }
+
+
+  
+/*--><!]]>*/
+</style><div class="footer-new-container">
+
+<!-- left column -->
+  <div class="footer-column">
+    <ul><li><h4>Shopping</h4>
+        <ul><li><a href="http://www.wholefoodsmarket.com/stores/list">Find a Store</a></li>
+          <li><a href="http://www.wholefoodsmarket.com/coupons">Coupons</a></li>
+          <li><a href="http://www.wholefoodsmarket.com/sales-flyer">Sales Flyers</a></li>
+          <!--<li><a href="http://www.wholefoodsmarket.com/about-our-products/whole-deal"><em>The Whole Deal</em><sup>&reg;</sup></a></li>-->
+          <li><a href="http://www.wholefoodsmarket.com/online-ordering">Catering &amp; Online Ordering</a></li>
+          <li><a href="http://www.wholefoodsmarket.com/buy-gift-cards">Gift Cards</a></li>
+          <li><a href="http://www.wholefoodsmarket.com/store-departments">Store Departments</a></li>
+          <li><a href="http://www.wholefoodsmarket.com/events">Store Events</a></li>
+        </ul></li>
+     
+      <li><h4>Company</h4>
+        <ul><li><a href="http://www.wholefoodsmarket.com/company-info">About Whole Foods Market</a></li>
+          <li><a href="http://www.wholefoodsmarket.com/careers/find-and-apply-jobs">Careers</a></li>
+          <li><a href="http://www.wholefoodsmarket.com/mission-values">Mission &amp; Values</a></li>
+          <!--REMOVED 27 JANUARY 2016<li><a href="http://www.wholefoodsmarket.com/company-info/information-potential-suppliers">Info for Potential Suppliers</a></li>-->
+          <li><a href="http://www.wholefoodsmarket.com/company-info/investor-relations">Investor Relations</a></li>
+          <li class="footer-external-links"><a href="http://media.wholefoodsmarket.com">Newsroom</a></li>
+          <li><a href="http://www.wholefoodsmarket.com/customer-service">Customer Service</a></li>
+        </ul></li>
+
+     <!--REMOVED 27 JANUARY 2016 and Moved to Company as MISSION & VALUES
+      <li><h4>Community &amp; Values</h4>
+        <ul>
+          <li><a href="http://www.wholefoodsmarket.com/mission-values/core-values">Our Core Values</a></li>
+          <li><a href="http://www.wholefoodsmarket.com/mission-values/caring-communities/community-giving">Community Giving</a></li>
+          <li><a href="http://www.wholefoodsmarket.com/mission-values/caring-communities/local-producer-loan-program">Local Producer Loan Program</a></li>
+          <li><a href="http://www.wholefoodsmarket.com/mission-values/whole-trade-program">Whole Trade<sup>&reg;</sup> Program</a></li>
+          <li><a href="http://www.wholefoodsmarket.com/mission-values/environmental-stewardship">Environmental Stewardship</a></li>
+          
+          <li><a href="http://www.wholefoodsmarket.com/mission-values/animal-welfare">Animal Welfare</a></li>
+          <li><a href="http://www.wholefoodsmarket.com/mission-values/seafood-sustainability">Seafood Sustainability</a></li>
+        </ul>
+      </li>
+    </ul>
+    -->
+  </ul></div><!-- left column -->
+
+
+<!-- center column -->
+  <div class="footer-column">
+    <ul><li><h4>Eating &amp; Cooking</h4>
+        <ul><li><a href="http://www.wholefoodsmarket.com/healthy-eating">Healthy Eating</a></li>
+          <!--REMOVED 27 JANUARY 2016<li><a href="http://www.wholefoodsmarket.com/recipes">Featured &amp; Top-Rated Recipes</a></li>-->
+          <li><a href="http://www.wholefoodsmarket.com/recipe-collections">Recipe Collections</a></li>
+          <li><a href="http://www.wholefoodsmarket.com/healthy-eating/special-diets">Special Diets</a></li>
+          <!--REMOVED 27 JANUARY 2016<li><a href="http://www.wholefoodsmarket.com/recipes/food-guides">Food Guides</a></li>
+          <li><li><a href="http://www.wholefoodsmarket.com/recipes/cooking-entertainment-guides">Cooking &amp; Entertainment Guides</a></li>-->
+          <li><a href="http://www.wholefoodsmarket.com/healthy-eating/kid-friendly">Parents &amp; Kids</a></li>
+        </ul></li>
+
+      <li><h4>About Our Products</h4>
+        <ul><li><a href="http://www.wholefoodsmarket.com/about-our-products/quality-standards">Quality Standards</a></li>
+          <li><a href="http://www.wholefoodsmarket.com/about-our-products/food-safety">Food Safety</a></li>
+          <li><a href="http://www.wholefoodsmarket.com/mission-values/organic/about-organic-farming">Organic Farming</a></li>
+          <li><a href="http://www.wholefoodsmarket.com/gmo-your-right-know">GMOs: Your Right to Know</a></li>
+          <!-- EMOVED 27 JANUARY 2016 <li><a href="http://www.wholefoodsmarket.com/about-our-products/our-product-lines">Our Product Lines</a></li> -->
+        </ul></li>
+
+      <h4>More from Whole Foods Market</h4>
+        <ul class="footer-external-links"><li><a href="https://www.wholeplanetfoundation.org">Whole Planet Foundation</a></li>
+          <li><a href="https://www.wholekidsfoundation.org">Whole Kids Foundation</a></li>
+          <li><a href="https://www.wholecitiesfoundation.org">Whole Cities Foundation</a></li>
+        </ul><!--REMOVED 27 JANUARY 2016 and Moved to Company as CAREERS
+      <li><h4>Careers</h4>
+        <ul>   
+          <!--REMOVED 27 JANUARY 2016
+          <li><a href="http://www.wholefoodsmarket.com/careers/find-and-apply-jobs">Find and Apply for Jobs</a></li>
+          <li><a href="http://www.wholefoodsmarket.com/careers/about-our-benefits">About Our Benefits</a></li>
+          <li><a href="http://www.wholefoodsmarket.com/careers/why-were-great-place-work">Why We're a Great Place to Work</a></li>
+        </ul>
+      </li>--><!--REMOVED 27 JANUARY 2016 
+      <li><h4>Videos</h4>
+        <ul>
+          <li><a href="http://www.wholefoodsmarket.com/videos">Featured &amp; Recent Videos</a></li>
+          <li><a href="http://www.wholefoodsmarket.com/healthy-eating/quick-simple-recipe-videos">Healthy Recipe How-Tos</a></li>
+          <li><a href="http://www.wholefoodsmarket.com/healthy-eating/healthy-cooking-videos">Healthy Cooking Techniques</a></li>
+        </ul>
+      </li>
+      <li><h4>Blogs</h4>
+        <ul>
+          <li><a href="http://www.wholefoodsmarket.com/blog/whole-story">The Whole Story</a></li>
+          <li><a href="http://www.wholefoodsmarket.com/blog/john-mackeys-blog">Co-CEO John Mackey's Blog</a></li>
+          <li><a href="http://www.wholefoodsmarket.com/blog/walter-robbs-blog">Co-CEO Walter Robb's Blog</a></li>
+        </ul>
+      </li>
+    </ul>
+  --></ul></div><!-- center column -->
+
+
+<!-- right column -->
+  <div class="footer-column" id="footer-right">
+    <h4 class="user-login">User Login</h4>
+    
+    <div id="footer-user-store-selector"><h4>Select a store</h4><p>Selecting a store allows you to see that store's content throughout the site, such as sales, store events, and more.</p><form class="store-select-form" action="/recipe/slow-cooker-split-pea-soup" method="post" id="store-select-form" accept-charset="UTF-8"><div><div class="form-item form-type-select form-item-state">
+  <label for="edit-state">Select Your Location </label>
+ <select class="state-select form-select" id="edit-state" name="state"><option value="0">Please Select Your Location</option><optgroup label="Canada"><option value="BC">British Columbia</option><option value="ON">Ontario</option></optgroup><optgroup label="United Kingdom"><option value="UK">United Kingdom</option></optgroup><optgroup label="United States"><option value="AL">Alabama</option><option value="AZ">Arizona</option><option value="AR">Arkansas</option><option value="CA">California</option><option value="CO">Colorado</option><option value="CT">Connecticut</option><option value="DC">District Of Columbia</option><option value="FL">Florida</option><option value="GA">Georgia</option><option value="HI">Hawaii</option><option value="ID">Idaho</option><option value="IL">Illinois</option><option value="IN">Indiana</option><option value="IA">Iowa</option><option value="KS">Kansas</option><option value="KY">Kentucky</option><option value="LA">Louisiana</option><option value="ME">Maine</option><option value="MD">Maryland</option><option value="MA">Massachusetts</option><option value="MI">Michigan</option><option value="MN">Minnesota</option><option value="MS">Mississippi</option><option value="MO">Missouri</option><option value="NE">Nebraska</option><option value="NV">Nevada</option><option value="NH">New Hampshire</option><option value="NJ">New Jersey</option><option value="NM">New Mexico</option><option value="NY">New York</option><option value="NC">North Carolina</option><option value="OH">Ohio</option><option value="OK">Oklahoma</option><option value="OR">Oregon</option><option value="PA">Pennsylvania</option><option value="RI">Rhode Island</option><option value="SC">South Carolina</option><option value="TN">Tennessee</option><option value="TX">Texas</option><option value="UT">Utah</option><option value="VA">Virginia</option><option value="WA">Washington</option><option value="WI">Wisconsin</option></optgroup></select>
 </div>
-<div id="block-block-3" class="block block-block">
+<div class="form-item form-type-select form-item-store">
+  <label for="edit-store">Select Your Store </label>
+ <select class="store-select form-select" id="edit-store" name="store"><option value="" selected="selected">Please Select a Store</option><optgroup label="ALBirmingham"><option value="6612">Mountain Brook - 3100 Cahaba Village Plaza</option></optgroup><optgroup label="ALHuntsville"><option value="3991101">Huntsville - 2501 Memorial Pkwy SW</option></optgroup><optgroup label="ALMobile"><option value="3627146">Mobile - 3968 Airport Blvd</option></optgroup><optgroup label="ARLittle Rock"><option value="2459776">Bowman - 501 Bowman Road</option></optgroup><optgroup label="AZChandler"><option value="6505">Chandler - 2955 West Ray Road</option></optgroup><optgroup label="AZFlagstaff"><option value="908646">Flagstaff - 320 S. Cambridge Lane</option></optgroup><optgroup label="AZPhoenix"><option value="273901">Camelback - 4701 N. 20th Street</option><option value="6682">Paradise Valley - 10810 N Tatum Blvd</option><option value="6707">Scottsdale - 7111 E. Mayo Blvd.</option></optgroup><optgroup label="AZPrescott"><option value="908651">Prescott - 1112 Iron Springs Rd.</option></optgroup><optgroup label="AZSedona"><option value="908656">Sedona - 1420 West Hwy. 89A</option></optgroup><optgroup label="AZTempe"><option value="6741">Tempe - 5120 S. Rural Rd</option></optgroup><optgroup label="AZTucson"><option value="6649">Oracle - 7133 N Oracle Rd</option><option value="109711">River Road - 5555 E. River Road</option><option value="6721">Speedway - 3360 E. Speedway Blvd.</option></optgroup><optgroup label="BCBurnaby"><option value="3969481">North Burnaby - 4420 Lougheed Highway</option></optgroup><optgroup label="BCVancouver"><option value="6513">Cambie - 510 West 8th Avenue</option><option value="6590">Kitsilano - 2285 West 4th Avenue</option><option value="6686">Robson - 1675 Robson Street</option></optgroup><optgroup label="BCWest Vancouver"><option value="6675">West Vancouver - 925 Main St</option></optgroup><optgroup label="CABerkeley"><option value="6484">Berkeley - 3000 Telegraph Ave</option><option value="1627736">Gilman - 1025 Gilman Street</option></optgroup><optgroup label="CABeverly Hills"><option value="6489">Beverly Hills - 239 North Crescent Dr</option></optgroup><optgroup label="CACampbell"><option value="6493">Campbell - 1690 South Bascom Ave</option></optgroup><optgroup label="CACapitola"><option value="6491">Capitola - 1710 41st Avenue</option></optgroup><optgroup label="CACupertino"><option value="6729">Cupertino - 20955 Stevens Creek Blvd</option></optgroup><optgroup label="CADavis"><option value="24166">Davis - 500 First Street</option></optgroup><optgroup label="CADel Mar"><option value="114206">Del Mar - 2600 Via De La Valle, Suite 100</option></optgroup><optgroup label="CADublin"><option value="3678971">Dublin CA - 5200 Dublin Blvd.</option></optgroup><optgroup label="CAEl Segundo"><option value="6656">Plaza El Segundo - 760 South Sepulveda Blvd.</option></optgroup><optgroup label="CAEncinitas"><option value="6534">Encinitas - 687 S. Coast Highway 101</option></optgroup><optgroup label="CAFolsom"><option value="6540">Folsom - 270 Palladio Parkway</option></optgroup><optgroup label="CAFremont"><option value="221996">Fremont - California - 3111 Mowry Avenue</option></optgroup><optgroup label="CAFresno"><option value="6545">Fresno - 650 W. Shaw Ave.</option></optgroup><optgroup label="CAGlendale"><option value="6556">Glendale - 331 North Glendale Ave</option></optgroup><optgroup label="CAHuntington Beach"><option value="6575">Huntington Beach - 7881 Edinger Ave Suite 150</option></optgroup><optgroup label="CALa Jolla"><option value="6595">La Jolla - 8825 Villa La Jolla Dr</option></optgroup><optgroup label="CALafayette"><option value="6593">Lafayette - 3502 Mt. Diablo Blvd.</option></optgroup><optgroup label="CALaguna Beach"><option value="6594">Laguna Beach - 283 Broadway St.</option></optgroup><optgroup label="CALaguna Niguel"><option value="6600">Laguna Niguel - 23932 Aliso Creek Road</option></optgroup><optgroup label="CALong Beach"><option value="6597">Long Beach - 6550 E. Pacific Coast Highway</option></optgroup><optgroup label="CALos Altos"><option value="6596">Los Altos - 4800 El Camino Real</option></optgroup><optgroup label="CALos Angeles"><option value="6538">3rd &amp; Fairfax - 6350 West 3rd Street</option><option value="6485">Brentwood - 11737 San Vicente Blvd</option><option value="3969416">Downtown Los Angeles - 788 S. Grand Avenue</option><option value="6770">West Los Angeles - 11666 National Blvd</option><option value="6783">Westwood - 1050 S. Gayley Ave</option></optgroup><optgroup label="CALos Gatos"><option value="6601">Los Gatos - 15980 Los Gatos Blvd</option></optgroup><optgroup label="CAMill Valley"><option value="6476">Blithedale - 731 East Blithedale</option><option value="6623">Mill Valley - 414 Miller Ave</option></optgroup><optgroup label="CAMonterey"><option value="6629">Monterey - 800 Del Monte Center</option></optgroup><optgroup label="CANapa"><option value="6639">Napa - 3682 Bel Aire Plaza</option></optgroup><optgroup label="CANewport Beach"><option value="60241">Newport Beach - 415 Newport Center Drive</option></optgroup><optgroup label="CANorthridge"><option value="6681">Northridge (Porter Ranch) - 19340 Rinaldi Street</option></optgroup><optgroup label="CANovato"><option value="6638">Novato - 790 De Long Avenue</option></optgroup><optgroup label="CAOakland"><option value="6564">Oakland - 230 Bay Place</option></optgroup><optgroup label="CAOxnard"><option value="77401">Oxnard - 650 Town Center Drive</option></optgroup><optgroup label="CAPalm Desert"><option value="847156">Palm Desert - 44459 Town Center Way</option></optgroup><optgroup label="CAPalo Alto"><option value="6652">Palo Alto - 774 Emerson Street</option></optgroup><optgroup label="CAPasadena"><option value="6464">Arroyo - 465 South Arroyo Parkway</option><option value="6654">Pasadena - 3751 E. Foothill Blvd.</option></optgroup><optgroup label="CAPetaluma"><option value="6659">Petaluma - 621 E. Washington St</option></optgroup><optgroup label="CAPlaya Vista"><option value="1367241">Playa Vista - 12746 West Jefferson Blvd</option></optgroup><optgroup label="CARedondo Beach"><option value="6689">Redondo Beach - 405 North Pacific Coast Hwy</option></optgroup><optgroup label="CARedwood City"><option value="6691">Redwood City - 1250 Jefferson Ave</option></optgroup><optgroup label="CARoseville"><option value="6698">Roseville - 1001 Galleria Blvd.</option></optgroup><optgroup label="CASacramento"><option value="6461">Sacramento - 4315 Arden Way</option></optgroup><optgroup label="CASan Diego"><option value="6568">Hillcrest - 711 University Ave</option></optgroup><optgroup label="CASan Francisco"><option value="322711">2001 Market Street - 2001 Market Street</option><option value="6543">Franklin - 1765 California St</option><option value="6732">Haight Street - 690 Stanyan Street</option><option value="6637">Noe Valley - 3950 24th Street</option><option value="24165">Ocean - 1150 Ocean Ave</option><option value="6678">Potrero Hill - 450 Rhode Island St</option><option value="6719">SoMa - 399 4th Street</option></optgroup><optgroup label="CASan Jose"><option value="6478">Blossom Hill - 1146 Blossom Hill Road</option><option value="1627741">San Jose - on The Alameda - 777 The Alameda</option></optgroup><optgroup label="CASan Luis Obispo"><option value="908661">San Luis Obispo - 1531 Froom Ranch Way</option></optgroup><optgroup label="CASan Mateo"><option value="6716">San Mateo - 1010 Park Place</option></optgroup><optgroup label="CASan Rafael"><option value="6725">San Rafael - 340 Third St</option></optgroup><optgroup label="CASan Ramon"><option value="6685">San Ramon - 100 Sunset Drive</option></optgroup><optgroup label="CASanta Barbara"><option value="6705">Santa Barbara - 3761 State Street</option></optgroup><optgroup label="CASanta Clarita"><option value="6755">Valencia - 24130 Valencia Blvd</option></optgroup><optgroup label="CASanta Cruz"><option value="6734">Santa Cruz - 911 Soquel Ave</option></optgroup><optgroup label="CASanta Monica"><option value="6715">23rd &amp; Wilshire Blvd - 2201 Wilshire Blvd</option><option value="6771">5th &amp; Wilshire Blvd - 500 Wilshire Blvd.</option><option value="6627">Montana Avenue - 1425 Montana Ave.</option></optgroup><optgroup label="CASanta Rosa"><option value="6516">Coddingtown - 390 Coddingtown Mall</option><option value="6726">Santa Rosa - 1181 Yulupa Ave</option></optgroup><optgroup label="CASebastopol"><option value="6709">Sebastopol - 6910 McKinley St</option></optgroup><optgroup label="CASherman Oaks"><option value="6712">Sherman Oaks - 12905 Riverside Dr</option><option value="6713">Sherman Oaks West - 4520 N. Sepulveda Blvd</option></optgroup><optgroup label="CASonoma"><option value="6717">Sonoma - Sonoma Marketplace</option></optgroup><optgroup label="CATarzana"><option value="6748">Tarzana - 18700 Ventura Blvd</option></optgroup><optgroup label="CAThousand Oaks"><option value="6647">Thousand Oaks - 740 North Moorpark Rd</option></optgroup><optgroup label="CATorrance"><option value="6745">Torrance - 2655 Pacific Coast Hwy</option></optgroup><optgroup label="CATustin"><option value="6582">Jamboree - 2847 Park Avenue</option></optgroup><optgroup label="CAVenice"><option value="6756">Venice - 225 Lincoln Blvd.</option></optgroup><optgroup label="CAWalnut Creek"><option value="6759">Walnut Creek - 1333 Newell Ave</option></optgroup><optgroup label="CAWest Hollywood"><option value="6571">West Hollywood - 7871 Santa Monica Blvd</option></optgroup><optgroup label="CAWoodland Hills"><option value="6764">Woodland Hills - 21347 Ventura Blvd</option></optgroup><optgroup label="COBasalt"><option value="43216">Roaring Fork - 340 Reed Street</option></optgroup><optgroup label="COBoulder"><option value="6487">Baseline - 2584 Baseline Rd.</option><option value="6577">Ideal Market - 1275 Alpine Ave.</option><option value="6671">Pearl - 2905 Pearl St</option></optgroup><optgroup label="COCentennial"><option value="409556">SouthGlenn - 6853 South York Street</option></optgroup><optgroup label="COColorado Springs"><option value="6635">First &amp; Main - 3180 New Center Point</option><option value="6670">Pikes Peak - 7635 North Academy Blvd</option></optgroup><optgroup label="CODenver"><option value="6518">Capitol Hill - 900 E. 11th Ave.</option><option value="6495">Cherry Creek - 2375 E. 1st Ave</option><option value="7756">Tamarac - 7400 E. Hampden Ave</option><option value="6781">Washington Park - 1111 S. Washington Street</option></optgroup><optgroup label="COFort Collins"><option value="6548">Fort Collins - 2201 S College Ave</option></optgroup><optgroup label="COFrisco"><option value="327486">Frisco - 261 Lusher Court</option></optgroup><optgroup label="COGlendale"><option value="6517">Colorado Boulevard - 870 S. Colorado Blvd.</option></optgroup><optgroup label="COGolden"><option value="6498">Colfax - 14357 W. Colfax Ave.</option></optgroup><optgroup label="COHighlands Ranch"><option value="6570">Highlands Ranch - 9366 S. Colorado Blvd.</option></optgroup><optgroup label="COLakewood"><option value="6480">Belmar - 444 S.Wadsworth Blvd</option></optgroup><optgroup label="COLittleton"><option value="126856">Governor’s Ranch - 5155 S. Wadsworth Blvd.</option></optgroup><optgroup label="COSuperior"><option value="6736">Superior - 303 Marshall Rd.</option></optgroup><optgroup label="COWestminster"><option value="2543251">Bradburn - 4451 Main St.</option></optgroup><optgroup label="CTDanbury"><option value="212556">Danbury - 5C Sugar Hollow Road</option></optgroup><optgroup label="CTDarien"><option value="6526">Darien - 150 Ledge Road</option></optgroup><optgroup label="CTFairfield"><option value="6537">Fairfield - 350 Grasmere Avenue</option></optgroup><optgroup label="CTGlastonbury"><option value="6555">Glastonbury - 55 Welles Street</option></optgroup><optgroup label="CTGreenwich"><option value="6557">Greenwich - 90 E. Putnam Ave.</option></optgroup><optgroup label="CTMilford"><option value="6621">Milford - 1686 Boston Post Road</option></optgroup><optgroup label="CTWest Hartford"><option value="6486">Bishops Corner - 340 N. Main St.</option><option value="6766">West Hartford - 50 Raymond Rd</option></optgroup><optgroup label="CTWestport"><option value="6778">Westport - 399 Post Road West</option></optgroup><optgroup label="DCWashington"><option value="6560">Foggy Bottom - 2201 I Street NW</option><option value="6559">Georgetown - 2323 Wisconsin Ave N.W.</option><option value="6676">P Street - 1440 P Street NW</option><option value="6742">Tenleytown - 4530 40th St NW Tenley Circle</option></optgroup><optgroup label="FLAltamonte Springs"><option value="3996826">Altamonte Springs - 305 East Altamonte Drive</option></optgroup><optgroup label="FLAventura"><option value="6475">Aventura - 21105 Biscayne Blvd</option></optgroup><optgroup label="FLBoca Raton"><option value="6468">Boca Raton - 1400 Glades Rd</option></optgroup><optgroup label="FLClearwater"><option value="1556166">Clearwater - 27001 US 19 North</option></optgroup><optgroup label="FLCoral Gables"><option value="6499">Coral Gables - 6701 Red Road</option></optgroup><optgroup label="FLCoral Springs"><option value="6523">Coral Springs - 810 University Drive</option></optgroup><optgroup label="FLDavie"><option value="3112626">Davie - 1903 S. University Drive</option></optgroup><optgroup label="FLFort Lauderdale"><option value="6549">Fort Lauderdale - 2000 N Federal Hwy</option></optgroup><optgroup label="FLJacksonville"><option value="6583">Jacksonville - 10601 San Jose Blvd</option></optgroup><optgroup label="FLMiami"><option value="2819871">Downtown Miami - 299 SE 3rd Street</option></optgroup><optgroup label="FLMiami Beach"><option value="6704">South Beach - 1020 Alton Road</option></optgroup><optgroup label="FLNaples"><option value="6640">Naples - 9101 Strada Place</option></optgroup><optgroup label="FLNorth Miami"><option value="199321">North Miami - 12150 Biscayne Blvd</option></optgroup><optgroup label="FLOrlando"><option value="6474">Orlando - 8003 Turkey Lake Road</option></optgroup><optgroup label="FLPalm Beach Gardens"><option value="6660">Palm Beach Gardens - 11701 Lake Victoria Gardens Ave</option></optgroup><optgroup label="FLPembroke Pines"><option value="6658">Pembroke Pines - 14956 Pines Blvd</option></optgroup><optgroup label="FLPinecrest"><option value="6657">Pinecrest - 11701 South Dixie Highway</option></optgroup><optgroup label="FLPlantation"><option value="6665">Plantation CLOSED - 7720 Peters Rd</option></optgroup><optgroup label="FLPompano Beach"><option value="2817996">Pompano Beach - 2411 N Federal Highway</option></optgroup><optgroup label="FLSarasota"><option value="6703">Sarasota - 1451 1st Street</option></optgroup><optgroup label="FLTallahassee"><option value="309181">Tallahassee - 1817 Thomasville Road</option></optgroup><optgroup label="FLTampa"><option value="51956">Carrollwood - 3802 Northdale Blvd.</option><option value="6746">Tampa - 1548 North Dale Mabry Highway.</option></optgroup><optgroup label="FLWellington"><option value="6772">Wellington - 2635 State Road 7</option></optgroup><optgroup label="FLWest Palm Beach"><option value="3169376">West Palm Beach - 1845 Palm Beach Lakes Boulevard</option></optgroup><optgroup label="FLWinter Park"><option value="6777">Winter Park - 1989 Aloma Ave</option></optgroup><optgroup label="GAAlpharetta"><option value="1312136">Avalon - 2800 Old Milton Pkwy</option></optgroup><optgroup label="GAAtlanta"><option value="6469">Briarcliff - 2111 Briarcliff Rd NE</option><option value="6776">Buckhead  - 77 West Paces Ferry Rd NW</option><option value="6668">Ponce de Leon - 650 Ponce de Leon Ave NE</option><option value="6708">Sandy Springs - 5930 Roswell Rd</option></optgroup><optgroup label="GAAugusta"><option value="1312126">Augusta - 2907 Washington Rd.</option></optgroup><optgroup label="GAJohns Creek"><option value="6532">Johns Creek - 5945 State Bridge Rd</option></optgroup><optgroup label="GAMarietta"><option value="6515">Cobb Harry&#039;s - 70 Powers Ferry Rd SE</option><option value="6616">Merchants Walk - 1311 Johnson Ferry Road NE</option></optgroup><optgroup label="GASavannah"><option value="299911">Savannah - 1815 E. Victory Drive</option></optgroup><optgroup label="HIHonolulu"><option value="6591">Honolulu - 4211 Wai&#039;alae Avenue</option></optgroup><optgroup label="HIKahului"><option value="6625">Maui - 70 East Kaahumanu Avenue #B</option></optgroup><optgroup label="HIKailua"><option value="6587">Kailua - 629 Kailua Road, Suite 100</option></optgroup><optgroup label="IAWest Des Moines"><option value="6765">West Des Moines - 4100 University Ave Suite #260</option></optgroup><optgroup label="IDBoise"><option value="58876">Boise - 401 S. Broadway Street</option></optgroup><optgroup label="ILChicago"><option value="3810516">Chicago Edgewater - 6009 North Broadway</option><option value="3247326">DePaul - 959 West Fullerton Avenue</option><option value="6558">Gold Coast - 30 West Huron St</option><option value="6563">Halsted and Waveland - 3640 N Halsted St</option><option value="6603">Lakeview - 3300 N. Ashland Ave</option><option value="6588">Lincoln Park - 1550 N. Kingsbury Street</option><option value="6508">Sauganash - 6020 N Cicero Ave</option><option value="6714">South Loop - 1101 S. Canal St</option><option value="3247201">Streeterville - 255 E. Grand Ave</option><option value="3247576">West Loop - 1 N. Halsted Street</option></optgroup><optgroup label="ILDeerfield"><option value="6529">Deerfield - 760 Waukegan Rd</option></optgroup><optgroup label="ILElmhurst"><option value="3811616">Elmhurst - 215 S. IL Rte 83</option></optgroup><optgroup label="ILEvanston"><option value="6535">Downtown Evanston - 1640 Chicago Ave</option><option value="6536">Evanston South - 1111 Chicago Ave.</option><option value="3956706">Green Bay Road - 2748 Green Bay Road</option></optgroup><optgroup label="ILHinsdale"><option value="6569">Hinsdale - 500 E. Ogden Ave.</option></optgroup><optgroup label="ILKildeer"><option value="126881">Kildeer - 20281 N Rand Road</option></optgroup><optgroup label="ILNaperville"><option value="6641">Naperville - 2607 W. 75th Street</option></optgroup><optgroup label="ILNorthbrook"><option value="6634">Northbrook - 840 Willow Road</option></optgroup><optgroup label="ILOrland Park"><option value="88736">Orland Park - 15260 S. LaGrange Road</option></optgroup><optgroup label="ILPark Ridge"><option value="321081">Park Ridge - 225 W. Touhy Ave</option></optgroup><optgroup label="ILRiver Forest"><option value="6700">River Forest - 7245 Lake St</option></optgroup><optgroup label="ILSchaumburg"><option value="6706">Schaumburg - 750 N. Martingale Rd.</option></optgroup><optgroup label="ILWheaton"><option value="6782">Wheaton - 151 Rice Lake Square</option></optgroup><optgroup label="ILWillowbrook"><option value="3973026">Willowbrook - 6300 S. Robert Kingery Highway</option></optgroup><optgroup label="INCarmel"><option value="6520">Carmel - 14598 Clay Terrace Blvd.</option></optgroup><optgroup label="INIndianapolis"><option value="6578">Eighty-Sixth St. - 1300 E. 86th St.</option></optgroup><optgroup label="INMishawaka"><option value="109676">Mishawaka - 4230 Grape Road</option></optgroup><optgroup label="INSchererville"><option value="3973526">Schererville - 199 US HWY 41</option></optgroup><optgroup label="KSOlathe"><option value="3571721">Olathe - 14615 W. 119th Street</option></optgroup><optgroup label="KSOverland Park"><option value="2">119th St - 6621 West 119th Street</option><option value="3">91st and Metcalf - 7401 West 91st St</option></optgroup><optgroup label="KSWichita"><option value="327511">Wichita - 1423 N. Webb Rd. Suite 101</option></optgroup><optgroup label="KYLexington"><option value="6599">Lexington - 161 Lexington Green Circle</option></optgroup><optgroup label="KYLouisville"><option value="6608">Louisville  - 4944 Shelbyville Road</option></optgroup><optgroup label="LABaton Rouge"><option value="6488">Baton Rouge - 7529 Corporate Blvd</option></optgroup><optgroup label="LALafayette"><option value="484791">Ambassador Caffery - 4247 Ambassador Caffery Parkway</option></optgroup><optgroup label="LAMetairie"><option value="6757">Veterans - 3420 Veterans Memorial Blvd</option></optgroup><optgroup label="LANew Orleans"><option value="6456">Arabella Station - 5600 Magazine Street</option><option value="337306">Broad Street - 300 N Broad St</option></optgroup><optgroup label="MAAndover"><option value="6467">Andover - 40 Railroad St.</option></optgroup><optgroup label="MAArlington"><option value="321051">Arlington MA - 808 Massachusetts Avenue</option></optgroup><optgroup label="MABedford"><option value="6470">Bedford - 170 Great Rd</option></optgroup><optgroup label="MABellingham"><option value="6477">Bellingham - 255 Hartford Ave</option></optgroup><optgroup label="MABoston"><option value="6522">Charles River Plaza - 181 Cambridge St</option><option value="3178921">South End - 348 Harrison Ave</option><option value="6738">Symphony - 15 Westland Ave</option></optgroup><optgroup label="MABrighton"><option value="6483">Brighton - 15 Washington Street</option></optgroup><optgroup label="MABrookline"><option value="178661">Brookline - 1028 Beacon Street</option></optgroup><optgroup label="MACambridge"><option value="6541">Fresh Pond - 200 Alewife Brook Pkwy</option><option value="6490">Prospect Street - 115 Prospect St</option><option value="6701">River Street - 340 River St</option></optgroup><optgroup label="MACharlestown"><option value="288906">Charlestown - 51 Austin St.</option></optgroup><optgroup label="MADedham"><option value="6528">Dedham - 300 Legacy Place</option></optgroup><optgroup label="MAFramingham"><option value="6542">Framingham - 575 Worcester Rd</option></optgroup><optgroup label="MAHadley"><option value="6562">Hadley - 327 Russell St</option></optgroup><optgroup label="MAHingham"><option value="6567">Hingham - 94 Derby Street</option></optgroup><optgroup label="MAHyannis"><option value="854256">Hyannis - 990 Iyannough Road</option></optgroup><optgroup label="MAJamaica Plain"><option value="6586">Jamaica Plain - 413 Centre Street</option></optgroup><optgroup label="MALynnfield"><option value="288941">Lynnfield - 100 Market Street</option></optgroup><optgroup label="MAMedford"><option value="6615">Medford - 2151 Mystic Valley Parkway</option></optgroup><optgroup label="MAMelrose"><option value="282591">Melrose - 880 Main Street</option></optgroup><optgroup label="MANewton"><option value="6636">Newton - 916 Walnut St</option></optgroup><optgroup label="MANewtonville"><option value="6643">Newtonville - 647 Washington Street</option></optgroup><optgroup label="MASomerville"><option value="306431">Somerville - 45 Beacon Street</option></optgroup><optgroup label="MASouth Weymouth"><option value="273951">South Weymouth - 35 Pleasant Street</option></optgroup><optgroup label="MASwampscott"><option value="6737">Swampscott - 331 Paradise Rd</option></optgroup><optgroup label="MAWayland"><option value="6760">Wayland - 317 Boston Post Rd</option></optgroup><optgroup label="MAWellesley"><option value="6773">Wellesley - 442 Washington Street</option></optgroup><optgroup label="MAWoburn"><option value="6774">Woburn - 400 Cambridge Rd.</option></optgroup><optgroup label="MDAnnapolis"><option value="7758">Annapolis - 200 Harker PIace</option></optgroup><optgroup label="MDBaltimore"><option value="6579">Harbor East - 1001 Fleet Street</option><option value="6633">Mt. Washington - 1330 Smith Ave</option></optgroup><optgroup label="MDBethesda"><option value="6473">Bethesda - 5269 River Rd</option></optgroup><optgroup label="MDChevy Chase"><option value="6494">Friendship Heights - 4420 Willard Ave.</option></optgroup><optgroup label="MDColumbia"><option value="1690316">Columbia - Maryland - 10275 Little Patuxent Pkwy</option></optgroup><optgroup label="MDGaithersburg"><option value="6592">Kentlands - 316 Kentlands Blvd</option></optgroup><optgroup label="MDRockville"><option value="6702">Rockville - 11355 Woodglen Drive</option></optgroup><optgroup label="MDSilver Spring"><option value="6727">Silver Spring - 833 Wayne Ave</option></optgroup><optgroup label="MEPortland"><option value="6679">Portland - Maine - 2 Somerset St</option></optgroup><optgroup label="MIAnn Arbor"><option value="6460">Ann Arbor - 3135 Washtenaw Ave</option><option value="6519">Cranbrook - 990 W. Eisenhower Parkway</option></optgroup><optgroup label="MIDetroit"><option value="58961">Detroit - 115 Mack Ave.</option></optgroup><optgroup label="MIRochester Hills"><option value="6687">Rochester Hills - 2918 Walton Blvd</option></optgroup><optgroup label="MITroy"><option value="6728">Troy - 2880 West Maple Rd</option></optgroup><optgroup label="MIWest Bloomfield"><option value="6761">West Bloomfield - 7350 Orchard Lake Road</option></optgroup><optgroup label="MNEdina"><option value="7757">Edina - 7401 France Ave S</option></optgroup><optgroup label="MNMaple Grove"><option value="178676">Maple Grove - 12201 Elm Creek Blvd N</option></optgroup><optgroup label="MNMinneapolis"><option value="178686">Hennepin - 222 Hennepin Avenue</option><option value="6503">Lake Calhoun - 3060 Excelsior Blvd</option></optgroup><optgroup label="MNMinnetonka"><option value="6631">Minnetonka - 1001 Plymouth Road</option></optgroup><optgroup label="MNSt Paul"><option value="6733">St Paul - 30 South Fairview Ave</option></optgroup><optgroup label="MOSaint Louis"><option value="85">Galleria - 1601 S. Brentwood Blvd</option></optgroup><optgroup label="MOTown and Country"><option value="82">Town and Country - 1160 Town and Country Crossing</option></optgroup><optgroup label="MSJackson"><option value="362936">Jackson - 4500 I-55 North</option></optgroup><optgroup label="NCAsheville"><option value="1312111">Asheville - 4 South Tunnel Rd.</option><option value="6465">Greenlife Grocery Asheville - 70 Merrimon Ave</option></optgroup><optgroup label="NCCary"><option value="6492">Cary - 102B New Waverly Place</option></optgroup><optgroup label="NCChapel Hill"><option value="6504">Chapel Hill - 81 South Elliot Road</option></optgroup><optgroup label="NCCharlotte"><option value="27443">Charlotte - 6610 Fairview Rd.</option></optgroup><optgroup label="NCDurham"><option value="6530">Durham - 621 Broad Street</option></optgroup><optgroup label="NCGreensboro"><option value="6553">Greensboro Friendly - 3202 West Friendly Avenue</option></optgroup><optgroup label="NCHuntersville"><option value="1312141">Lake Norman - 9129 Sam Furr Rd.</option></optgroup><optgroup label="NCRaleigh"><option value="6642">North Raleigh - 8710 Six Forks Rd</option><option value="6684">Raleigh - 3540 Wade Ave</option></optgroup><optgroup label="NCWilmington"><option value="12584">Wilmington - 3804 Oleander Drive</option></optgroup><optgroup label="NCWinston-Salem"><option value="6769">Winston-Salem - 41 Miller Street</option></optgroup><optgroup label="NELincoln"><option value="264271">Lincoln - 6055 O Street</option></optgroup><optgroup label="NEOmaha"><option value="1">Omaha - 10020 Regency Circle</option></optgroup><optgroup label="NHNashua"><option value="1952041">Nashua - 255 Amherst Street</option></optgroup><optgroup label="NJCherry Hill"><option value="632951">Cherry Hill - 1558 North Kings Highway</option></optgroup><optgroup label="NJClark"><option value="3961576">Clark - 1255 Raritan Road Unit 150</option></optgroup><optgroup label="NJEdgewater"><option value="6533">Edgewater - 905 River Road</option></optgroup><optgroup label="NJMadison"><option value="6688">Rose City - 222 Main St</option></optgroup><optgroup label="NJMarlboro"><option value="837576">Marlboro - 113 Route 9 South</option></optgroup><optgroup label="NJMarlton"><option value="6628">Marlton - 940 Route 73 North</option></optgroup><optgroup label="NJMontclair"><option value="6626">Montclair - 701 Bloomfield Ave</option></optgroup><optgroup label="NJMorristown"><option value="3879321">Morristown - 110 Washington Street</option></optgroup><optgroup label="NJParamus"><option value="6653">Paramus - 300 Bergen Town Center</option></optgroup><optgroup label="NJPrinceton"><option value="6672">Princeton - 3495 US Route 1 South</option></optgroup><optgroup label="NJRed Bank"><option value="6620">Middletown - 471 State Route 35 North</option></optgroup><optgroup label="NJRidgewood"><option value="6690">Ridgewood - 44 Godwin Ave</option></optgroup><optgroup label="NJVauxhall"><option value="6613">Millburn - Union - 2245 Springfield Ave.</option></optgroup><optgroup label="NJWest Orange"><option value="6775">West Orange - 235 Prospect Ave</option></optgroup><optgroup label="NMAlbuquerque"><option value="6459">Academy - 5815 Wyoming Blvd NE</option><option value="6581">Indian School Plaza - 2103 Carlisle Boulevard NE</option></optgroup><optgroup label="NMSanta Fe"><option value="6497">Santa Fe (Cerrillos) - 753 Cerrillos Rd</option><option value="6730">Santa Fe (St. Francis) - 1090 S. Saint Francis Drive</option></optgroup><optgroup label="NVHenderson"><option value="6566">Henderson - 100 S. Green Valley Pkwy</option></optgroup><optgroup label="NVLas Vegas"><option value="6547">Fort Apache - 8855 West Charleston Blvd.</option><option value="6610">Las Vegas Blvd - 6689 Las Vegas Blvd.</option><option value="6750">Tenaya - 7250 W. Lake Mead Blvd.</option></optgroup><optgroup label="NVReno"><option value="6696">Reno - 6139 S. Virginia Street</option></optgroup><optgroup label="NYAlbany"><option value="845391">Albany - 1425 Central Ave</option></optgroup><optgroup label="NYBrooklyn"><option value="332786">Third and 3rd (Brooklyn) - 214 3rd Street</option></optgroup><optgroup label="NYJericho"><option value="6585">Jericho - 429 North Broadway</option></optgroup><optgroup label="NYLake Grove"><option value="6602">Lake Grove  - Lake Grove Commons</option></optgroup><optgroup label="NYManhasset"><option value="6619">Manhasset - 2101 Northern Blvd</option></optgroup><optgroup label="NYNew York"><option value="6572">Bowery - 95 East Houston St</option><option value="6500">Chelsea - 250 7th Ave</option><option value="6510">Columbus Circle - 10 Columbus Circle</option><option value="6617">Midtown East (E 57th St) - 226 East 57th Street</option><option value="6747">Tribeca - 270 Greenwich Street</option><option value="6753">Union Square - 4 Union Square South</option><option value="3237262">Upper East Side - 1551 3rd Ave</option><option value="6754">Upper West Side - 808 Columbus Avenue</option></optgroup><optgroup label="NYPort Chester"><option value="303291">Port Chester - 575 Boston Post Road</option></optgroup><optgroup label="NYWhite Plains"><option value="6767">White Plains - 110 Bloomingdale Road</option></optgroup><optgroup label="NYYonkers"><option value="10096">Yonkers - Westchester&#039;s Ridge Hill</option></optgroup><optgroup label="OHCincinnati"><option value="6509">Cincinnati - 2693 Edmondson Rd.</option></optgroup><optgroup label="OHColumbus"><option value="6531">Columbus - 3670 W. Dublin-Granville Rd</option><option value="3959571">Easton - 4100 Easton Gateway Drive</option></optgroup><optgroup label="OHDayton"><option value="3915761">Dayton - 1050 Miamisburg Centerville Road</option></optgroup><optgroup label="OHMason"><option value="6630">Mason - 5805 Deerfield Boulevard</option></optgroup><optgroup label="OHRocky River"><option value="3981166">Rocky River - 19607 Detroit Road</option></optgroup><optgroup label="OHUniversity Heights"><option value="6525">Cedar Center - 13998 Cedar Rd.</option></optgroup><optgroup label="OHUpper Arlington"><option value="6650">Upper Arlington - 1555 W. Lane Ave</option></optgroup><optgroup label="OHWoodmere"><option value="6501">Chagrin - 27249 Chagrin Blvd</option></optgroup><optgroup label="OKOklahoma City"><option value="6646">Oklahoma City - 6001 N. Western Ave.</option></optgroup><optgroup label="OKTulsa"><option value="84">Brookside - 1401 E. 41st St.</option><option value="356446">Yale - 9136 South Yale Avenue</option></optgroup><optgroup label="ONMarkham"><option value="55391">Unionville - 3997 Highway 7</option></optgroup><optgroup label="ONMississauga"><option value="6724">Square One Mississauga - 155 Square One Drive</option></optgroup><optgroup label="ONOakville"><option value="6645">Oakville - 301 Cornwall Rd</option></optgroup><optgroup label="ONOttawa"><option value="1579116">Lansdowne Park - 951 Bank Street</option></optgroup><optgroup label="ONToronto"><option value="1811736">Yonge and Sheppard - 4771 Yonge Street</option><option value="6788">Yorkville - 87 Avenue Rd</option></optgroup><optgroup label="ORBend"><option value="6481">Bend - 2610 Highway 20</option></optgroup><optgroup label="ORHillsboro"><option value="6740">Tanasbourne - 19440 NW Cornell Rd.</option></optgroup><optgroup label="ORPortland"><option value="6539">Fremont - Oregon - 3535 NE 15th Ave.</option><option value="6576">Hollywood - 4301 NE Sandy Blvd.</option><option value="6605">Laurelhurst - 2825 East Burnside St.</option><option value="6674">Pearl District Portland - 1210 NW Couch St</option></optgroup><optgroup label="ORTigard"><option value="6482">Bridgeport - 7380 SW Bridgeport Rd.</option><option value="633166">Greenway - 12220 SW Scholls Ferry Road</option></optgroup><optgroup label="PAGlen Mills"><option value="6496">Glen Mills - 475 Wilmington</option></optgroup><optgroup label="PAJenkintown"><option value="6584">Jenkintown - 1575 The Fairway</option></optgroup><optgroup label="PANorth Wales"><option value="6644">North Wales - 1210 Bethlehem Pike</option></optgroup><optgroup label="PAPhiladelphia"><option value="6661">Callowhill - 2001 Pennsylvania Avenue</option><option value="6720">South Street - 929 South Street</option></optgroup><optgroup label="PAPittsburgh"><option value="6677">Pittsburgh - 5880 Centre Ave</option></optgroup><optgroup label="PAPlymouth Meeting"><option value="6666">Plymouth Meeting - 500 W. Germantown Pike</option></optgroup><optgroup label="PAWayne"><option value="6527">Devon - 821 W. Lancaster Ave</option></optgroup><optgroup label="PAWexford"><option value="7755">Wexford - 10576 Perry Highway</option></optgroup><optgroup label="PAWynnewood"><option value="6785">Wynnewood - 339 East Lancaster Ave</option></optgroup><optgroup label="RICranston"><option value="6521">Garden City Center - 151 Sockanosset Cross Road</option></optgroup><optgroup label="RIProvidence"><option value="6673">Providence - 261 Waterman St</option><option value="6752">University - 601 N Main St</option></optgroup><optgroup label="SCColumbia"><option value="79066">Columbia - 702 Cross Hill Rd + Fort Jackson Blvd</option></optgroup><optgroup label="SCGreenville"><option value="6763">Greenville - 1140 Woodruff Road</option></optgroup><optgroup label="SCHilton Head Island"><option value="1012691">Hilton Head Island - 50 Shelter Cove Lane</option></optgroup><optgroup label="SCMount Pleasant"><option value="6502">Charleston - 923 Houston Northcutt Blvd</option></optgroup><optgroup label="TNChattanooga"><option value="6506">Chattanooga - 301 Manufacturers Rd</option></optgroup><optgroup label="TNFranklin"><option value="6614">McEwen - 1566 West McEwen Drive</option></optgroup><optgroup label="TNGermantown"><option value="3960746">Germantown - 7825 U.S. Highway 72</option></optgroup><optgroup label="TNKnoxville"><option value="3642086">Knoxville - 6730 Papermill Drive</option></optgroup><optgroup label="TNMemphis"><option value="418296">Poplar Avenue - 5014 Poplar Avenue</option></optgroup><optgroup label="TNNashville"><option value="6554">Green Hills - 4021 Hillsboro Pike</option></optgroup><optgroup label="TXAddison"><option value="259016">Addison - 5100 Belt Line Road, Suite 1012</option></optgroup><optgroup label="TXArlington"><option value="6664">Arlington TX - 801 East Lamar Blvd.</option></optgroup><optgroup label="TXAustin"><option value="6457">Arbor Trails - 4301 W. William Cannon</option><option value="386501">Domain - 11920 Domain Drive</option><option value="6561">Gateway - 9607 Research Blvd.</option><option value="6606">Lamar - 525 N Lamar Blvd.</option></optgroup><optgroup label="TXBee Cave"><option value="6471">Bee Cave - 12601 Hill Country Blvd</option></optgroup><optgroup label="TXColleyville"><option value="455586">Colleyville - 4801 Colleyville Blvd</option></optgroup><optgroup label="TXDallas"><option value="6546">Forest - 11700 Preston Rd</option><option value="6604">Lakewood - 2118 Abrams Road</option><option value="6663">Park Lane - 8190 Park Lane, Suite 351</option><option value="2203066">Uptown Dallas - 2510 McKinney Ave</option></optgroup><optgroup label="TXFairview"><option value="6550">Fairview - The Village at Fairview</option></optgroup><optgroup label="TXHighland Park"><option value="6573">Highland Park - 4100 Lomo Alto Dr</option></optgroup><optgroup label="TXHighland Village"><option value="455646">Highland Village - 4041 Waller Creek</option></optgroup><optgroup label="TXHouston"><option value="6472">Bellaire - 4004 Bellaire Blvd</option><option value="455341">Champions - 10133 Louetta Road</option><option value="6589">Kirby - 2955 Kirby Dr</option><option value="6632">Montrose - 701 Waugh Drive</option><option value="455606">Post Oak - 1700 Post Oak Blvd</option><option value="2460051">Voss - 1407 South Voss Rd</option><option value="6768">Wilcrest - 11145 Westheimer Rd</option></optgroup><optgroup label="TXKaty"><option value="119641">Katy - 6601 S. Fry Road</option></optgroup><optgroup label="TXPlano"><option value="6667">Plano - 2201 Preston Rd</option></optgroup><optgroup label="TXSan Antonio"><option value="6683">Alamo Quarry - 255 E. Basse Rd, Ste. 130</option><option value="20920">Vineyard - 18403 Blanco Road</option></optgroup><optgroup label="TXSugar Land"><option value="6710">Sugar Land - 15900 Southwest Freeway</option></optgroup><optgroup label="TXThe Woodlands"><option value="2202856">The Woodlands - 1925 Hughes Landing Blvd.</option></optgroup><optgroup label="UKGlasgow"><option value="6552">Giffnock - 124-134 Fenwick Road</option></optgroup><optgroup label="UKGloucestershire"><option value="6524">Cheltenham - Gallagher Retail Park</option></optgroup><optgroup label="UKLondon"><option value="6514">Camden - 49 Parkway</option><option value="6511">Clapham Junction - 305-311 Lavender Hill</option><option value="236406">Fulham - 2-6 Fulham Broadway</option><option value="6574">Kensington - 63-97 Kensington High Street</option><option value="21603">Piccadilly Circus - 20 Glasshouse Street</option><option value="236391">Richmond - 1-3 George Street</option><option value="6731">Stoke Newington - 32-40 Stoke Newington Church St</option></optgroup><optgroup label="UTCottonwood Heights"><option value="6565">Cottonwood Heights - 6930 S. Highland Drive</option></optgroup><optgroup label="UTDraper"><option value="327491">South Valley - 11479 S. State Street, Unit B</option></optgroup><optgroup label="UTPark City"><option value="6662">Park City - 1748 W Redstone Center Dr.</option></optgroup><optgroup label="UTSalt Lake City"><option value="6735">Sugar House - 1131 E. Wilmington Ave.</option><option value="6749">Trolley Square - 544 South 700 East</option></optgroup><optgroup label="VAAlexandria"><option value="6651">Old Town - 1700 Duke St</option></optgroup><optgroup label="VAArlington"><option value="6463">Arlington VA - 2700 Wilson Blvd</option></optgroup><optgroup label="VAAshburn"><option value="3952066">Ashburn - 19800 Belmont Chase Drive</option></optgroup><optgroup label="VACharlottesville"><option value="6507">Charlottesville - 1797 Hydraulic Road</option></optgroup><optgroup label="VAFairfax"><option value="6544">Fair Lakes - 4501 Market Commons Dr</option></optgroup><optgroup label="VAFalls Church"><option value="6751">Tysons - 7511 Leesburg Pike</option></optgroup><optgroup label="VAGlen Allen"><option value="6722">Short Pump - 11173 West Broad Street</option></optgroup><optgroup label="VANewport News"><option value="3990511">Newport News - 12080 Jefferson Ave.</option></optgroup><optgroup label="VAReston"><option value="6692">Reston - 11660 Plaza America Dr</option></optgroup><optgroup label="VASpringfield"><option value="6723">Springfield - 8402 Old Keene Mill Rd</option></optgroup><optgroup label="VAVienna"><option value="6758">Vienna - 143 Maple Ave East</option></optgroup><optgroup label="VAVirginia Beach"><option value="70051">Virginia Beach - 1800 Laskin Road</option></optgroup><optgroup label="WABellevue"><option value="6479">Bellevue - 888 116th Ave NE</option></optgroup><optgroup label="WALynnwood"><option value="6607">Lynnwood - 2800 SW 196th St. SW</option></optgroup><optgroup label="WARedmond"><option value="6695">Redmond - 17991 NE Redmond Way</option></optgroup><optgroup label="WASeattle"><option value="6580">Interbay - 2001 15th Avenue W</option><option value="6699">Roosevelt Square - 1026 NE 64th Street</option><option value="6779">South Lake Union - 2210 Westlake Ave</option></optgroup><optgroup label="WAUniversity Place"><option value="3905746">Chambers Bay - 3515 Bridgeport Way West</option></optgroup><optgroup label="WAVancouver"><option value="6622">Mill Plain - 815 Southeast 160th Avenue</option></optgroup><optgroup label="WIMadison"><option value="6611">Madison - 3313 University Ave</option></optgroup><optgroup label="WIMilwaukee"><option value="6624">Milwaukee - 2305 N. Prospect Ave</option></optgroup></select>
+</div>
+<input id="store-select-submit" class="store-select-submit form-submit" type="submit" name="op" value="Continue" /><input type="hidden" name="form_build_id" value="form-sdsgeyS_ri_eTQWFTcCzP9lmk1BWGWz0ndUGgX4Or6w" />
+<input type="hidden" name="form_id" value="store_select_form" />
+</div></form></div>     
+    <h4>Connect with Us</h4>
+
+      <div>
+        <ul class="socmedul"><a href="https://www.facebook.com/wholefoods"><li class="footersomed socmedicon socmedfacebook" alt="Facebook"></li>
+          </a><a href="https://twitter.com/wholefoods/"><li class="footersomed socmedicon socmedtwitter" alt="Twitter"></li></a>
+          <a href="https://pinterest.com/wholefoods/"><li class="footersomed socmedicon socmedpinterest" alt="Pinterest"></li></a>
+          <a href="https://plus.google.com/108900531664537360582/posts"><li class="footersomed socmedicon socmedgoogle" alt="Google Plus"></li></a>
+          <a href="https://instagram.com/wholefoods"><li class="footersomed socmedicon socmedinstagram" alt="Instagram"></li></a>
+          <a href="https://www.youtube.com/wholefoods"><li class="footersomed socmedicon socmedyoutube" alt="Youtube"></li></a>
+        </ul></div><!-- footer-somed -->
+<div class="footer-subscribe">
+    <h4>Newsletter Subscription</h4>
+        <ul><li><div id="block-wfm-blocks-wfm-blocks-subscription" class="block block-wfm-blocks">
 
     
   <div class="content">
-    <style>
-.footer-link { color: white; text-decoration: none }
-.footer-link:hover { color: white; }
-.footer-link:active { color: white; }
-.footer-link:visited { color: white; }
-</style>
-<a href="/sites/default/files/media/California_Transparency_in_Supply_Chains_Act_Disclosure.pdf" class="footer-link" target="_blank">California Transparency in Supply Chains Act Disclosure (PDF)</a>  </div>
+    <div class="nl-subscription-form"><div class="form-description">Enter your email address for recipes, news and tips.</div><form action="/recipe/slow-cooker-split-pea-soup" method="post" id="wfm-blocks-subsciption-form" accept-charset="UTF-8"><div><div class="form-item form-type-textfield form-item-subscription-email">
+ <input class="email form-text" placeholder="Email Address..." type="text" id="edit-subscription-email" name="subscription_email" value="" size="60" maxlength="128" />
 </div>
-<div id="block-block-4" class="block block-block">
+<input type="submit" id="edit-submit--2" name="op" value="Submit" class="form-submit" /><input type="hidden" name="form_build_id" value="form-BwKAPvdTQA40fbNy45d0izmK9_aqLhHKKyx_8fLato0" />
+<input type="hidden" name="form_id" value="wfm_blocks_subsciption_form" />
+</div></form><div class="error-area"></div></div>  </div>
+</div>
+</li>
+        </ul></div>  
 
-    
-  <div class="content">
-    Copyright 2012 Whole Foods Market IP. L.P.  </div>
+  </div><!-- right column -->
+
+<div class="footer-new-secondary">
+<p><a href="http://www.wholefoodsmarket.com/sites/default/files/media/California_Transparency_in_Supply_Chains_Act_Disclosure.pdf">California Transparency in Supply Chains Act Disclosure (PDF)</a><br /><strong>Copyright 2016 Whole Foods Market IP. L.P.</strong>   |   <a href="http://www.wholefoodsmarket.com/terms-use">Terms of Use</a>   |   <a href="http://www.wholefoodsmarket.com/privacy-policy">Privacy Policy</a>   |   <a href="http://www.wholefoodsmarket.com/site-map">Site Map</a> | <a href="http://www.wholefoodsmarket.com/site-information">Site Information</a><br />"Whole Foods Market" is a registered trademark of Whole Foods Market IP, L.P.</p>
+</div><!-- footer-new-secondary -->
+
+</div><!-- container -->   </div>
 </div>
-  </div>
+   </div>
     </div></div> <!-- /.section, /#footer -->
   <!-- force install of chrome frame if browser is less than ie7 -->
-  <!--[if lt IE 7 ]>
-    <!-- STRIPPED SCRIPT TAG -->
-    <!-- STRIPPED SCRIPT TAG -->
-  <![endif]-->
-  <!-- STRIPPED SCRIPT TAG --><!-- STRIPPED SCRIPT TAG -->
+  <!-- STRIPPED CONDITIONAL COMMENT -->
+  <!-- STRIPPED SCRIPT TAG -->
+
+<div id="signInHTML">
+    <div style="display:none;" id="signIn">
+        <div class="capture_signin">
+            <h3>Sign in with a social account</h3>
+            {* loginWidget *} <br />
+        </div>
+
+        <div class="capture_backgroundColor">
+            <div class="capture_signin">
+                <h3>Sign in with a</h3>
+                <h3>Whole Foods Market account</h3>
+                {* #userInformationForm *}
+                    {* traditionalSignIn_emailAddress *}
+                    {* traditionalSignIn_password *}
+                    <div class="capture_form_item">
+                        <a href="#" data-capturescreen="forgotPassword">Forgot your password?</a>
+                    </div>
+                    <div class="buttons">
+                        {* traditionalSignIn_signInButton *}{* traditionalSignIn_createButton *}
+                    </div>
+                {* /userInformationForm *}
+            </div>
+        </div>
+    </div>
+
+    <div style="display:none;" id="returnSocial">
+        <div class="capture_header">
+            <h3>Sign in with your social account</h3>
+        </div>
+        <div class="capture_signin">
+            <h2>Welcome back {* welcomeName *}!</h2>
+            {* loginWidget *}
+            <div class="capture_centerText switchLink"><a href="#" data-cancelcapturereturnexperience="true">Use another account</a></div>
+        </div>
+    </div>
+
+    <div style="display:none;" id="returnTraditional">
+        <div class="capture_backgroundColor">
+            <div class="capture_header">
+                <h3>Sign in with your</h3>
+                <h3>Whole Foods Market account</h3>
+            </div>
+            <h2 class="capture_centerText"><span id="traditionalWelcomeName">Welcome back {* welcomeName *}!</span></h2>
+            <div class="capture_backgroundColor">
+                {* #userInformationForm *}
+                    {* traditionalSignIn_emailAddress *}
+                    {* traditionalSignIn_password *}
+                    <div class="capture_form_item capture_rightText">
+                        {* traditionalSignIn_signInButton *}
+                    </div>
+                {* /userInformationForm *}
+                <div class="capture_centerText switchLink"><a href="#" data-cancelcapturereturnexperience="true">Use another account</a></div>
+            </div>
+        </div>
+    </div>
+
+    <div style="display:none;" id="socialRegistration">
+        <div class="capture_header">
+            <h1>Almost Done!</h1>
+        </div>
+        <h2>Please confirm the information below before signing in.</h2>
+        {* #socialRegistrationForm *}
+            {* socialRegistration_firstName *}
+            {* socialRegistration_lastName *}
+            {* socialRegistration_emailAddress *}
+            {* socialRegistration_displayName *}
+            {* socialRegistration_postalCode *}
+            By clicking "Sign in", you confirm that you accept our <a href="/terms-use">terms of service</a> and have read and understand <a href="/privacy-policy">privacy policy</a>.
+            <div class="capture_footer">
+                <div class="capture_left">
+                    {* backButton *}
+                </div>
+                <div class="capture_right">
+                    {* socialRegistration_signInButton *}
+                </div>
+            </div>
+        {* /socialRegistrationForm *}
+    </div>
+
+    <div style="display:none;" id="registrationNewVerification">
+        <div class="capture_header">
+            <h1>Thank you for registering!</h1>
+        </div>
+        <p>We have sent a confirmation email to {* emailAddressData *}. Please check your email and click on the link to activate your account.</p>
+        <div class="capture_footer">
+            <a href="#" onclick="window.location.reload()" class="capture_btn capture_primary">Close</a>
+        </div>
+    </div>
+
+    <div style="display:none;" id="traditionalRegistration">
+        <div class="capture_header">
+            <h3>Almost Done!</h3>
+        </div>
+        <p>Please confirm the information below before signing in. Already have an account? <a href="#" data-capturescreen="signIn">Sign In.</a></p>
+        {* #registrationForm *}
+            {* traditionalRegistration_firstName *}
+            {* traditionalRegistration_lastName *}
+            {* traditionalRegistration_emailAddress *}
+            {* traditionalRegistration_password *}
+            {* traditionalRegistration_passwordConfirm *}
+            {* traditionalRegistration_displayName *}
+            {* traditionalRegistration_postalCode *}
+            {* captcha *}
+            By clicking "Create Account", you confirm that you accept our <a href="/terms-use">terms of service</a> and have read and understand <a href="/privacy-policy">privacy policy</a>.
+            <div class="capture_footer">
+                <div class="capture_left">
+                    {* backButton *}
+                </div>
+                <div class="capture_right">
+                    {* createAccountButton *}
+                </div>
+            </div>
+        {* /registrationForm *}
+    </div>
+
+    <div style="display:none;" id="forgotPassword">
+        <div class="capture_header">
+            <h1>Create a new password</h1>
+        </div>
+        <h2>We'll email you a link to create a new password.</h2>
+        {* #forgotPasswordForm *}
+            {* traditionalSignIn_emailAddress *}
+            <div class="capture_footer">
+                <div class="capture_left">
+                    {* backButton *}
+                </div>
+                <div class="capture_right">
+                    {* forgotPassword_sendButton *}
+                </div>
+            </div>
+        {* /forgotPasswordForm *}
+    </div>
+
+    <div style="display:none;" id="forgotPasswordSuccess">
+        <div class="capture_header">
+            <h1>Create a new password</h1>
+        </div>
+            <p>We've sent an email with instructions to create a new password. Your existing password has not been changed.</p>
+        <div class="capture_footer">
+            <a href="#" onclick="janrain.capture.ui.modal.close()" class="capture_btn capture_primary">Close</a>
+        </div>
+    </div>
+
+    <div style="display:none;" id="mergeAccounts">
+        {* mergeAccounts *}
+    </div>
+
+    <div style="display:none;" id="traditionalAuthenticateMerge">
+        <div class="capture_header">
+            <h1>Sign in to complete account merge</h1>
+        </div>
+        <div class="capture_signin">
+            {* #tradAuthenticateMergeForm *}
+                {* traditionalSignIn_emailAddress *}
+                {* mergePassword *}
+                <div class="capture_footer">
+                    <div class="capture_left">
+                        {* backButton *}
+                    </div>
+                    <div class="capture_right">
+                        {* traditionalSignIn_signInButton *}
+                    </div>
+                </div>
+             {* /tradAuthenticateMergeForm *}
+        </div>
+    </div>
+
+</div><!--/ signInHTML -->
 <!-- STRIPPED SCRIPT TAG -->
+  <!-- STRIPPED SCRIPT TAG -->
 </body>
 </html>


### PR DESCRIPTION
# Change Summary
According to schema.org, it's valid to tag content with meta tags*, especially when you don't want data to appear visibly on the page. This is not usually done for recipes because the information you want to mark up generally appears on the page. For some reason, Health Starts in the Kitchen (WPURP) was using these meta tags instead of tagging the visible recipe data with the schema.org tags. Since this is technically valid, I added logic to the parser to get data from these meta tags if they exist.
# Release Notes
We need to make sure this gets into the vendor code for the scraper. I had difficulty ensuring this happened last time
# Testing
Added a recipe from Health Starts in the Kitchen (previously not scraping) to the RecipeParser tests and made sure that all tests were passing, including the exisint tests.

*https://schema.org/docs/gs.html#advanced_missing.