### PR TITLE
CORE-1283: add error message when Incapsula is blocking scraper traffic

### DIFF
--- a/lib/RecipeParser.php
+++ b/lib/RecipeParser.php
@@ -107,6 +107,10 @@ class RecipeParser {
 
         // If we haven't found a matching parser, bail out.
         if (!$parser) {
+            $message = '';
+            if (stripos($html, "Incapsula incident") !== false) {
+                $message = 'Programmatic access to site is blocked.'
+            }
             throw new NoMatchingParserException();
         }
 

--- a/lib/RecipeParser.php
+++ b/lib/RecipeParser.php
@@ -109,9 +109,9 @@ class RecipeParser {
         if (!$parser) {
             $message = '';
             if (stripos($html, "Incapsula incident") !== false) {
-                $message = 'Programmatic access to site is blocked.'
+                $message = 'Programmatic access to site is blocked.';
             }
-            throw new NoMatchingParserException();
+            throw new NoMatchingParserException($message);
         }
 
         // Initialize the right parser and run it.


### PR DESCRIPTION
# Change Summary
Add error message when Incapsula is blocking scraper traffic.
# Release Notes
None.
# Testing
Tested locally:
1. In chicory-scraper root directory, typed ```php artisan scrape:recipe http://beetificbeginnings.com/brussels-sprout-caesar-salad-wraps-smoky-portobello-bacon/```
2. Received error message ```[NoMatchingParserException] Programmatic access to site is blocked.```