### PR TITLE
CORE-1252: Fix xpath query for title in the data-vocabulary parser

### DIFF
--- a/lib/RecipeParser/Parser/MicrodataDataVocabulary.php
+++ b/lib/RecipeParser/Parser/MicrodataDataVocabulary.php
@@ -17,7 +17,7 @@ class RecipeParser_Parser_MicrodataDataVocabulary {
         if ($microdata) {
 
             // Title
-            $nodes = $xpath->query('.//*[@itemprop="name" and *[not(ancestor::.//*[@itemprop="ingredient"])]]', $microdata);
+            $nodes = $xpath->query('.//*[@itemprop="name" and not(ancestor::*[@itemprop="ingredient"])]', $microdata);
             if ($nodes->length) {
                 $value = $nodes->item(0)->nodeValue;
                 $value = RecipeParser_Text::formatTitle($value);


### PR DESCRIPTION
# CHANGE SUMMARY 
There was a semantic error in the xpath query that was responsible for identifying the title of data-vocabulary formats. 

# RELEASE NOTES
None 

# TESTING
Verified on: 
- http://www.inerikaskitchen.com/2016/01/chicken-with-40-cloves-of-garlic.html
- http://www.myrecipes.com/recipe/banana-berry-smoothie-0