### PR TITLE
Core 1439: JSON-LD support

### DIFF
--- a/bin/fetch_parser_test_file
+++ b/bin/fetch_parser_test_file
@@ -17,7 +17,7 @@ $hostname = parse_url($recipe_url, PHP_URL_HOST);
 
 $html = FileUtil::downloadPage($recipe_url);
 $html = RecipeParser_Text::forceUTF8($html);
-$html = RecipeParser_Text::cleanupClippedRecipeHtml($html);
+$html = RecipeParser_Text::cleanupClippedRecipeHtmlWithScripts($html);
 
 $title = getHtmlTitle($html);
 $title = RecipeParser_Text::formatFilenameFromTitle($title);

--- a/lib/RecipeParser.php
+++ b/lib/RecipeParser.php
@@ -10,6 +10,7 @@ class RecipeParser {
     const RDF_DATA_VOCABULARY_SPEC = "MicrodataRdfDataVocabulary";
     const MICROFORMAT_SPEC         = "Microformat";
     const MICROFORMAT_V2_SPEC      = "MicroformatV2";
+    const JSON_LD                  = "MicrodataJsonLd";
 
     /**
      * Load registered parsers from ini file.
@@ -62,7 +63,10 @@ class RecipeParser {
      * @return string Name of matching parser (or null)
      */
     static public function matchMarkupFormat(&$html) {
-        if (stripos($html, "schema.org/Recipe") !== false) {
+        if (stripos($html, "ld+json") !== false) {
+            return self::JSON_LD;
+        }
+        else if (stripos($html, "schema.org/Recipe") !== false) {
             return self::SCHEMA_SPEC;
         }
         else if (stripos($html, "//data-vocabulary.org/Recipe") !== false) {

--- a/lib/RecipeParser/Parser/MicrodataJsonLd.php
+++ b/lib/RecipeParser/Parser/MicrodataJsonLd.php
@@ -1,0 +1,183 @@
+<?php
+
+use \ML\JsonLD\JsonLD as JsonLD;
+
+class RecipeParser_Parser_MicrodataJsonLd {
+
+    static public function parse(DOMDocument $doc, $url) {
+        $recipe = new RecipeParser_Recipe();
+        $xpath = new DOMXPath($doc);
+        
+
+        $microdata = null;
+        $nodes = $xpath->query('//*[contains(@itemtype, "//schema.org/Recipe") or contains(@itemtype, "//schema.org/recipe")]');
+        if ($nodes->length) {
+            $microdata = $nodes->item(0);
+        }
+
+        // Parse elements
+        if ($microdata) {
+
+            // Title
+            $nodes = $xpath->query('.//*[@itemprop="name"]', $microdata);
+            if ($nodes->length) {
+                $value = trim($nodes->item(0)->nodeValue);
+                $recipe->title = RecipeParser_Text::formatTitle($value);
+            }
+
+            // Summary
+            $nodes = $xpath->query('.//*[@itemprop="description"]', $microdata);
+            if ($nodes->length) {
+                $value = $nodes->item(0)->nodeValue;
+                $value = RecipeParser_Text::formatAsParagraphs($value);
+                $recipe->description = $value;
+            }
+
+            // Times
+            $searches = array('prepTime' => 'prep',
+                              'cookTime' => 'cook',
+                              'totalTime' => 'total');
+            foreach ($searches as $itemprop => $time_key) {
+                $nodes = $xpath->query('.//*[@itemprop="' . $itemprop . '"]', $microdata);
+                if ($nodes->length) {
+                    if (strlen($nodes->item(0)->getAttribute('content')) >= 2) { #bug in bonappetit where content is only "P"
+                        $value = $nodes->item(0)->getAttribute('content');
+                        $value = RecipeParser_Text::iso8601ToMinutes($value);
+                    } else if ($value = $nodes->item(0)->getAttribute('datetime')) {
+                        $value = RecipeParser_Text::iso8601ToMinutes($value);
+                    } else {
+                        $value = trim($nodes->item(0)->nodeValue);
+                        $value = RecipeParser_Times::toMinutes($value);
+                    }
+                    if ($value) {
+                        $recipe->time[$time_key] = $value;
+                    }
+                }
+            }
+
+            // Yield
+            $nodes = $xpath->query('.//*[@itemprop="recipeYield"]', $microdata);
+            if (!$nodes->length) {
+                $nodes = $xpath->query('.//*[@itemprop="recipeyield"]', $microdata);
+            }
+            if ($nodes->length) {
+                if ($nodes->item(0)->hasAttribute('content')) {
+                    $line = $nodes->item(0)->getAttribute('content');
+                } else {
+                    $line = $nodes->item(0)->nodeValue;
+                }
+                $recipe->yield = RecipeParser_Text::formatYield($line);
+            }
+
+            // Ingredients 
+            $nodes = $xpath->query('.//*[@itemprop="ingredients"]', $microdata);
+            foreach ($nodes as $node) {
+                $value = $node->nodeValue;
+                $value = RecipeParser_Text::formatAsOneLine($value);
+                if (empty($value)) {
+                    continue;
+                }
+                if (strlen($value) > 150) {
+                    // probably a mistake, like a run-on of existing ingredients?
+                    continue;
+                }
+
+                if (RecipeParser_Text::matchSectionName($value)) {
+                    $value = RecipeParser_Text::formatSectionName($value);
+                    $recipe->addIngredientsSection($value);
+                } else {
+                    $recipe->appendIngredient($value);
+                }
+            }
+
+            // Instructions
+            $found = false;
+
+            // Look for markup that uses <li> tags for each instruction.
+            if (!$found) {
+                $nodes = $xpath->query('.//*[@itemprop="recipeInstructions"]//li', $microdata);
+                if ($nodes->length) {
+                    RecipeParser_Text::parseInstructionsFromNodes($nodes, $recipe);
+                    $found = true;
+                }
+            }
+
+            // Look for instructions as direct descendents of "recipeInstructions".
+            if (!$found) {
+                $nodes = $xpath->query('.//*[@itemprop="recipeInstructions"]/*', $microdata);
+                if ($nodes->length) {
+                    RecipeParser_Text::parseInstructionsFromNodes($nodes, $recipe);
+                    $found = true;
+
+                    // Recipe.com gets caught up in here, but doesn't have well-formed nodes wrapping each ingredient.
+                }
+            }
+
+            // Some sites will use an "instruction" class for each line.
+            if (!$found) {
+                $nodes = $xpath->query('.//*[@itemprop="recipeInstructions"]//*[contains(concat(" ", normalize-space(@class), " "), " instruction ")]', $microdata);
+                if ($nodes->length) {
+                    RecipeParser_Text::parseInstructionsFromNodes($nodes, $recipe);
+                    $found = true;
+                }
+            }
+
+            // Either multiple recipeInstructions nodes, or one node with a blob of text.
+            if (!$found) {
+                $nodes = $xpath->query('.//*[@itemprop="recipeInstructions"]', $microdata);
+                if ($nodes->length > 1) {
+                    // Multiple nodes
+                    RecipeParser_Text::parseInstructionsFromNodes($nodes, $recipe);
+                    $found = true;
+                } else if ($nodes->length == 1) {
+                    // Blob
+                    $str = $nodes->item(0)->nodeValue;
+                    RecipeParser_Text::parseInstructionsFromBlob($str, $recipe);
+                    $found = true;
+                }
+            }
+
+            // Photo
+            $photo_url = "";
+            if (!$photo_url) {
+                // try to find open graph url
+                $nodes = $xpath->query('//meta[@property="og:image"]');
+                if ($nodes->length) {
+                    $photo_url = $nodes->item(0)->getAttribute('content');
+                }
+            }
+            if (!$photo_url) {
+                $nodes = $xpath->query('.//*[@itemprop="image"]', $microdata);
+                if ($nodes->length) {
+                    $photo_url = $nodes->item(0)->getAttribute('src');
+                }
+            }
+            if (!$photo_url) {
+                // for <img> as sub-node of class="photo"
+                $nodes = $xpath->query('.//*[@itemprop="image"]//img', $microdata);
+                if ($nodes->length) {
+                    $photo_url = $nodes->item(0)->getAttribute('src');
+                }
+            }
+            if ($photo_url) {
+                $recipe->photo_url = RecipeParser_Text::relativeToAbsolute($photo_url, $url);
+            }
+
+            // Credits
+            $line = "";
+            $nodes = $xpath->query('.//*[@itemprop="author"]', $microdata);
+            if ($nodes->length) {
+                $line = $nodes->item(0)->nodeValue;
+            }
+            $nodes = $xpath->query('.//*[@itemprop="publisher"]', $microdata);
+            if ($nodes->length) {
+                $line = $nodes->item(0)->nodeValue;
+            }
+
+            $recipe->credits = RecipeParser_Text::formatCredits($line);
+        }
+
+        return $recipe;
+    }
+
+}

--- a/lib/RecipeParser/Parser/MicrodataJsonLd.php
+++ b/lib/RecipeParser/Parser/MicrodataJsonLd.php
@@ -8,9 +8,9 @@ class RecipeParser_Parser_MicrodataJsonLd {
         $recipe = new RecipeParser_Recipe();
         $xpath = new DOMXPath($doc);
         
-        // playground
         $jsonScripts = $xpath->query('//script[@type="application/ld+json"]');
         $json = trim( $jsonScripts->item(0)->nodeValue );
+        $json = RecipeParser_Text::cleanJson($json);
         $data = json_decode( $json );
         print_r($data);
 

--- a/lib/RecipeParser/Parser/MicrodataJsonLd.php
+++ b/lib/RecipeParser/Parser/MicrodataJsonLd.php
@@ -10,98 +10,86 @@ class RecipeParser_Parser_MicrodataJsonLd {
         $json = trim( $jsonScripts->item(0)->nodeValue );
         $json = RecipeParser_Text::cleanJson($json);
         $data = json_decode( $json );
-        print_r($data);
-
-        if ($data && property_exists($data, "@context") && stripos($data->{'@context'}, "schema.org") !== false ) {
-            // Parse elements
-            if ($data && property_exists($data, "@type") && $data->{'@type'} == 'Recipe') {
-            
-                // Title
-                if (property_exists($data, "name")) {
-                    $name = $data->name;
-                    $recipe->title = RecipeParser_Text::formatTitle($name);
-                }
-            
-                // Summary
-                if (property_exists($data, "description")) {
-                    $summary = $data->description;
-                    $recipe->description = RecipeParser_Text::formatAsParagraphs($summary);;
-                }
-            
-                // Times
-                if (property_exists($data, "prepTime")) {
-                    $prepTime = $data->prepTime;
-                    $recipe->time['prep'] = RecipeParser_Text::formatISO_8601($prepTime);;
-                }
-                if (property_exists($data, "cookTime")) {
-                    $cookTime = $data->cookTime;
-                    $recipe->time['cook'] = RecipeParser_Text::formatISO_8601($cookTime);;
-                }
-                if (property_exists($data, "totalTime")) {
-                    $totalTime = $data->totalTime;
-                    $recipe->time['total'] = RecipeParser_Text::formatISO_8601($totalTime);;
-                }
-            
-                // Yield
-                if (property_exists($data, "recipeYield")) {
-                    $recipeYield = $data->recipeYield;
-                    $recipe->yield = RecipeParser_Text::formatAsParagraphs($recipeYield);;
-                }
-            
-                // Ingredients
-                if (property_exists($data, "recipeIngredient")) {
-                    $ingredients = $data->recipeIngredient;
-                    foreach ($ingredients as $ingredient) {
-                        $ingredient = RecipeParser_Text::formatAsOneLine($ingredient);
-                        if (empty($ingredient)) {
-                            continue;
-                        }
-                        if (strlen($ingredient) > 150) {
-                            // probably a mistake, like a run-on of existing ingredients?
-                            continue;
-                        }
-                        if (RecipeParser_Text::matchSectionName($ingredient)) {
-                            $ingredient = RecipeParser_Text::formatSectionName($ingredient);
-                            $recipe->addIngredientsSection($ingredient);
-                        } else {
-                            $recipe->appendIngredient($ingredient);
-                        }
-                    }
-                }
-                else if (property_exists($data, "ingredients")) {
-                    $ingredients = $data->ingredients;
-                    foreach ($ingredients as $ingredient) {
-                        $ingredient = RecipeParser_Text::formatAsOneLine($ingredient);
-                        if (empty($ingredient)) {
-                            continue;
-                        }
-                        if (strlen($ingredient) > 150) {
-                            // probably a mistake, like a run-on of existing ingredients?
-                            continue;
-                        }
-                        if (RecipeParser_Text::matchSectionName($ingredient)) {
-                            $ingredient = RecipeParser_Text::formatSectionName($ingredient);
-                            $recipe->addIngredientsSection($ingredient);
-                        } else {
-                            $recipe->appendIngredient($ingredient);
-                        }
-                    }
-                }
-            
-                // Photo
-                if (property_exists($data, "image")) {
-                    $photo_url = $data->image;
-                    $recipe->photo_url = RecipeParser_Text::relativeToAbsolute($photo_url, $url);
-                }
-            
-                // Credits
-                if (property_exists($data, "author")) {
-                    if (property_exists($data->author, "name")) {
-                        $recipe->credits = RecipeParser_Text::formatCredits($data->author->name);
-                    }
-                }
+        
+        // Bail JSON-LD not marked up properly
+        if (!$data || !property_exists($data, "@context") || stripos($data->{'@context'}, "schema.org") == false ) {
+            return $recipe;
+        }
+        // Bail if no recipe in the markup
+        if ($data && property_exists($data, "@type") && $data->{'@type'} == 'Recipe') {
+            return $recipe;
+        }
+        
+        // Parse elements:
+        
+        // Title
+        if (property_exists($data, "name")) {
+            $name = $data->name;
+            $recipe->title = RecipeParser_Text::formatTitle($name);
+        }
+    
+        // Summary
+        if (property_exists($data, "description")) {
+            $summary = $data->description;
+            $recipe->description = RecipeParser_Text::formatAsParagraphs($summary);;
+        }
+    
+        // Times
+        if (property_exists($data, "prepTime")) {
+            $prepTime = $data->prepTime;
+            $recipe->time['prep'] = RecipeParser_Text::formatISO_8601($prepTime);;
+        }
+        if (property_exists($data, "cookTime")) {
+            $cookTime = $data->cookTime;
+            $recipe->time['cook'] = RecipeParser_Text::formatISO_8601($cookTime);;
+        }
+        if (property_exists($data, "totalTime")) {
+            $totalTime = $data->totalTime;
+            $recipe->time['total'] = RecipeParser_Text::formatISO_8601($totalTime);;
+        }
+    
+        // Yield
+        if (property_exists($data, "recipeYield")) {
+            $recipeYield = $data->recipeYield;
+            $recipe->yield = RecipeParser_Text::formatAsParagraphs($recipeYield);;
+        }
+    
+        // Ingredients
+        $ingredients = property_exists($data, "recipeIngredient") ? $data->recipeIngredient : false;
+        if (!$ingredients) {
+            $ingredients = property_exists($data, "ingredients") ? $data->ingredients : [];
+        }
+        
+        foreach ($ingredients as $ingredient) {
+            $ingredient = RecipeParser_Text::formatAsOneLine($ingredient);
+            if (empty($ingredient)) {
+                continue;
+            }
+            if (strlen($ingredient) > 150) {
+                // probably a mistake, like a run-on of existing ingredients?
+                continue;
+            }
+            if (RecipeParser_Text::matchSectionName($ingredient)) {
+                $ingredient = RecipeParser_Text::formatSectionName($ingredient);
+                $recipe->addIngredientsSection($ingredient);
+            } else {
+                $recipe->appendIngredient($ingredient);
             }
         }
+    
+        // Photo
+        if (property_exists($data, "image")) {
+            $photo_url = $data->image;
+            $recipe->photo_url = RecipeParser_Text::relativeToAbsolute($photo_url, $url);
+        }
+    
+        // Credits
+        if (property_exists($data, "author")) {
+            if (property_exists($data->author, "name")) {
+                $recipe->credits = RecipeParser_Text::formatCredits($data->author->name);
+            }
+        }
+        
         return $recipe;
     }
 

--- a/lib/RecipeParser/Parser/MicrodataJsonLd.php
+++ b/lib/RecipeParser/Parser/MicrodataJsonLd.php
@@ -1,7 +1,5 @@
 <?php
 
-use \ML\JsonLD\JsonLD as JsonLD;
-
 class RecipeParser_Parser_MicrodataJsonLd {
 
     static public function parse(DOMDocument $doc, $url) {

--- a/lib/RecipeParser/Parser/MicrodataJsonLd.php
+++ b/lib/RecipeParser/Parser/MicrodataJsonLd.php
@@ -16,7 +16,7 @@ class RecipeParser_Parser_MicrodataJsonLd {
             return $recipe;
         }
         // Bail if no recipe in the markup
-        if ($data && property_exists($data, "@type") && $data->{'@type'} == 'Recipe') {
+        if (!property_exists($data, "@type") || $data->{'@type'} != 'Recipe') {
             return $recipe;
         }
         
@@ -87,6 +87,8 @@ class RecipeParser_Parser_MicrodataJsonLd {
         if (property_exists($data, "author")) {
             if (property_exists($data->author, "name")) {
                 $recipe->credits = RecipeParser_Text::formatCredits($data->author->name);
+            } else {
+                $recipe->credits = RecipeParser_Text::formatCredits($data->author);
             }
         }
         

--- a/lib/RecipeParser/Parser/MicrodataJsonLd.php
+++ b/lib/RecipeParser/Parser/MicrodataJsonLd.php
@@ -33,15 +33,15 @@ class RecipeParser_Parser_MicrodataJsonLd {
                 // Times
                 if (property_exists($data, "prepTime")) {
                     $prepTime = $data->prepTime;
-                    $recipe->prepTime = RecipeParser_Text::formatAsParagraphs($prepTime);;
+                    $recipe->time['prep'] = RecipeParser_Text::formatISO_8601($prepTime);;
                 }
                 if (property_exists($data, "cookTime")) {
                     $cookTime = $data->cookTime;
-                    $recipe->cookTime = RecipeParser_Text::formatAsParagraphs($cookTime);;
+                    $recipe->time['cook'] = RecipeParser_Text::formatISO_8601($cookTime);;
                 }
                 if (property_exists($data, "totalTime")) {
                     $totalTime = $data->totalTime;
-                    $recipe->totalTime = RecipeParser_Text::formatAsParagraphs($totalTime);;
+                    $recipe->time['total'] = RecipeParser_Text::formatISO_8601($totalTime);;
                 }
             
                 // Yield

--- a/lib/RecipeParser/Parser/MicrodataJsonLd.php
+++ b/lib/RecipeParser/Parser/MicrodataJsonLd.php
@@ -12,7 +12,7 @@ class RecipeParser_Parser_MicrodataJsonLd {
         $data = json_decode( $json );
         
         // Bail JSON-LD not marked up properly
-        if (!$data || !property_exists($data, "@context") || stripos($data->{'@context'}, "schema.org") == false ) {
+        if (!$data || !property_exists($data, "@context") || stripos($data->{'@context'}, "schema.org") === false ) {
             return $recipe;
         }
         // Bail if no recipe in the markup

--- a/lib/RecipeParser/Parser/MicrodataJsonLd.php
+++ b/lib/RecipeParser/Parser/MicrodataJsonLd.php
@@ -8,175 +8,102 @@ class RecipeParser_Parser_MicrodataJsonLd {
         $recipe = new RecipeParser_Recipe();
         $xpath = new DOMXPath($doc);
         
+        // playground
+        $jsonScripts = $xpath->query('//script[@type="application/ld+json"]');
+        $json = trim( $jsonScripts->item(0)->nodeValue );
+        $data = json_decode( $json );
+        print_r($data);
 
-        $microdata = null;
-        $nodes = $xpath->query('//*[contains(@itemtype, "//schema.org/Recipe") or contains(@itemtype, "//schema.org/recipe")]');
-        if ($nodes->length) {
-            $microdata = $nodes->item(0);
-        }
-
-        // Parse elements
-        if ($microdata) {
-
-            // Title
-            $nodes = $xpath->query('.//*[@itemprop="name"]', $microdata);
-            if ($nodes->length) {
-                $value = trim($nodes->item(0)->nodeValue);
-                $recipe->title = RecipeParser_Text::formatTitle($value);
-            }
-
-            // Summary
-            $nodes = $xpath->query('.//*[@itemprop="description"]', $microdata);
-            if ($nodes->length) {
-                $value = $nodes->item(0)->nodeValue;
-                $value = RecipeParser_Text::formatAsParagraphs($value);
-                $recipe->description = $value;
-            }
-
-            // Times
-            $searches = array('prepTime' => 'prep',
-                              'cookTime' => 'cook',
-                              'totalTime' => 'total');
-            foreach ($searches as $itemprop => $time_key) {
-                $nodes = $xpath->query('.//*[@itemprop="' . $itemprop . '"]', $microdata);
-                if ($nodes->length) {
-                    if (strlen($nodes->item(0)->getAttribute('content')) >= 2) { #bug in bonappetit where content is only "P"
-                        $value = $nodes->item(0)->getAttribute('content');
-                        $value = RecipeParser_Text::iso8601ToMinutes($value);
-                    } else if ($value = $nodes->item(0)->getAttribute('datetime')) {
-                        $value = RecipeParser_Text::iso8601ToMinutes($value);
-                    } else {
-                        $value = trim($nodes->item(0)->nodeValue);
-                        $value = RecipeParser_Times::toMinutes($value);
+        if ($data && property_exists($data, "@context") && stripos($data->{'@context'}, "schema.org") !== false ) {
+            // Parse elements
+            if ($data && property_exists($data, "@type") && $data->{'@type'} == 'Recipe') {
+            
+                // Title
+                if (property_exists($data, "name")) {
+                    $name = $data->name;
+                    $recipe->title = RecipeParser_Text::formatTitle($name);
+                }
+            
+                // Summary
+                if (property_exists($data, "description")) {
+                    $summary = $data->description;
+                    $recipe->description = RecipeParser_Text::formatAsParagraphs($summary);;
+                }
+            
+                // Times
+                if (property_exists($data, "prepTime")) {
+                    $prepTime = $data->prepTime;
+                    $recipe->prepTime = RecipeParser_Text::formatAsParagraphs($prepTime);;
+                }
+                if (property_exists($data, "cookTime")) {
+                    $cookTime = $data->cookTime;
+                    $recipe->cookTime = RecipeParser_Text::formatAsParagraphs($cookTime);;
+                }
+                if (property_exists($data, "totalTime")) {
+                    $totalTime = $data->totalTime;
+                    $recipe->totalTime = RecipeParser_Text::formatAsParagraphs($totalTime);;
+                }
+            
+                // Yield
+                if (property_exists($data, "recipeYield")) {
+                    $recipeYield = $data->recipeYield;
+                    $recipe->yield = RecipeParser_Text::formatAsParagraphs($recipeYield);;
+                }
+            
+                // Ingredients
+                if (property_exists($data, "recipeIngredient")) {
+                    $ingredients = $data->recipeIngredient;
+                    foreach ($ingredients as $ingredient) {
+                        $ingredient = RecipeParser_Text::formatAsOneLine($ingredient);
+                        if (empty($ingredient)) {
+                            continue;
+                        }
+                        if (strlen($ingredient) > 150) {
+                            // probably a mistake, like a run-on of existing ingredients?
+                            continue;
+                        }
+                        if (RecipeParser_Text::matchSectionName($ingredient)) {
+                            $ingredient = RecipeParser_Text::formatSectionName($ingredient);
+                            $recipe->addIngredientsSection($ingredient);
+                        } else {
+                            $recipe->appendIngredient($ingredient);
+                        }
                     }
-                    if ($value) {
-                        $recipe->time[$time_key] = $value;
+                }
+                else if (property_exists($data, "ingredients")) {
+                    $ingredients = $data->ingredients;
+                    foreach ($ingredients as $ingredient) {
+                        $ingredient = RecipeParser_Text::formatAsOneLine($ingredient);
+                        if (empty($ingredient)) {
+                            continue;
+                        }
+                        if (strlen($ingredient) > 150) {
+                            // probably a mistake, like a run-on of existing ingredients?
+                            continue;
+                        }
+                        if (RecipeParser_Text::matchSectionName($ingredient)) {
+                            $ingredient = RecipeParser_Text::formatSectionName($ingredient);
+                            $recipe->addIngredientsSection($ingredient);
+                        } else {
+                            $recipe->appendIngredient($ingredient);
+                        }
+                    }
+                }
+            
+                // Photo
+                if (property_exists($data, "image")) {
+                    $photo_url = $data->image;
+                    $recipe->photo_url = RecipeParser_Text::relativeToAbsolute($photo_url, $url);
+                }
+            
+                // Credits
+                if (property_exists($data, "author")) {
+                    if (property_exists($data->author, "name")) {
+                        $recipe->credits = RecipeParser_Text::formatCredits($data->author->name);
                     }
                 }
             }
-
-            // Yield
-            $nodes = $xpath->query('.//*[@itemprop="recipeYield"]', $microdata);
-            if (!$nodes->length) {
-                $nodes = $xpath->query('.//*[@itemprop="recipeyield"]', $microdata);
-            }
-            if ($nodes->length) {
-                if ($nodes->item(0)->hasAttribute('content')) {
-                    $line = $nodes->item(0)->getAttribute('content');
-                } else {
-                    $line = $nodes->item(0)->nodeValue;
-                }
-                $recipe->yield = RecipeParser_Text::formatYield($line);
-            }
-
-            // Ingredients 
-            $nodes = $xpath->query('.//*[@itemprop="ingredients"]', $microdata);
-            foreach ($nodes as $node) {
-                $value = $node->nodeValue;
-                $value = RecipeParser_Text::formatAsOneLine($value);
-                if (empty($value)) {
-                    continue;
-                }
-                if (strlen($value) > 150) {
-                    // probably a mistake, like a run-on of existing ingredients?
-                    continue;
-                }
-
-                if (RecipeParser_Text::matchSectionName($value)) {
-                    $value = RecipeParser_Text::formatSectionName($value);
-                    $recipe->addIngredientsSection($value);
-                } else {
-                    $recipe->appendIngredient($value);
-                }
-            }
-
-            // Instructions
-            $found = false;
-
-            // Look for markup that uses <li> tags for each instruction.
-            if (!$found) {
-                $nodes = $xpath->query('.//*[@itemprop="recipeInstructions"]//li', $microdata);
-                if ($nodes->length) {
-                    RecipeParser_Text::parseInstructionsFromNodes($nodes, $recipe);
-                    $found = true;
-                }
-            }
-
-            // Look for instructions as direct descendents of "recipeInstructions".
-            if (!$found) {
-                $nodes = $xpath->query('.//*[@itemprop="recipeInstructions"]/*', $microdata);
-                if ($nodes->length) {
-                    RecipeParser_Text::parseInstructionsFromNodes($nodes, $recipe);
-                    $found = true;
-
-                    // Recipe.com gets caught up in here, but doesn't have well-formed nodes wrapping each ingredient.
-                }
-            }
-
-            // Some sites will use an "instruction" class for each line.
-            if (!$found) {
-                $nodes = $xpath->query('.//*[@itemprop="recipeInstructions"]//*[contains(concat(" ", normalize-space(@class), " "), " instruction ")]', $microdata);
-                if ($nodes->length) {
-                    RecipeParser_Text::parseInstructionsFromNodes($nodes, $recipe);
-                    $found = true;
-                }
-            }
-
-            // Either multiple recipeInstructions nodes, or one node with a blob of text.
-            if (!$found) {
-                $nodes = $xpath->query('.//*[@itemprop="recipeInstructions"]', $microdata);
-                if ($nodes->length > 1) {
-                    // Multiple nodes
-                    RecipeParser_Text::parseInstructionsFromNodes($nodes, $recipe);
-                    $found = true;
-                } else if ($nodes->length == 1) {
-                    // Blob
-                    $str = $nodes->item(0)->nodeValue;
-                    RecipeParser_Text::parseInstructionsFromBlob($str, $recipe);
-                    $found = true;
-                }
-            }
-
-            // Photo
-            $photo_url = "";
-            if (!$photo_url) {
-                // try to find open graph url
-                $nodes = $xpath->query('//meta[@property="og:image"]');
-                if ($nodes->length) {
-                    $photo_url = $nodes->item(0)->getAttribute('content');
-                }
-            }
-            if (!$photo_url) {
-                $nodes = $xpath->query('.//*[@itemprop="image"]', $microdata);
-                if ($nodes->length) {
-                    $photo_url = $nodes->item(0)->getAttribute('src');
-                }
-            }
-            if (!$photo_url) {
-                // for <img> as sub-node of class="photo"
-                $nodes = $xpath->query('.//*[@itemprop="image"]//img', $microdata);
-                if ($nodes->length) {
-                    $photo_url = $nodes->item(0)->getAttribute('src');
-                }
-            }
-            if ($photo_url) {
-                $recipe->photo_url = RecipeParser_Text::relativeToAbsolute($photo_url, $url);
-            }
-
-            // Credits
-            $line = "";
-            $nodes = $xpath->query('.//*[@itemprop="author"]', $microdata);
-            if ($nodes->length) {
-                $line = $nodes->item(0)->nodeValue;
-            }
-            $nodes = $xpath->query('.//*[@itemprop="publisher"]', $microdata);
-            if ($nodes->length) {
-                $line = $nodes->item(0)->nodeValue;
-            }
-
-            $recipe->credits = RecipeParser_Text::formatCredits($line);
         }
-
         return $recipe;
     }
 

--- a/lib/RecipeParser/Parser/MicrodataSchema.php
+++ b/lib/RecipeParser/Parser/MicrodataSchema.php
@@ -7,50 +7,6 @@ class RecipeParser_Parser_MicrodataSchema {
     static public function parse(DOMDocument $doc, $url) {
         $recipe = new RecipeParser_Recipe();
         $xpath = new DOMXPath($doc);
-        
-    // playground
-        $jsonScripts = $xpath->query('//script[@type="application/ld+json"]');
-        $json = trim( $jsonScripts->item(0)->nodeValue );
-        $data = json_decode( $json );
-        print_r($data);
-        
-        // Parse elements
-        if ($data && $data->{'@type'} == 'Recipe') {
-            
-            // Title
-            $name = $data->name;
-            if ($name) {
-                $recipe->title = RecipeParser_Text::formatTitle($value);
-            }
-            
-            // Summary
-            $summary = $data->description;
-            if ($summary) {
-                $recipe->description = RecipeParser_Text::formatAsParagraphs($summary);;
-            }
-            
-            // Times
-            $prepTime = $data->prepTime;
-            if ($prepTime) {
-                $recipe->prepTime = RecipeParser_Text::formatAsParagraphs($prepTime);;
-            }
-            $cookTime = $data->cookTime;
-            if ($cookTime) {
-                $recipe->cookTime = RecipeParser_Text::formatAsParagraphs($cookTime);;
-            }
-            $prepTime = $data->totalTime;
-            if ($totalTime) {
-                $recipe->totalTime = RecipeParser_Text::formatAsParagraphs($totalTime);;
-            }
-            
-            // Yield
-            $recipeYield = $data->recipeYield;
-            if ($recipeYield) {
-                $recipe->yield = RecipeParser_Text::formatAsParagraphs($recipeYield);;
-            }
-            
-        }
-    // end playground
 
         $microdata = null;
         $nodes = $xpath->query('//*[contains(@itemtype, "//schema.org/Recipe") or contains(@itemtype, "//schema.org/recipe")]');

--- a/lib/RecipeParser/Parser/MicrodataSchema.php
+++ b/lib/RecipeParser/Parser/MicrodataSchema.php
@@ -7,7 +7,7 @@ class RecipeParser_Parser_MicrodataSchema {
         $xpath = new DOMXPath($doc);
 
         $microdata = null;
-        $nodes = $xpath->query('//*[contains(@itemtype, "//schema.org/Recipe") or contains(@itemtype, "//schema.org/recipe")]');
+        $nodes = $xpath->query('//*[contains(@itemtype, "schema.org/Recipe") or contains(@itemtype, "schema.org/recipe")]');
         if ($nodes->length) {
             $microdata = $nodes->item(0);
         }
@@ -18,15 +18,24 @@ class RecipeParser_Parser_MicrodataSchema {
             // Title
             $nodes = $xpath->query('.//*[@itemprop="name"]', $microdata);
             if ($nodes->length) {
-                $value = trim($nodes->item(0)->nodeValue);
+                if ($nodes->item(0)->hasAttribute('content')) {
+                    $line = $nodes->item(0)->getAttribute('content');
+                } else {
+                    $line = $nodes->item(0)->nodeValue;
+                }
+                $value = trim($line);
                 $recipe->title = RecipeParser_Text::formatTitle($value);
             }
 
             // Summary
             $nodes = $xpath->query('.//*[@itemprop="description"]', $microdata);
             if ($nodes->length) {
-                $value = $nodes->item(0)->nodeValue;
-                $value = RecipeParser_Text::formatAsParagraphs($value);
+                if ($nodes->item(0)->hasAttribute('content')) {
+                    $line = $nodes->item(0)->getAttribute('content');
+                } else {
+                    $line = $nodes->item(0)->nodeValue;
+                }
+                $value = RecipeParser_Text::formatAsParagraphs($line);
                 $recipe->description = $value;
             }
 
@@ -68,9 +77,16 @@ class RecipeParser_Parser_MicrodataSchema {
 
             // Ingredients 
             $nodes = $xpath->query('.//*[@itemprop="ingredients"]', $microdata);
+            if (!$nodes->length) {
+                $nodes = $xpath->query('.//*[@itemprop="recipeIngredient"]', $microdata);
+            }
             foreach ($nodes as $node) {
-                $value = $node->nodeValue;
-                $value = RecipeParser_Text::formatAsOneLine($value);
+                if ($nodes->item(0)->hasAttribute('content')) {
+                    $line = $node->getAttribute('content');
+                } else {
+                    $line = $node->nodeValue;
+                }
+                $value = RecipeParser_Text::formatAsOneLine($line);
                 if (empty($value)) {
                     continue;
                 }

--- a/lib/RecipeParser/Parser/MicrodataSchema.php
+++ b/lib/RecipeParser/Parser/MicrodataSchema.php
@@ -1,7 +1,5 @@
 <?php
 
-use \ML\JsonLD\JsonLD as JsonLD;
-
 class RecipeParser_Parser_MicrodataSchema {
 
     static public function parse(DOMDocument $doc, $url) {

--- a/lib/RecipeParser/Text.php
+++ b/lib/RecipeParser/Text.php
@@ -95,6 +95,7 @@ ONETSP_TIME: $time
     }
     
     static public function cleanupClippedRecipeHtmlWithScripts($html) {
+        $html = RecipeParser_Text::stripConditionalComments($html);
         $html = self::normalize($html);
         return $html;
     }

--- a/lib/RecipeParser/Text.php
+++ b/lib/RecipeParser/Text.php
@@ -100,6 +100,11 @@ ONETSP_TIME: $time
         return $html;
     }
     
+    static public function cleanJson($str) {
+        $str = preg_replace( "/\r|\n/", "", $str ); // Line breaks are a common way to ruin otherwise-valid JSON
+        return $str;
+    }
+    
     static public function normalize($html) {
         $html = preg_replace('/(\r\n|\r)/', "\n", $html);            // Normalize line breaks
         $html = str_replace('&nbsp;', ' ', $html);                   // get rid of non-breaking space (html code)

--- a/lib/RecipeParser/Text.php
+++ b/lib/RecipeParser/Text.php
@@ -95,8 +95,8 @@ ONETSP_TIME: $time
     }
     
     static public function cleanupClippedRecipeHtmlWithScripts($html) {
-        $html = RecipeParser_Text::stripConditionalComments($html);
         $html = self::normalize($html);
+        $html = RecipeParser_Text::stripConditionalComments($html);
         return $html;
     }
     

--- a/lib/RecipeParser/Text.php
+++ b/lib/RecipeParser/Text.php
@@ -84,17 +84,27 @@ ONETSP_TIME: $time
      * @return string HTML
      */
     static public function cleanupClippedRecipeHtml($html) {
-        $html = preg_replace('/(\r\n|\r)/', "\n", $html);            // Normalize line breaks
-        $html = str_replace('&nbsp;', ' ', $html);                   // get rid of non-breaking space (html code)
-        $html = str_replace('&#160;', ' ', $html);                   // get rid of non-breaking space (numeric)
-        $html = preg_replace('/\xC2\xA0/', ' ', $html);              // get rid of non-breaking space (UTF-8)
-        $html = preg_replace('/[\x{0096}-\x{0097}]/u', '-', $html);  // ndash, mdash (bonappetit)
+        $html = self::normalize($html);
 
         // Strip out script tags so they don't accidentally get executed if we ever display
         // clipped content to end-users.
         $html = RecipeParser_Text::stripTagAndContents('script', $html);
         $html = RecipeParser_Text::stripConditionalComments($html);
 
+        return $html;
+    }
+    
+    static public function cleanupClippedRecipeHtmlWithScripts($html) {
+        $html = self::normalize($html);
+        return $html;
+    }
+    
+    static public function normalize($html) {
+        $html = preg_replace('/(\r\n|\r)/', "\n", $html);            // Normalize line breaks
+        $html = str_replace('&nbsp;', ' ', $html);                   // get rid of non-breaking space (html code)
+        $html = str_replace('&#160;', ' ', $html);                   // get rid of non-breaking space (numeric)
+        $html = preg_replace('/\xC2\xA0/', ' ', $html);              // get rid of non-breaking space (UTF-8)
+        $html = preg_replace('/[\x{0096}-\x{0097}]/u', '-', $html);  // ndash, mdash (bonappetit)
         return $html;
     }
 
@@ -124,6 +134,11 @@ ONETSP_TIME: $time
         $str = str_replace("<p>", "\n\n", $str);        // <p> back to newlines
         $str = trim($str);
         return $str;
+    }
+    
+    public static function formatISO_8601($str) {
+        $d = new DateInterval($str);
+        return ($d->h * 60) + $d->i;
     }
 
     /**

--- a/tests/RecipeParser_Parser_MicrodataJsonLdTest.php
+++ b/tests/RecipeParser_Parser_MicrodataJsonLdTest.php
@@ -1,0 +1,62 @@
+<?php
+
+require_once '../bootstrap.php';
+
+class RecipeParser_Parser_MicrodataDataVocabularyTest extends PHPUnit_Framework_TestCase {
+
+    public function test_jsonld_sweet_paul() {
+        $path = "data/sweetpaulmag_com_tomato_tart_with_basil_oil_and_curl.html";
+        $url = "http://www.sweetpaulmag.com/food/tomato-tart-with-basil-oil-and-almond-amp-pepper-crust";
+
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
+        if (isset($_SERVER['VERBOSE'])) print_r($recipe);
+
+        $this->assertEquals("Tomato Tart with Basil Oil and Almond &amp; Pepper Crust", $recipe->title);
+        $this->assertEquals("Sweet Paul", $recipe->credits);
+        $this->assertEquals("", $recipe->description);
+
+        $this->assertEquals(0, $recipe->time['prep']);
+        $this->assertEquals(0, $recipe->time['cook']);
+        $this->assertEquals(0, $recipe->time['total']);
+        $this->assertEquals('Makes 1 Tart', $recipe->yield);
+
+        $this->assertEquals(1, count($recipe->ingredients));
+        $this->assertEquals(15, count($recipe->ingredients[0]['list']));
+        $this->assertEquals("1 cup all&shy;purpose flour", $recipe->ingredients[0]['list'][1]);
+        $this->assertEquals("1/4 cup almond flour", $recipe->ingredients[0]['list'][2]);
+        $this->assertEquals("1/2 teaspoon salt", $recipe->ingredients[0]['list'][3]);
+
+        $this->assertEquals('http://www.sweetpaulmag.com/1EatContent/images/2014/4625980_281271_tomtart1.jpg', 
+                            $recipe->photo_url);
+    }
+    
+    public function test_jsonld_sweet_life() {
+        $path = "data/gracessweetlife_com_cannoli_and_cannoli_filling_graces_sweet_curl.html";
+        $url = "http://gracessweetlife.com/2010/06/cannoli-siciliani-the-ultimate-italian-pastry/";
+
+        $doc = RecipeParser_Text::getDomDocument(file_get_contents($path));
+        $recipe = RecipeParser::parse($doc, $url);
+        if (isset($_SERVER['VERBOSE'])) print_r($recipe);
+
+        $this->assertEquals("Cannoli Siciliani &ndash; The Ultimate Italian Pastry", $recipe->title);
+        $this->assertEquals("Grace Massa Langlois", $recipe->credits);
+        $this->assertRegexp("/^Prepare one .* creamy ricotta filling.$/s", $recipe->description);
+
+        $this->assertEquals(138, $recipe->time['prep']);
+        $this->assertEquals(45, $recipe->time['cook']);
+        $this->assertEquals(183, $recipe->time['total']);
+        $this->assertEquals('28 pastries', $recipe->yield);
+
+        $this->assertEquals(1, count($recipe->ingredients));
+        $this->assertEquals(13, count($recipe->ingredients[0]['list']));
+        $this->assertEquals("167 g (1 1/3 cups) plain (all-purpose) flour", $recipe->ingredients[0]['list'][0]);
+        $this->assertEquals("1/4 teaspoon salt", $recipe->ingredients[0]['list'][1]);
+        $this->assertEquals("14 g (1 tablespoon) granulated sugar", $recipe->ingredients[0]['list'][2]);
+
+        $this->assertEquals('http://gracessweetlife.com/wp-content/uploads/2010/06/ccc3-e1381295500919.jpg', 
+                            $recipe->photo_url);
+    }
+}
+
+?>

--- a/tests/data/gracessweetlife_com_cannoli_and_cannoli_filling_graces_sweet_curl.html
+++ b/tests/data/gracessweetlife_com_cannoli_and_cannoli_filling_graces_sweet_curl.html
@@ -1,0 +1,1270 @@
+<!--
+ONETSP_URL: http://gracessweetlife.com/2010/06/cannoli-siciliani-the-ultimate-italian-pastry/
+ONETSP_USER_AGENT: curl
+ONETSP_TIME: Tue, 05 Jul 2016 17:24:06 +0000
+-->
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+
+<head>
+<meta name="robots" content="index, follow"/>
+<meta name="msvalidate.01" content="BAF745F432ED927023BCBCB1217E2578" />
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<meta http-equiv="content-language" content="en-us" />
+<meta name="google-site-verification" content="6GY5x3vDdWgJQJUYE3HOzQ97n5BoCSQvbYCJFtFx6xo" />
+<meta name="google-site-verification" content="RpVhBen1lV98xWMgfUM_PWEeaGnm480rnOsKieQ4Pfw" />
+<meta name="y_key" content="3e63f048d1863bd5" />
+<meta name="majestic-site-verification" content="MJ12_e8607604-7188-4203-b5fc-3ef18cb558a9"/>
+<link rel="author" href="https://plus.google.com/+GraceMassaLanglois"/>
+
+<!-- ukey="2E744ED8" -->
+<title>Cannoli and Cannoli Filling Recipe: Grace's Sweet Life Pastries</title>
+
+<link rel="stylesheet" type="text/css" href="http://gracessweetlife.com/wp-content/themes/simplewp/style.css" />
+
+<link rel="alternate" type="application/rss+xml" title="Grace&#039;s Sweet Life RSS Feed" href="http://gracessweetlife.com/feed/" />
+
+<link rel="pingback" href="http://gracessweetlife.com/xmlrpc.php" />
+
+
+<!-- All in One SEO Pack 2.3.5.1 by Michael Torbert of Semper Fi Web Design[890,1000] -->
+<meta name="description"  content="What is Cannoli? The Ultimate Italian Pastry! Authentic Italian Recipe for Cannoli, traditional crispy Pastry Shells with classic Ricotta Cannoli Filling." />
+
+<link rel="canonical" href="http://gracessweetlife.com/2010/06/cannoli-siciliani-the-ultimate-italian-pastry/" />
+<meta property="og:title" content="Cannoli and Cannoli Filling Recipe: Grace&#039;s Sweet Life Pastries" />
+<meta property="og:type" content="article" />
+<meta property="og:url" content="http://gracessweetlife.com/2010/06/cannoli-siciliani-the-ultimate-italian-pastry/" />
+<meta property="og:image" content="http://gracessweetlife.com/wp-content/uploads/2010/06/ccc16-e1381295276780.jpg" />
+<meta property="og:site_name" content="Grace&#039;s Sweet Life" />
+<meta property="fb:admins" content="642755124" />
+<meta property="og:description" content="What is Cannoli? The Ultimate Italian Pastry! Authentic Italian Recipe for Cannoli, traditional crispy Pastry Shells with classic Ricotta Cannoli Filling." />
+<meta property="article:publisher" content="https://www.facebook.com/GracesSweetLife" />
+<meta property="article:author" content="https://www.facebook.com/GraceMassaLanglois" />
+<meta property="article:published_time" content="2010-06-07T05:12:45Z" />
+<meta property="article:modified_time" content="2015-07-22T20:39:35Z" />
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:site" content="@GracesSweetLife" />
+<meta name="twitter:domain" content="Grace&#039;s Sweet Life" />
+<meta name="twitter:title" content="Cannoli and Cannoli Filling Recipe: Grace&#039;s Sweet Life Pastries" />
+<meta name="twitter:description" content="What is Cannoli? The Ultimate Italian Pastry! Authentic Italian Recipe for Cannoli, traditional crispy Pastry Shells with classic Ricotta Cannoli Filling." />
+<meta name="twitter:image" content="http://gracessweetlife.com/wp-content/uploads/2010/06/ccc16-e1381295276780.jpg" />
+<!-- /all in one seo pack -->
+<link rel="alternate" type="application/rss+xml" title="Grace&#039;s Sweet Life &raquo; Cannoli Siciliani – The Ultimate Italian Pastry Comments Feed" href="http://gracessweetlife.com/2010/06/cannoli-siciliani-the-ultimate-italian-pastry/feed/" />
+<!-- This site is powered by Shareaholic - https://shareaholic.com -->
+<script type='text/javascript' data-cfasync='false'>
+  //<![CDATA[
+    _SHR_SETTINGS = {"endpoints":{"local_recs_url":"http:\/\/gracessweetlife.com\/wp-admin\/admin-ajax.php?action=shareaholic_permalink_related","share_counts_url":"http:\/\/gracessweetlife.com\/wp-admin\/admin-ajax.php?action=shareaholic_share_counts_api"}};
+  //]]>
+</script>
+<script type='text/javascript' data-cfasync='false'
+        src='//dsms0mj1bbhn4.cloudfront.net/assets/pub/shareaholic.js'
+        data-shr-siteid='26bee0688488a418ad8c7c7317c039b6' async='async' >
+</script>
+
+<!-- Shareaholic Content Tags -->
+<meta name='shareaholic:site_name' content='Grace&#039;s Sweet Life' />
+<meta name='shareaholic:language' content='en-US' />
+<meta name='shareaholic:url' content='http://gracessweetlife.com/2010/06/cannoli-siciliani-the-ultimate-italian-pastry/' />
+<meta name='shareaholic:keywords' content='after school treat, afternoon tea, cannoli filling, cannoli pastries, cannoli ricotta filling, cookie, cupcake fillings, dessert, desserts, desserts for entertaining, entertaining, food, food photography, food photos, fried pastries, individual dessert, individual desserts, italian cookie, italian dessert, italian desserts, italian pastries, italian pastry, italian recipes, italian sweet, italian sweets, pastry cream, pastry fillings, ricotta cheese, ricotta filling, baking &amp; pastry, baking mise en place, basics, custards, creams &amp; mousses, dolci fritti, fillings, frostings &amp; dessert sauces, fried desserts, mini desserts, pasticcini, pastries, pastry doughs &amp; batter, piccola pasticceria, recipes, ricette di base' />
+<meta name='shareaholic:article_published_time' content='2010-06-07T09:12:45+00:00' />
+<meta name='shareaholic:article_modified_time' content='2016-04-16T22:21:40+00:00' />
+<meta name='shareaholic:shareable_page' content='true' />
+<meta name='shareaholic:article_author_name' content='Grace Massa Langlois' />
+<meta name='shareaholic:site_id' content='26bee0688488a418ad8c7c7317c039b6' />
+<meta name='shareaholic:wp_version' content='7.7.1.0' />
+<meta name='shareaholic:image' content='http://gracessweetlife.com/wp-content/uploads/2010/06/ccc2-e1381295877162.jpg' />
+<!-- Shareaholic Content Tags End -->
+		<script type="text/javascript">
+			window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/72x72\/","ext":".png","source":{"concatemoji":"http:\/\/gracessweetlife.com\/wp-includes\/js\/wp-emoji-release.min.js?ver=4.5.3"}};
+			!function(a,b,c){function d(a){var c,d,e,f=b.createElement("canvas"),g=f.getContext&&f.getContext("2d"),h=String.fromCharCode;if(!g||!g.fillText)return!1;switch(g.textBaseline="top",g.font="600 32px Arial",a){case"flag":return g.fillText(h(55356,56806,55356,56826),0,0),f.toDataURL().length>3e3;case"diversity":return g.fillText(h(55356,57221),0,0),c=g.getImageData(16,16,1,1).data,d=c[0]+","+c[1]+","+c[2]+","+c[3],g.fillText(h(55356,57221,55356,57343),0,0),c=g.getImageData(16,16,1,1).data,e=c[0]+","+c[1]+","+c[2]+","+c[3],d!==e;case"simple":return g.fillText(h(55357,56835),0,0),0!==g.getImageData(16,16,1,1).data[0];case"unicode8":return g.fillText(h(55356,57135),0,0),0!==g.getImageData(16,16,1,1).data[0]}return!1}function e(a){var c=b.createElement("script");c.src=a,c.type="text/javascript",b.getElementsByTagName("head")[0].appendChild(c)}var f,g,h,i;for(i=Array("simple","flag","unicode8","diversity"),c.supports={everything:!0,everythingExceptFlag:!0},h=0;h<i.length;h++)c.supports[i[h]]=d(i[h]),c.supports.everything=c.supports.everything&&c.supports[i[h]],"flag"!==i[h]&&(c.supports.everythingExceptFlag=c.supports.everythingExceptFlag&&c.supports[i[h]]);c.supports.everythingExceptFlag=c.supports.everythingExceptFlag&&!c.supports.flag,c.DOMReady=!1,c.readyCallback=function(){c.DOMReady=!0},c.supports.everything||(g=function(){c.readyCallback()},b.addEventListener?(b.addEventListener("DOMContentLoaded",g,!1),a.addEventListener("load",g,!1)):(a.attachEvent("onload",g),b.attachEvent("onreadystatechange",function(){"complete"===b.readyState&&c.readyCallback()})),f=c.source||{},f.concatemoji?e(f.concatemoji):f.wpemoji&&f.twemoji&&(e(f.twemoji),e(f.wpemoji)))}(window,document,window._wpemojiSettings);
+		</script>
+		<style type="text/css">
+img.wp-smiley,
+img.emoji {
+	display: inline !important;
+	border: none !important;
+	box-shadow: none !important;
+	height: 1em !important;
+	width: 1em !important;
+	margin: 0 .07em !important;
+	vertical-align: -0.1em !important;
+	background: none !important;
+	padding: 0 !important;
+}
+</style>
+<link rel='stylesheet' id='wp-paginate-css'  href='http://gracessweetlife.com/wp-content/plugins/wp-paginate/wp-paginate.css?ver=1.3.1' type='text/css' media='screen' />
+<script type='text/javascript' src='http://gracessweetlife.com/wp-includes/js/jquery/jquery.js?ver=1.12.4'></script>
+<script type='text/javascript' src='http://gracessweetlife.com/wp-includes/js/jquery/jquery-migrate.min.js?ver=1.4.1'></script>
+<link rel='https://api.w.org/' href='http://gracessweetlife.com/wp-json/' />
+<link rel="EditURI" type="application/rsd+xml" title="RSD" href="http://gracessweetlife.com/xmlrpc.php?rsd" />
+<link rel="wlwmanifest" type="application/wlwmanifest+xml" href="http://gracessweetlife.com/wp-includes/wlwmanifest.xml" /> 
+<link rel='prev' title='Chocolate Hazelnut Tart &#8211; Chocolate Explosion' href='http://gracessweetlife.com/2010/06/chocolate-explosion-chocolate-hazelnut-tart/' />
+<link rel='next' title='Ben &#038; Jerry&#8217;s Chocolate Ice Cream &#8211; Creamy &#038; Delicious' href='http://gracessweetlife.com/2010/06/ben-jerrys-chocolate-ice-cream-creamy-delicious/' />
+<link rel='shortlink' href='http://gracessweetlife.com/?p=985' />
+<link rel="alternate" type="application/json+oembed" href="http://gracessweetlife.com/wp-json/oembed/1.0/embed?url=http%3A%2F%2Fgracessweetlife.com%2F2010%2F06%2Fcannoli-siciliani-the-ultimate-italian-pastry%2F" />
+<link rel="alternate" type="text/xml+oembed" href="http://gracessweetlife.com/wp-json/oembed/1.0/embed?url=http%3A%2F%2Fgracessweetlife.com%2F2010%2F06%2Fcannoli-siciliani-the-ultimate-italian-pastry%2F&#038;format=xml" />
+<!-- <meta name="NextGEN" version="2.1.46" /> -->
+<link type="text/css" rel="stylesheet" href="http://gracessweetlife.com/wp-content/plugins/wordpress-print-this-section/css/printthis.css" />
+<!-- Print This Plugin Was Here! -->
+
+<!-- Start: GPT Async -->
+<script type='text/javascript'>
+	var gptadslots=[];
+	var googletag = googletag || {};
+	googletag.cmd = googletag.cmd || [];
+	(function(){ var gads = document.createElement('script');
+		gads.async = true; gads.type = 'text/javascript';
+		var useSSL = 'https:' == document.location.protocol;
+		gads.src = (useSSL ? 'https:' : 'http:') + '//www.googletagservices.com/tag/js/gpt.js';
+		var node = document.getElementsByTagName('script')[0];
+		node.parentNode.insertBefore(gads, node);
+	})();
+</script>
+
+<script type="text/javascript">
+	googletag.cmd.push(function() {
+
+		//Adslot 1 declaration
+		gptadslots[1]= googletag.defineSlot('/3865/circle.gracessweetlife', [[728,90]],'div-gpt-ad-267054579815088135-1').addService(googletag.pubads());
+
+		googletag.pubads().enableAsyncRendering();
+		googletag.enableServices();
+	});
+</script>
+<!-- End: GPT -->
+
+
+<script type="text/javascript" async defer
+  src="https://apis.google.com/js/platform.js?publisherid=116455008338712344229">
+</script>
+
+<!-- Google Analytics -->
+<script type="text/javascript">
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+ga('create', 'UA-15712937-1', 'auto');  
+ga('send', 'pageview');
+
+</script>
+<!-- End Google Analytics -->
+
+</head>
+
+<body>
+
+<div id="wrapper">
+<!--
+<div id="top"><div id="date">Tuesday, 5th July 2016.</div><div id="subscribe"><a href="http://gracessweetlife.com/feed/">Subscribe</a></div></div>
+-->
+<!-- Beginning Async AdSlot 1 for Ad unit circle.gracessweetlife  ### size: [[728,90]] -->
+<!-- Adslot's refresh function: googletag.pubads().refresh([gptadslots[1]]) -->
+<div id='div-gpt-ad-267054579815088135-1'>
+	<script type='text/javascript'>
+		googletag.cmd.push(function() { googletag.display('div-gpt-ad-267054579815088135-1'); });
+	</script>
+</div>
+<!-- End AdSlot 1 -->
+<div id="header">
+
+
+
+<!--
+<div id="search">
+
+<form method="get" action="http://gracessweetlife.com/">
+
+<input name="s" type="text" value="" id="field" /><input type="image" src="http://gracessweetlife.com/wp-content/themes/simplewp/images/search_button.png" id="button" />
+
+</form>
+
+</div>
+--><!-- Search div -->
+
+</div><!-- Header div -->
+
+<div id="menu-wrapper">
+<ul class="menu">
+
+<li ><a href="http://gracessweetlife.com">Home</a></li>
+
+
+<li class="page_item page-item-2"><a href="http://gracessweetlife.com/about/">About</a></li>
+<li class="page_item page-item-4"><a href="http://gracessweetlife.com/graces-bookshelf/">Grace&#8217;s Bookshelf</a></li>
+<li class="page_item page-item-2082"><a href="http://gracessweetlife.com/inspiration/">Inspiration</a></li>
+<li class="page_item page-item-23"><a href="http://gracessweetlife.com/photography/">Photography</a></li>
+<li class="page_item page-item-3"><a href="http://gracessweetlife.com/recipes/">Recipes</a></li>
+<li class="page_item page-item-5148"><a href="http://gracessweetlife.com/my-book/" title=" ">My Book</a></li>
+<li class="page_item page-item-9955"><a href="http://gracessweetlife.com/privacy-policy/">Privacy Policy</a></li>
+
+</ul>
+</div>
+
+<div id="maincontent">
+
+
+<div id="content">
+
+
+
+
+
+
+<div class="archivearticle">
+
+<div class="title">
+
+<div class="posttitle"><h1 style="color: #7E7E72 !important; font-size: 22px !important;"><a style="color: #7E7E72 !important; font-size: 22px !important;" href="http://gracessweetlife.com/2010/06/cannoli-siciliani-the-ultimate-italian-pastry/" rel="bookmark" title="Permanent Link to Cannoli Siciliani – The Ultimate Italian Pastry">Cannoli Siciliani – The Ultimate Italian Pastry</a></h1></div>
+
+</div> <!-- Title div -->
+
+<div class="postcontent">
+
+<p>Posted by <span class="bold">Grace Massa Langlois</span> on <span class="bold">Monday, 7th June 2010</span></p>
+
+
+
+
+<div class='shareaholic-canvas' data-app-id='95854' data-app='share_buttons' data-title='Cannoli Siciliani – The Ultimate Italian Pastry' data-link='http://gracessweetlife.com/2010/06/cannoli-siciliani-the-ultimate-italian-pastry/' data-summary=''></div><p><strong><em>Cannoli Siciliani</em></strong> has to be, in my opinion, the ultimate Italian pastry. The shells should be covered in bubbles to give you the most amazing crispy texture. The filling is absolutely divine! How could you go wrong with silky, whipped ricotta speckled with mini chocolate chips?  Sprinkle with icing sugar and you are ready to indulge in one of the best Italian Pastries.</p>
+<p><a href="http://gracessweetlife.com/2010/06/cannoli-siciliani-the-ultimate-italian-pastry/italian-cannoli/" rel="attachment wp-att-992"><img class="alignnone size-full wp-image-992" src="http://gracessweetlife.com/wp-content/uploads/2010/06/ccc16-e1381295276780.jpg" alt="A photo of Italian Cannoli placed in a row on a white dessert dish with a pink and white ribbon." width="480" height="320" /></a></p>
+<p>As a kid I couldn&#8217;t wait for Sundays, every Sunday on the way home from 10 o&#8217;clock mass we would stop at Angelo&#8217;s Bakery. We would pick up freshly baked bread, Italian deli meats and fresh cheese. I remember tugging at my mom&#8217;s skirt every time we passed the pastry counter, pointing out the Cannoli and <a title="Cannoncini, Italian Custard Horns" href="http://gracessweetlife.com/2011/01/cannoncini-alla-crema-pasticcera/">Italian Custard Horns</a> (Cannoncini). They are two of my most favourite Italian pastries. My Mom would always give in and home we went with a box full of the delicious Italian Desserts.</p>
+<p><a href="http://gracessweetlife.com/2010/06/cannoli-siciliani-the-ultimate-italian-pastry/sicilian-cannoli/" rel="attachment wp-att-993"><img class="alignnone size-full wp-image-993" src="http://gracessweetlife.com/wp-content/uploads/2010/06/ccc3-e1381295500919.jpg" alt="A close up photo of Sicilian Cannoli on a silver serving tray lined with small white doilies." width="480" height="320" /></a></p>
+<p>Fast forward all these years later and today I may go to the bakery (same one) alone (kids don&#8217;t enjoy the weekly ritual) but I almost always come home with a box of the same pastries. My kids love them too!</p>
+<p><a href="http://gracessweetlife.com/2010/06/cannoli-siciliani-the-ultimate-italian-pastry/traditional-sicilian-cannoli/" rel="attachment wp-att-994"><img class="alignnone size-full wp-image-994" src="http://gracessweetlife.com/wp-content/uploads/2010/06/ccc7-e1381295577115.jpg" alt="A close up photo of Traditional Sicilian Cannoli on a white dessert dish lined with white doilies." width="480" height="320" /></a></p>
+<p>A few years back I decided to try and make them at home and I am so happy I did. They are even better, especially if you fill the shells just prior to eating or serving them because the shells are crispier.</p>
+<p><a href="http://gracessweetlife.com/2010/06/cannoli-siciliani-the-ultimate-italian-pastry/italian-cannoli-pastries/" rel="attachment wp-att-995"><img class="alignnone size-full wp-image-995" src="http://gracessweetlife.com/wp-content/uploads/2010/06/ccc13-e1381295632672.jpg" alt="A photo of Italian Cannoli Pastries on a white cake stand with a blue and white ribbon." width="480" height="319" /></a></p>
+<p>I spent yesterday afternoon making about eighty shells in preparation for V&#8217;s bridal shower. I froze them and will fill the shells just prior to heading out the door for the shower.</p>
+<p><a href="http://gracessweetlife.com/2010/06/cannoli-siciliani-the-ultimate-italian-pastry/cannoli-pastries/" rel="attachment wp-att-997"><img class="alignnone size-full wp-image-997" src="http://gracessweetlife.com/wp-content/uploads/2010/06/ccc19-e1381295749237.jpg" alt="A photo of Cannoli Pastries placed on top of a stack of white napkins set along side a white bag with a purple ribbon." width="480" height="386" /></a></p>
+<p>There are many recipes available for the shells but the dough for these shells are made with Marsala wine. The addition of Marsala makes a big difference in the taste of the shells and the use of the sweet wine is traditional. The filling is super easy to make but it&#8217;s imperative to drain the ricotta over night to achieve the silky smooth texture.</p>
+<p>As you can see from the photos I had to make a batch just for home, the kids waited all day for their special treat, and yes they are all gone.</p>
+<p><a href="http://gracessweetlife.com/2010/06/cannoli-siciliani-the-ultimate-italian-pastry/cannoli-siciliani-pastries/" rel="attachment wp-att-1006"><img class="alignnone size-full wp-image-1006" src="http://gracessweetlife.com/wp-content/uploads/2010/06/ccc2-e1381295877162.jpg" alt="A close up photo of Cannoli Siciliani Pastries on a silver tray lined with white doilies." width="480" height="269" /></a></p>
+<p>You must try this recipe, these pastries are absolutely delicious!</p>
+<p>If you enjoy Italian Desserts as much as I do you must try one of my most favourite Italian treats, <a title="gracessweetlife.com, Italian Desserts, Italian Pastries" href="http://gracessweetlife.com/2010/04/cicerchiata-struffoli-italian-honey-balls/" target="_self">Cicerchiata</a> (Italian Honey Balls), deep-fried pastry balls dripping with honey. And of course I can&#8217;t go without mentioning another traditional Italian Dessert, Panna Cotta; it&#8217;s a family favourite and it can be paired with many different flavours. A pairing perfect for the summer is <a title="gracessweetlife.com, Italian Desserts, Panna Cotta and Raspberry Jelly Parfait" href="http://gracessweetlife.com/2010/05/panna-cotta-raspberry-jelly-parfait/" target="_self">Panna Cotta and Raspberry Jelly Parfait</a> and for the Holiday Season, <a title="gracessweetlife.com, Vanilla-Coconut Panna Cotta with Pomegranate Jelly recipe, Italian Desserts" href="http://gracessweetlife.com/2010/12/vanilla-coconut-panna-cotta-with-pomegranate-jelly/" target="_self">Vanilla-Coconut Panna Cotta with Pomegranate Jelly</a>.</p>
+<p><a href="http://gracessweetlife.com/2010/06/cannoli-siciliani-the-ultimate-italian-pastry/cannoli-shells/" rel="attachment wp-att-1000"><img class="alignnone size-full wp-image-1000" src="http://gracessweetlife.com/wp-content/uploads/2010/06/ccc51-e1381295997151.jpg" alt="A photo of two empty Cannoli shells." width="480" height="386" /></a></p>
+<p><a href="http://www.mycitycuisine.org/wiki/Cannoli"><img style="border: 0px; padding: 0px; width: 232px; height: 97px;" src="http://www.mycitycuisine.org/exlink/index.php?pg=23445&amp;tp=6" alt="Italian Cannoli" /></a></p>
+<div class="print-this-button-shell">
+<button type="button" class="print-this-button" onClick="parent.location='http://gracessweetlife.com/2010/06/cannoli-siciliani-the-ultimate-italian-pastry/?printthis=1&printsect=1'">    Print Recipe    </button>
+</div>
+<!-- Print This Section 1 Start -->
+<div class="print-this-content"></p>
+<h1><strong>Cannoli Siciliani</strong></h1>
+<p>Prepare one of Italy&#8217;s most famous pastries at home, cannoli siciliani. Crispy cannoli shells filled with creamy ricotta filling.</p>
+<p>Total Time: 3 hours 3 minutes</p>
+<p>Cook Time: 45 minutes</p>
+<p>Prep Time: 2 hours 18 minutes</p>
+<p>Makes about 28 pastries</p>
+<p>*Special Equipment: Pasta Machine, Pastry Tubes, Large Pastry Bag and large plain round tip (i.e. Wilton 1A)</p>
+<h2>Cannoli Shells {Cialde per Cannoli}</h2>
+<ul>
+<li>167 g (1 1/3 cups) plain (all-purpose) flour</li>
+<li>1/4 teaspoon salt</li>
+<li>14 g (1 tablespoon) granulated sugar</li>
+<li>5 g (2 teaspoons) unsweetened cocoa powder (not Dutch processed)</li>
+<li>28 g (2 tablespoons) vegetable shortening</li>
+<li>6 to 7 tablespoons sweet Marsala wine</li>
+<li>Vegetable Oil for frying</li>
+<li>1 to 2 large egg whites, lightly beaten</li>
+</ul>
+<div>
+<ol>
+<li>Sift flour, salt, sugar and cocoa into the bowl of a stand mixer. Whisk to combine well.</li>
+<li>Attach paddle attachment to stand mixer. Add the vegetable shortening and mix on low speed for a few minutes, flour mixture should resemble fine crumbs.</li>
+<li>With mixer on low speed add the 6 tablespoons of the Marsala wine one tablespoon at a time, mixing to make dough that is as stiff as pasta dough. If the dough doesn&#8217;t gather into a mass, gradually add some or all the entire remaining tablespoon of the Marsala wine.</li>
+<li>Place the dough onto an unfloured work area and knead for 3 minutes. Shape dough into a ball, flatten and wrap in plastic wrap. Let rest at room temperature for 1 hour.</li>
+<li>Cut a 3 by 11½-cm (4½-inch) oval from cardboard to make a template for cutting the dough.</li>
+<li>Divide the dough into 4 equal pieces. Roll one piece of dough at a time, keep remaining dough wrapped in plastic wrap at all times to prevent it from drying out.</li>
+<li>Set pasta machine to the widest opening and pass the dough through the rollers. If the dough is sticky, flour it lightly. Fold the dough in thirds and pass it through the widest setting again, starting with an open end. Repeat this process several times to knead the dough. Then decrease the setting by one, passing the dough (do not fold) once through until you complete your last pass at the second last setting. If dough is sticky, flour slightly, brush off any excess flour with a pastry brush, place on work area and cover with a tea towel. Repeat the process with the remaining pieces of the dough.</li>
+<li>Place the cardboard template at one end of the dough strip, using the tip of a sharp knife or straight pastry wheel, cut out an oval. Set ovals aside on your work surface (do not overlap cut dough), cover and repeat until all of the remaining dough is cut in the ovals.</li>
+<li>Pour 8-cm (3-inch) of oil into a large heavy pot. Clamp a deep-fat thermometer to the side of the pot. Over medium heat, heat oil to between 177° C to 182° C (350° F to 360° F).</li>
+<li>Meanwhile, shape the shells. Roll an oval of dough around an ungreased tube and moisten the edge of the dough with the lightly beaten egg white. Set on a baking sheet lined with plastic wrap.  Repeat to shape as many shells as you have tubes. Line another baking sheet with 4 layers of paper towels.</li>
+<li>To cook the shells, carefully slip 3 to 4 dough wrapped tubes into the hot oil (they will sink). After a couple of seconds, using tongs, move the tubes around grasping the uncovered tube ends. You&#8217;ll notice that the dough has developed dozens of small bubbles all over the surface. After 45 seconds or so in the oil, using tongs, grasp one end of the cannoli tube and using a second tong gently push the shell from the tube into the oil. Set the tube aside on a heatproof surface to cool.  (Be very careful, the tube is extremely hot.) Repeat with remaining shells and continue to cook shells until light golden brown (be careful not to cook too long as they can over-darken quite quickly). Gently, using tongs, lift each shell out of the oil, draining oil back into the pot and transfer to paper towel-lined baking sheet. Repeat until all shells are cooked. (Wash the tubes in soapy water and dry in between uses.)</li>
+<li>Let cool completely before filling.</li>
+</ol>
+</div>
+<h2>Ricotta Cannoli Filling {Crema di Ricotta}</h2>
+<ul>
+<li>660 g (3 cups) fresh ricotta, drained overnight</li>
+<li>167 g to 188 g (1 1/3 to 1½ cups) confectioners&#8217; sugar, sifted</li>
+<li>1½ teaspoons pure vanilla extract</li>
+<li>50 g (1/3 cup) finely diced candied citron or candied orange peel, or a combination (optional)</li>
+<li>65 g (1/3 cup) miniature semi-sweet chocolate chips</li>
+</ul>
+<ol>
+<li>Place drained ricotta in the bowl of a stand mixer fitted with the paddle attachment. Beat the ricotta on medium speed for 2 to 3 minutes or until smooth.</li>
+<li>Add 167 g (1 1/3 cups) of the confectioners&#8217; sugar and the vanilla. Beat until fluffy and very smooth.  Taste the mixture, if you would like it sweeter add the remaining confectioners&#8217; sugar and beat until smooth.</li>
+<li>Stir in citron or candied peel or combination of both (if using) and chocolate chips.</li>
+<li>Place filling in an airtight container and refrigerate. (The filling can be made one day in advance but I recommend adding the chocolate chips and candied peel just before filling.)</li>
+</ol>
+<div>
+<h2>Assembling Cannoli</h2>
+<ul>
+<li>Finely chopped unsalted pistachios (optional)</li>
+<li>Sifted confectioners&#8217; sugar for dusting</li>
+</ul>
+<ol>
+<li>Fit the large pastry bag with the 1¼-cm (½-inch) tip. Spoon the filling into the pastry bag.</li>
+<li>Insert pastry tip into one side of the shell and gently squeeze until the shell is half full. Repeat on the other side of the shell.</li>
+<li>If you are using the pistachios, smooth the exposed filling on both ends of the pastry with the back of a small spoon, and sprinkle both ends with pistachios.</li>
+<li>Dust the pastries with confectioners&#8217; sugar and serve immediately.</li>
+<li>Buon Appetito!</li>
+</ol>
+</div>
+<p><div class="clear"></div></div>
+<!-- Print This Section 1 End -->
+
+<p><a href="http://gracessweetlife.com/2010/06/cannoli-siciliani-the-ultimate-italian-pastry/cannoli-siciliani/" rel="attachment wp-att-1002"><img class="alignnone size-full wp-image-1002" src="http://gracessweetlife.com/wp-content/uploads/2010/06/ccc121-e1381296319773.jpg" alt="A close up photo of two Cannoli Siciliani on a white dessert dish with a cup of tea." width="480" height="320" /></a><br />
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "Recipe",
+  "image" : "http://gracessweetlife.com/wp-content/uploads/2010/06/ccc3-e1381295500919.jpg",
+  "name": "Cannoli Siciliani – The Ultimate Italian Pastry",
+  "description" : "Prepare one of Italy's most famous pastries at home, cannoli siciliani. Crispy cannoli shells filled with creamy ricotta filling.",
+  "totalTime" : "PT3H3M",
+  "cookTime" : "PT45M",
+  "prepTime" : "PT2H18M", 
+  "recipeCategory" : "Pastries",
+  "recipeYield" : "28 pastries",
+  "ingredients" : [
+     "167 g (1 1/3 cups) plain (all-purpose) flour",
+     "1/4 teaspoon salt",
+     "14 g (1 tablespoon) granulated sugar",
+     "5 g (2 teaspoons) unsweetened cocoa powder (not Dutch processed)",
+     "28 g (2 tablespoons) vegetable shortening",
+     "6 to 7 tablespoons sweet Marsala wine",
+     "Vegetable Oil for frying",
+     "1 to 2 large egg whites, lightly beaten",
+     "660 g (3 cups) fresh ricotta, drained overnight",
+     "167 g to 188 g (1 1/3 to 1½ cups) confectioners’ sugar, sifted",
+     "1½ teaspoons pure vanilla extract",
+     "50 g (1/3 cup) finely diced candied citron or candied orange peel, or a combination (optional)",
+     "65 g (1/3 cup) miniature semi-sweet chocolate chips"
+] ,
+  "datePublished" : "2010-06-07",
+  "author" : {
+  "@type": "Person",
+  "name" : "Grace Massa Langlois",
+  "sameAs" : [ 
+    "https://plus.google.com/+GraceMassaLanglois",
+    "https://www.freebase.com/m/012nfryb",
+    "https://www.freebase.com/m/012njm1b",
+    "https://www.facebook.com/GraceMassaLanglois",
+    "https://www.linkedin.com/in/gracemassalanglois",
+    "http://www.stumbleupon.com/stumbler/GracesSweetLife/comments",
+    "https://www.flickr.com/people/gracessweetlife/"
+]
+  }
+  }
+</script></p>
+<div class='shareaholic-canvas' data-app-id='95801' data-app='share_buttons' data-title='Cannoli Siciliani – The Ultimate Italian Pastry' data-link='http://gracessweetlife.com/2010/06/cannoli-siciliani-the-ultimate-italian-pastry/' data-summary=''></div><div class='shareaholic-canvas' data-app-id='337247' data-app='recommendations' data-title='Cannoli Siciliani – The Ultimate Italian Pastry' data-link='http://gracessweetlife.com/2010/06/cannoli-siciliani-the-ultimate-italian-pastry/' data-summary=''></div>
+
+
+
+
+
+<p>Tags: <a href="http://gracessweetlife.com/tag/after-school-treat/" rel="tag">after school treat</a>, <a href="http://gracessweetlife.com/tag/afternoon-tea/" rel="tag">afternoon tea</a>, <a href="http://gracessweetlife.com/tag/cannoli-filling/" rel="tag">cannoli filling</a>, <a href="http://gracessweetlife.com/tag/cannoli-pastries/" rel="tag">cannoli pastries</a>, <a href="http://gracessweetlife.com/tag/cannoli-ricotta-filling/" rel="tag">cannoli ricotta filling</a>, <a href="http://gracessweetlife.com/tag/cookie/" rel="tag">cookie</a>, <a href="http://gracessweetlife.com/tag/cupcake-fillings/" rel="tag">cupcake fillings</a>, <a href="http://gracessweetlife.com/tag/dessert/" rel="tag">dessert</a>, <a href="http://gracessweetlife.com/tag/desserts/" rel="tag">desserts</a>, <a href="http://gracessweetlife.com/tag/desserts-for-entertaining/" rel="tag">desserts for entertaining</a>, <a href="http://gracessweetlife.com/tag/entertaining/" rel="tag">entertaining</a>, <a href="http://gracessweetlife.com/tag/food/" rel="tag">food</a>, <a href="http://gracessweetlife.com/tag/food-photography/" rel="tag">food photography</a>, <a href="http://gracessweetlife.com/tag/food-photos/" rel="tag">food photos</a>, <a href="http://gracessweetlife.com/tag/fried-pastries/" rel="tag">fried pastries</a>, <a href="http://gracessweetlife.com/tag/individual-dessert/" rel="tag">individual dessert</a>, <a href="http://gracessweetlife.com/tag/individual-desserts/" rel="tag">individual desserts</a>, <a href="http://gracessweetlife.com/tag/italian-cookie/" rel="tag">Italian cookie</a>, <a href="http://gracessweetlife.com/tag/italian-dessert/" rel="tag">Italian dessert</a>, <a href="http://gracessweetlife.com/tag/italian-desserts/" rel="tag">Italian desserts</a>, <a href="http://gracessweetlife.com/tag/italian-pastries/" rel="tag">Italian Pastries</a>, <a href="http://gracessweetlife.com/tag/italian-pastry/" rel="tag">Italian pastry</a>, <a href="http://gracessweetlife.com/tag/italian-recipes/" rel="tag">Italian recipes</a>, <a href="http://gracessweetlife.com/tag/italian-sweet/" rel="tag">Italian sweet</a>, <a href="http://gracessweetlife.com/tag/italian-sweets/" rel="tag">Italian sweets</a>, <a href="http://gracessweetlife.com/tag/pastry-cream/" rel="tag">pastry cream</a>, <a href="http://gracessweetlife.com/tag/pastry-fillings/" rel="tag">pastry fillings</a>, <a href="http://gracessweetlife.com/tag/ricotta-cheese/" rel="tag">ricotta cheese</a>, <a href="http://gracessweetlife.com/tag/ricotta-filling/" rel="tag">ricotta filling</a><br/>Posted in <a href="http://gracessweetlife.com/category/recipes/baking-pastry/" rel="category tag">Baking &amp; Pastry</a>, <a href="http://gracessweetlife.com/category/recipes/baking-pastry/baking-mise-en-place/" rel="category tag">Baking Mise en Place</a>, <a href="http://gracessweetlife.com/category/recipes/basics/" rel="category tag">Basics</a>, <a href="http://gracessweetlife.com/category/recipes/baking-pastry/custards-creams-mousses/" rel="category tag">Custards, Creams &amp; Mousses</a>, <a href="http://gracessweetlife.com/category/recipes/dolci-fritti/" rel="category tag">Dolci Fritti</a>, <a href="http://gracessweetlife.com/category/recipes/baking-pastry/fillings-frostings-dessert-sauces/" rel="category tag">Fillings, Frostings &amp; Dessert Sauces</a>, <a href="http://gracessweetlife.com/category/recipes/fried-desserts/" rel="category tag">Fried Desserts</a>, <a href="http://gracessweetlife.com/category/recipes/mini-desserts/" rel="category tag">Mini Desserts</a>, <a href="http://gracessweetlife.com/category/recipes/pasticcini/" rel="category tag">Pasticcini</a>, <a href="http://gracessweetlife.com/category/recipes/pastries/" rel="category tag">Pastries</a>, <a href="http://gracessweetlife.com/category/recipes/baking-pastry/pastry-doughs-batter/" rel="category tag">Pastry Doughs &amp; Batter</a>, <a href="http://gracessweetlife.com/category/recipes/piccola-pasticceria/" rel="category tag">Piccola Pasticceria</a>, <a href="http://gracessweetlife.com/category/recipes/" rel="category tag">Recipes</a>, <a href="http://gracessweetlife.com/category/recipes/ricette-di-base/" rel="category tag">Ricette di Base</a> <br/><br/> <a href="http://gracessweetlife.com/2010/06/cannoli-siciliani-the-ultimate-italian-pastry/#comments">Comments (90)</a></p>
+
+
+
+
+<!-- You can start editing here. -->
+
+	<h3 id="comments">90 Responses to &#8220;Cannoli Siciliani – The Ultimate Italian Pastry&#8221;</h3>
+
+	<ol class="commentlist">
+
+	
+		<li class="alt" id="comment-759">
+<img alt='' src='http://0.gravatar.com/avatar/c2ad347c8135e98781d8e7562208aebb?s=30&#038;d=identicon&#038;r=g' srcset='http://0.gravatar.com/avatar/c2ad347c8135e98781d8e7562208aebb?s=60&amp;d=identicon&amp;r=g 2x' class='avatar avatar-30 photo' height='30' width='30' />			<cite>Martha</cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-759" title="">June 7th, 2010 at 2:26 pm</a> </small>
+
+			<p>Cannolis are one of my favorite pastries as well! I might skip out on the shells my first time around, but I definitely want to attempt making my own filling and enjoy a homemade cannoli &#8211; thanks for sharing this!</p>
+
+		</li>
+
+	
+	
+		<li id="comment-760">
+<img alt='' src='http://1.gravatar.com/avatar/a2194110aac13b2f1e7462d3aff9e237?s=30&#038;d=identicon&#038;r=g' srcset='http://1.gravatar.com/avatar/a2194110aac13b2f1e7462d3aff9e237?s=60&amp;d=identicon&amp;r=g 2x' class='avatar avatar-30 photo' height='30' width='30' />			<cite>Grace</cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-760" title="">June 7th, 2010 at 3:53 pm</a> </small>
+
+			<p>Martha you are most welcome.  I was intimidated by the shells my first time, but believe it or not it&#8217;s just like making fresh pasta, pretty easy, just a little time consuming (a labour of love).</p>
+
+		</li>
+
+	
+	
+		<li class="alt" id="comment-774">
+<img alt='' src='http://2.gravatar.com/avatar/2c76fd3fa734338b3f6c8d4d27b6feb1?s=30&#038;d=identicon&#038;r=g' srcset='http://2.gravatar.com/avatar/2c76fd3fa734338b3f6c8d4d27b6feb1?s=60&amp;d=identicon&amp;r=g 2x' class='avatar avatar-30 photo' height='30' width='30' />			<cite>Deborah</cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-774" title="">June 8th, 2010 at 2:34 pm</a> </small>
+
+			<p>I just stumbled across your blog and can tell that I&#8217;ll need to spend some time going through previous post.  Lovely photography and delicious recipes!  I love cannolis and have had a request from a friend to make some again.  Might be time to try a new reipe!</p>
+
+		</li>
+
+	
+	
+		<li id="comment-788">
+<img alt='' src='http://1.gravatar.com/avatar/a2194110aac13b2f1e7462d3aff9e237?s=30&#038;d=identicon&#038;r=g' srcset='http://1.gravatar.com/avatar/a2194110aac13b2f1e7462d3aff9e237?s=60&amp;d=identicon&amp;r=g 2x' class='avatar avatar-30 photo' height='30' width='30' />			<cite>Grace</cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-788" title="">June 8th, 2010 at 9:07 pm</a> </small>
+
+			<p>Thank you so much Deborah!  This is a great recipe, please let me know if you have a chance to try it, would love your feedback.</p>
+
+		</li>
+
+	
+	
+		<li class="alt" id="comment-780">
+<img alt='' src='http://2.gravatar.com/avatar/2a9f6f81fc89d514a96e8ae2e94ba0e8?s=30&#038;d=identicon&#038;r=g' srcset='http://2.gravatar.com/avatar/2a9f6f81fc89d514a96e8ae2e94ba0e8?s=60&amp;d=identicon&amp;r=g 2x' class='avatar avatar-30 photo' height='30' width='30' />			<cite><a href='http://www.namelymarly.com' rel='external nofollow' class='url'>Marly</a></cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-780" title="">June 8th, 2010 at 5:23 pm</a> </small>
+
+			<p>Wow &#8211; these look spectacular! Are they low calorie too? Just kidding. I have a feeling I know the answer to that one!</p>
+
+		</li>
+
+	
+	
+		<li id="comment-787">
+<img alt='' src='http://1.gravatar.com/avatar/a2194110aac13b2f1e7462d3aff9e237?s=30&#038;d=identicon&#038;r=g' srcset='http://1.gravatar.com/avatar/a2194110aac13b2f1e7462d3aff9e237?s=60&amp;d=identicon&amp;r=g 2x' class='avatar avatar-30 photo' height='30' width='30' />			<cite>Grace</cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-787" title="">June 8th, 2010 at 9:05 pm</a> </small>
+
+			<p>Too funny Marly, don&#8217;t think I ever made anything low cal.</p>
+
+		</li>
+
+	
+	
+		<li class="alt" id="comment-809">
+<img alt='' src='http://0.gravatar.com/avatar/392bf3891fe0d282a9589299e0c9a317?s=30&#038;d=identicon&#038;r=g' srcset='http://0.gravatar.com/avatar/392bf3891fe0d282a9589299e0c9a317?s=60&amp;d=identicon&amp;r=g 2x' class='avatar avatar-30 photo' height='30' width='30' />			<cite><a href='http://theurbanbaker.blogspot.com' rel='external nofollow' class='url'>susan</a></cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-809" title="">June 9th, 2010 at 11:09 pm</a> </small>
+
+			<p>these look spectacular!  i LOVED cannolis in college.  I just may have to bring back those glorious days and make some of these!</p>
+
+		</li>
+
+	
+	
+		<li id="comment-821">
+<img alt='' src='http://1.gravatar.com/avatar/a2194110aac13b2f1e7462d3aff9e237?s=30&#038;d=identicon&#038;r=g' srcset='http://1.gravatar.com/avatar/a2194110aac13b2f1e7462d3aff9e237?s=60&amp;d=identicon&amp;r=g 2x' class='avatar avatar-30 photo' height='30' width='30' />			<cite>Grace</cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-821" title="">June 10th, 2010 at 3:38 am</a> </small>
+
+			<p>Thank you Susan!</p>
+
+		</li>
+
+	
+	
+		<li class="alt" id="comment-1118">
+<img alt='' src='http://1.gravatar.com/avatar/7694ddac85a53bdb67f28cb926e88daf?s=30&#038;d=identicon&#038;r=g' srcset='http://1.gravatar.com/avatar/7694ddac85a53bdb67f28cb926e88daf?s=60&amp;d=identicon&amp;r=g 2x' class='avatar avatar-30 photo' height='30' width='30' />			<cite><a href='http://www.bakingpictures.blogspot.com' rel='external nofollow' class='url'>Gale Reeves</a></cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-1118" title="">June 21st, 2010 at 11:55 pm</a> </small>
+
+			<p>My brother loves these, but we live in TN, and you just don&#8217;t find these on every corner.  I think I read that your daughter is the photographer&#8230;.these are GREAT images!</p>
+
+		</li>
+
+	
+	
+		<li id="comment-1398">
+			<cite><a href='http://gracessweetlife.com/2010/06/gordon-ramsays-baked-lemon-tart/' rel='external nofollow' class='url'>Gordon Ramsay's Baked Lemon Tart &amp; Chocolate Shortcrust Pastry | La Mia Vita Dolce</a></cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-1398" title="">July 4th, 2010 at 6:07 pm</a> </small>
+
+			<p>[&#8230;] Our dessert table looked magnificent, it was brimming with so many varieties of cookies and baked goods and Italian pastries.  Some of our extended family and close friends also joined us in the baking.  I can&#8217;t wait to try some of the recipes.  My freezer is full of special treats.  I promise to share some of the recipes over the next little while.  The Orange Cupcakes and Deep-Chocolate Brownie Cupcakes were enjoyed by all.  The contrast in colours was striking on the tiered serving rack. Everyone mentioned how much they enjoyed the Cannoli Siciliani. [&#8230;]</p>
+
+		</li>
+
+	
+	
+		<li class="alt" id="comment-4860">
+<img alt='' src='http://2.gravatar.com/avatar/54f79ea5398a307aa229096d7fd7cacb?s=30&#038;d=identicon&#038;r=g' srcset='http://2.gravatar.com/avatar/54f79ea5398a307aa229096d7fd7cacb?s=60&amp;d=identicon&amp;r=g 2x' class='avatar avatar-30 photo' height='30' width='30' />			<cite><a href='http://brielegrandfromage.blogspot.com/' rel='external nofollow' class='url'>Brie</a></cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-4860" title="">October 18th, 2010 at 9:42 pm</a> </small>
+
+			<p>wow, that is some sexy and scrumptious looking cannoli.</p>
+
+		</li>
+
+	
+	
+		<li id="comment-4888">
+<img alt='' src='http://0.gravatar.com/avatar/9f3b5ef4294bafb575b419690b0d278d?s=30&#038;d=identicon&#038;r=g' srcset='http://0.gravatar.com/avatar/9f3b5ef4294bafb575b419690b0d278d?s=60&amp;d=identicon&amp;r=g 2x' class='avatar avatar-30 photo' height='30' width='30' />			<cite><a href='http://cajunchefryan.rymocs.com/blog2/' rel='external nofollow' class='url'>Cajun Chef Ryan</a></cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-4888" title="">October 19th, 2010 at 7:01 am</a> </small>
+
+			<p>Love me some cannoli! These look wonderful!</p>
+
+		</li>
+
+	
+	
+		<li class="alt" id="comment-4889">
+<img alt='' src='http://1.gravatar.com/avatar/a2194110aac13b2f1e7462d3aff9e237?s=30&#038;d=identicon&#038;r=g' srcset='http://1.gravatar.com/avatar/a2194110aac13b2f1e7462d3aff9e237?s=60&amp;d=identicon&amp;r=g 2x' class='avatar avatar-30 photo' height='30' width='30' />			<cite>Grace</cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-4889" title="">October 19th, 2010 at 7:18 am</a> </small>
+
+			<p>Thanks Chef, these are my absolute favourite</p>
+
+		</li>
+
+	
+	
+		<li id="comment-4895">
+<img alt='' src='http://0.gravatar.com/avatar/fe15e276dfc4a3b6ba251430b119888a?s=30&#038;d=identicon&#038;r=g' srcset='http://0.gravatar.com/avatar/fe15e276dfc4a3b6ba251430b119888a?s=60&amp;d=identicon&amp;r=g 2x' class='avatar avatar-30 photo' height='30' width='30' />			<cite><a href='http://www.ccrecipe.com' rel='external nofollow' class='url'>Camala - CC Recipe</a></cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-4895" title="">October 19th, 2010 at 8:33 am</a> </small>
+
+			<p>Oh, Wow&#8230;these look fabulous, I love Cannoli&#8217;s and whenever I go anywhere that has them in a case I just stare at them:) Just like I am staring at these, lovely pictures!</p>
+
+		</li>
+
+	
+	
+		<li class="alt" id="comment-4900">
+<img alt='' src='http://1.gravatar.com/avatar/7f644152abc7f87cccc42773f1795b42?s=30&#038;d=identicon&#038;r=g' srcset='http://1.gravatar.com/avatar/7f644152abc7f87cccc42773f1795b42?s=60&amp;d=identicon&amp;r=g 2x' class='avatar avatar-30 photo' height='30' width='30' />			<cite><a href='http://motherrimmy.com' rel='external nofollow' class='url'>Kristi Rimkus</a></cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-4900" title="">October 19th, 2010 at 10:00 am</a> </small>
+
+			<p>What a beautiful dish! I love your pictures. Terrific presentation.</p>
+
+		</li>
+
+	
+	
+		<li id="comment-4909">
+<img alt='' src='http://0.gravatar.com/avatar/c98d9d360fb3a0a24e7c909d42d62809?s=30&#038;d=identicon&#038;r=g' srcset='http://0.gravatar.com/avatar/c98d9d360fb3a0a24e7c909d42d62809?s=60&amp;d=identicon&amp;r=g 2x' class='avatar avatar-30 photo' height='30' width='30' />			<cite><a href='http://jeanetteshealthyliving.blogspot.com' rel='external nofollow' class='url'>Jeanette</a></cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-4909" title="">October 19th, 2010 at 12:52 pm</a> </small>
+
+			<p>What beautiful cannoli&#8217;s!  I&#8217;ve never seen a recipe for the dough. I always thought people just bought them and filled them.</p>
+
+		</li>
+
+	
+	
+		<li class="alt" id="comment-4943">
+<img alt='' src='http://1.gravatar.com/avatar/a2194110aac13b2f1e7462d3aff9e237?s=30&#038;d=identicon&#038;r=g' srcset='http://1.gravatar.com/avatar/a2194110aac13b2f1e7462d3aff9e237?s=60&amp;d=identicon&amp;r=g 2x' class='avatar avatar-30 photo' height='30' width='30' />			<cite>Grace</cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-4943" title="">October 19th, 2010 at 11:10 pm</a> </small>
+
+			<p>Thanks for stopping by for a visit Jeanette.  I thought the shells would be more difficult to make than they were and they taste so much better than the ones you buy.  The recipe makes quite a few.  I usually freeze a good portion of the batch and then fill when I need them.  The cannoli are best eaten fresh.  I usually fill right before I am ready to serve so the shell stays crisp.</p>
+
+		</li>
+
+	
+	
+		<li id="comment-4951">
+<img alt='' src='http://1.gravatar.com/avatar/af3300ad8ef5dbd308c7c8ec05aea698?s=30&#038;d=identicon&#038;r=g' srcset='http://1.gravatar.com/avatar/af3300ad8ef5dbd308c7c8ec05aea698?s=60&amp;d=identicon&amp;r=g 2x' class='avatar avatar-30 photo' height='30' width='30' />			<cite><a href='http://theenchantedcook.blogspot.com' rel='external nofollow' class='url'>The Enchanted Cook</a></cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-4951" title="">October 20th, 2010 at 1:11 am</a> </small>
+
+			<p>Your cannoli&#8217;s look heavenly! Yum! Congrats on the Top 9!</p>
+<p>Best,<br />
+Veronica</p>
+
+		</li>
+
+	
+	
+		<li class="alt" id="comment-4975">
+<img alt='' src='http://1.gravatar.com/avatar/a2194110aac13b2f1e7462d3aff9e237?s=30&#038;d=identicon&#038;r=g' srcset='http://1.gravatar.com/avatar/a2194110aac13b2f1e7462d3aff9e237?s=60&amp;d=identicon&amp;r=g 2x' class='avatar avatar-30 photo' height='30' width='30' />			<cite>Grace</cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-4975" title="">October 20th, 2010 at 7:24 am</a> </small>
+
+			<p>Thanks Veronica!</p>
+
+		</li>
+
+	
+	
+		<li id="comment-4981">
+<img alt='' src='http://0.gravatar.com/avatar/0dcdce4f2849f91ab78f2757a230d189?s=30&#038;d=identicon&#038;r=g' srcset='http://0.gravatar.com/avatar/0dcdce4f2849f91ab78f2757a230d189?s=60&amp;d=identicon&amp;r=g 2x' class='avatar avatar-30 photo' height='30' width='30' />			<cite><a href='http://passthesushi.com' rel='external nofollow' class='url'>Kita</a></cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-4981" title="">October 20th, 2010 at 7:53 am</a> </small>
+
+			<p>These look divine. I love a good cannoli. :)</p>
+
+		</li>
+
+	
+	
+		<li class="alt" id="comment-4987">
+<img alt='' src='http://2.gravatar.com/avatar/8e0d680f7d075dd2f6d0a2f18266b5d6?s=30&#038;d=identicon&#038;r=g' srcset='http://2.gravatar.com/avatar/8e0d680f7d075dd2f6d0a2f18266b5d6?s=60&amp;d=identicon&amp;r=g 2x' class='avatar avatar-30 photo' height='30' width='30' />			<cite><a href='http://flourdusted.blogspot.ca/' rel='external nofollow' class='url'>briarrose</a></cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-4987" title="">October 20th, 2010 at 8:46 am</a> </small>
+
+			<p>Beautiful.  I would be hard pressed to stop with one.  ;)</p>
+
+		</li>
+
+	
+	
+		<li id="comment-4993">
+<img alt='' src='http://1.gravatar.com/avatar/a2194110aac13b2f1e7462d3aff9e237?s=30&#038;d=identicon&#038;r=g' srcset='http://1.gravatar.com/avatar/a2194110aac13b2f1e7462d3aff9e237?s=60&amp;d=identicon&amp;r=g 2x' class='avatar avatar-30 photo' height='30' width='30' />			<cite>Grace</cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-4993" title="">October 20th, 2010 at 9:56 am</a> </small>
+
+			<p>I can never eat just one, I try, but it never happens.</p>
+
+		</li>
+
+	
+	
+		<li class="alt" id="comment-4999">
+<img alt='' src='http://0.gravatar.com/avatar/07bf47b7e0143777b42aa3b2ee456aa8?s=30&#038;d=identicon&#038;r=g' srcset='http://0.gravatar.com/avatar/07bf47b7e0143777b42aa3b2ee456aa8?s=60&amp;d=identicon&amp;r=g 2x' class='avatar avatar-30 photo' height='30' width='30' />			<cite><a href='http://cookisgood.blogspot.com/' rel='external nofollow' class='url'>Cook is Good</a></cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-4999" title="">October 20th, 2010 at 11:19 am</a> </small>
+
+			<p>Delicious. I literally LOVE cannoli sicialiani.Congrats on the TOP 1  ;-D<br />
+Giorgia</p>
+
+		</li>
+
+	
+	
+		<li id="comment-5007">
+<img alt='' src='http://1.gravatar.com/avatar/a2194110aac13b2f1e7462d3aff9e237?s=30&#038;d=identicon&#038;r=g' srcset='http://1.gravatar.com/avatar/a2194110aac13b2f1e7462d3aff9e237?s=60&amp;d=identicon&amp;r=g 2x' class='avatar avatar-30 photo' height='30' width='30' />			<cite>Grace</cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-5007" title="">October 20th, 2010 at 12:29 pm</a> </small>
+
+			<p>Thanks Giorgia!</p>
+
+		</li>
+
+	
+	
+		<li class="alt" id="comment-5008">
+<img alt='' src='http://2.gravatar.com/avatar/ba41aecc255ae167e831aca79e362093?s=30&#038;d=identicon&#038;r=g' srcset='http://2.gravatar.com/avatar/ba41aecc255ae167e831aca79e362093?s=60&amp;d=identicon&amp;r=g 2x' class='avatar avatar-30 photo' height='30' width='30' />			<cite>Joan in Seattle</cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-5008" title="">October 20th, 2010 at 12:53 pm</a> </small>
+
+			<p>These are beautiful and look delicious. I love cannoli; they make me think of North Beach in San Francisco on my honeymoon. The cannoli may be just the thing to get me to buy a pasta attachment for my Kitchenaid. Thank you for posting!</p>
+
+		</li>
+
+	
+	
+		<li id="comment-5009">
+<img alt='' src='http://1.gravatar.com/avatar/a2194110aac13b2f1e7462d3aff9e237?s=30&#038;d=identicon&#038;r=g' srcset='http://1.gravatar.com/avatar/a2194110aac13b2f1e7462d3aff9e237?s=60&amp;d=identicon&amp;r=g 2x' class='avatar avatar-30 photo' height='30' width='30' />			<cite>Grace</cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-5009" title="">October 20th, 2010 at 12:55 pm</a> </small>
+
+			<p>Thanks Joan, I bought one of those attachments, so handy!  I was just in North Beach last week, love San Fran.</p>
+
+		</li>
+
+	
+	
+		<li class="alt" id="comment-5014">
+<img alt='' src='http://1.gravatar.com/avatar/d35bb55a16a01ef9e3dfa652016a603e?s=30&#038;d=identicon&#038;r=g' srcset='http://1.gravatar.com/avatar/d35bb55a16a01ef9e3dfa652016a603e?s=60&amp;d=identicon&amp;r=g 2x' class='avatar avatar-30 photo' height='30' width='30' />			<cite><a href='http://meltingbutter.com/' rel='external nofollow' class='url'>Jenny</a></cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-5014" title="">October 20th, 2010 at 1:33 pm</a> </small>
+
+			<p>wow, these look so amazing. Great post :)</p>
+
+		</li>
+
+	
+	
+		<li id="comment-5024">
+<img alt='' src='http://2.gravatar.com/avatar/bc1a64f2964f6efc3db542dabceac3de?s=30&#038;d=identicon&#038;r=g' srcset='http://2.gravatar.com/avatar/bc1a64f2964f6efc3db542dabceac3de?s=60&amp;d=identicon&amp;r=g 2x' class='avatar avatar-30 photo' height='30' width='30' />			<cite><a href='http://bigfatbaker.com/blog' rel='external nofollow' class='url'>BigFatBaker</a></cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-5024" title="">October 20th, 2010 at 4:18 pm</a> </small>
+
+			<p>Wow those look fabulous. After reading this post I realized I wasn&#8217;t eating enough cannoli! It&#8217;s hard for me to find them :( I was wondering if is it possible to roll out the dough with a rolling pin? I (unfortunately) don&#8217;t have a stand mixer.</p>
+
+		</li>
+
+	
+	
+		<li class="alt" id="comment-5025">
+<img alt='' src='http://1.gravatar.com/avatar/a2194110aac13b2f1e7462d3aff9e237?s=30&#038;d=identicon&#038;r=g' srcset='http://1.gravatar.com/avatar/a2194110aac13b2f1e7462d3aff9e237?s=60&amp;d=identicon&amp;r=g 2x' class='avatar avatar-30 photo' height='30' width='30' />			<cite>Grace</cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-5025" title="">October 20th, 2010 at 4:32 pm</a> </small>
+
+			<p>Would you happen to have a crank pasta machine, that would work.  I think if you could roll the dough out thin enough by hand it would definitely work.</p>
+
+		</li>
+
+	
+	
+		<li id="comment-5052">
+<img alt='' src='http://0.gravatar.com/avatar/fab4041e72861b2db036b266adc3c37b?s=30&#038;d=identicon&#038;r=g' srcset='http://0.gravatar.com/avatar/fab4041e72861b2db036b266adc3c37b?s=60&amp;d=identicon&amp;r=g 2x' class='avatar avatar-30 photo' height='30' width='30' />			<cite><a href='http://potatochopsandbonelesschix.blogspot.ca/' rel='external nofollow' class='url'>Potato Chops and Boneless Chicken</a></cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-5052" title="">October 20th, 2010 at 11:17 pm</a> </small>
+
+			<p>My God, how lush. Cannolis are one of my absolute favourites. You&#8217;ve given me a real craving. YUM!!</p>
+
+		</li>
+
+	
+	
+		<li class="alt" id="comment-5053">
+<img alt='' src='http://1.gravatar.com/avatar/d7a4799203cb0ba43f718d73a37ea312?s=30&#038;d=identicon&#038;r=g' srcset='http://1.gravatar.com/avatar/d7a4799203cb0ba43f718d73a37ea312?s=60&amp;d=identicon&amp;r=g 2x' class='avatar avatar-30 photo' height='30' width='30' />			<cite><a href='http://www.sweetpeaskitchen.com' rel='external nofollow' class='url'>Christina @ Sweet Pea's Kitchen</a></cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-5053" title="">October 20th, 2010 at 11:20 pm</a> </small>
+
+			<p>I want one of these babies now! Fabulous! :)</p>
+
+		</li>
+
+	
+	
+		<li id="comment-5057">
+<img alt='' src='http://2.gravatar.com/avatar/b70bd4c4c538808234d22698dba3aabd?s=30&#038;d=identicon&#038;r=g' srcset='http://2.gravatar.com/avatar/b70bd4c4c538808234d22698dba3aabd?s=60&amp;d=identicon&amp;r=g 2x' class='avatar avatar-30 photo' height='30' width='30' />			<cite><a href='http://www.tasty-trials.com/' rel='external nofollow' class='url'>Karen</a></cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-5057" title="">October 21st, 2010 at 12:52 am</a> </small>
+
+			<p>Wow!  These look amazing!  I think I could eat way too many of these cannoli.  Congrats on the Top 9!</p>
+
+		</li>
+
+	
+	
+		<li class="alt" id="comment-5084">
+<img alt='' src='http://1.gravatar.com/avatar/a2194110aac13b2f1e7462d3aff9e237?s=30&#038;d=identicon&#038;r=g' srcset='http://1.gravatar.com/avatar/a2194110aac13b2f1e7462d3aff9e237?s=60&amp;d=identicon&amp;r=g 2x' class='avatar avatar-30 photo' height='30' width='30' />			<cite>Grace</cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-5084" title="">October 21st, 2010 at 7:14 am</a> </small>
+
+			<p>Thanks Karen</p>
+
+		</li>
+
+	
+	
+		<li id="comment-5108">
+<img alt='' src='http://2.gravatar.com/avatar/8565b5ee3ca8683a2f2091fa5295344c?s=30&#038;d=identicon&#038;r=g' srcset='http://2.gravatar.com/avatar/8565b5ee3ca8683a2f2091fa5295344c?s=60&amp;d=identicon&amp;r=g 2x' class='avatar avatar-30 photo' height='30' width='30' />			<cite><a href='http://www.squirrelbakes.com/' rel='external nofollow' class='url'>Debbie</a></cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-5108" title="">October 21st, 2010 at 1:16 pm</a> </small>
+
+			<p>OH these look fabulous! I made some the other day, but have yet to make my own shells. I love the story about getting to stop by the bakery every sunday, reminds me of the donut shop that I got to go to after church :-) THanks</p>
+
+		</li>
+
+	
+	
+		<li class="alt" id="comment-7585">
+			<cite><a href='http://www.sweetkiera.com/?p=1155' rel='external nofollow' class='url'>Ay, Oh. Homemade Cannolis. Fahgetaboutit!</a></cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-7585" title="">November 19th, 2010 at 7:50 am</a> </small>
+
+			<p>[&#8230;] followed a recipe for making the dough that I found on a blog called &#8220;La Mia Vita Dolce&#8221;.  The only thing I was initially worried about was not having the pasta dough machine &#8212; but [&#8230;]</p>
+
+		</li>
+
+	
+	
+		<li id="comment-8283">
+			<cite><a href='http://gracessweetlife.com/2010/04/cicerchiata-struffoli-italian-honey-balls/' rel='external nofollow' class='url'>Cicerchiata-Struffoli, Italian Honey Balls Recipe-Abruzzo Dessert | La Mia Vita Dolce</a></cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-8283" title="">December 2nd, 2010 at 8:14 am</a> </small>
+
+			<p>[&#8230;] very popular Italian treat is Cannoli Siciliani, the Ultimate Italian Pastry and my absolute [&#8230;]</p>
+
+		</li>
+
+	
+	
+		<li class="alt" id="comment-11554">
+			<cite><a href='http://gracessweetlife.com/2011/01/pate-croissant-and-pain-au-chocolat-croissant-dough-chocolate-croissant/' rel='external nofollow' class='url'>Pâte Croissant and Pain au Chocolate-Croissant Dough-Chocolate Croissant | La Mia Vita Dolce</a></cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-11554" title="">January 29th, 2011 at 11:00 am</a> </small>
+
+			<p>[&#8230;] already know I&#8217;m a huge lover of Italian Pastries. What you may not know (because I&#8217;ve hardly talked about it) there&#8217;s another pastry in [&#8230;]</p>
+
+		</li>
+
+	
+	
+		<li id="comment-22233">
+			<cite><a href='http://gracessweetlife.com/2011/06/charlotte-con-mousse-di-cioccolato-bianco-e-lamponi-white-chocolate-and-raspberry-charlotte/' rel='external nofollow' class='url'>Mousse Cakes-Chocolate Mousse Cakes-Charlotte Cakes-Italian Desserts | La Mia Vita Dolce</a></cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-22233" title="">June 10th, 2011 at 1:13 pm</a> </small>
+
+			<p>[&#8230;]  I had a little mishap in the kitchen on Monday; I burned my hand terribly when I was deep frying Cannoli Shells for Natalie&#8217;s (my niece) Bridal Shower. The form slipped from the tongs and fell into the hot [&#8230;]</p>
+
+		</li>
+
+	
+	
+		<li class="alt" id="comment-22523">
+<img alt='' src='http://2.gravatar.com/avatar/27dfb9dfb7ff694229775a9bcd24b484?s=30&#038;d=identicon&#038;r=g' srcset='http://2.gravatar.com/avatar/27dfb9dfb7ff694229775a9bcd24b484?s=60&amp;d=identicon&amp;r=g 2x' class='avatar avatar-30 photo' height='30' width='30' />			<cite>Matteo</cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-22523" title="">June 16th, 2011 at 12:07 pm</a> </small>
+
+			<p>They are absolutely amazing! And I&#8217;m from Sicily.</p>
+
+		</li>
+
+	
+	
+		<li id="comment-22530">
+<img alt='' src='http://1.gravatar.com/avatar/a2194110aac13b2f1e7462d3aff9e237?s=30&#038;d=identicon&#038;r=g' srcset='http://1.gravatar.com/avatar/a2194110aac13b2f1e7462d3aff9e237?s=60&amp;d=identicon&amp;r=g 2x' class='avatar avatar-30 photo' height='30' width='30' />			<cite>Grace</cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-22530" title="">June 17th, 2011 at 2:58 pm</a> </small>
+
+			<p>Thank you Matteo coming from you that means so much!</p>
+
+		</li>
+
+	
+	
+		<li class="alt" id="comment-22559">
+			<cite><a href='http://gracessweetlife.com/2011/05/milk-chocolate-panna-cotta-with-port-cherry-sauce/' rel='external nofollow' class='url'>Panna Cotta-Panna Cotta Recipes-Italian Dessert-Chocolate Desserts | La Mia Vita Dolce</a></cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-22559" title="">June 22nd, 2011 at 11:17 pm</a> </small>
+
+			<p>[&#8230;] little time for reading.The week leading up to the shower will be hectic.  I plan on making Cannoli Siciliani, Cannoncini alla Crema Pasticcera, mini Torta Caprese, mini Hazelnut, Raspberry Jam and White [&#8230;]</p>
+
+		</li>
+
+	
+	
+		<li id="comment-22631">
+			<cite><a href='http://gracessweetlife.com/2011/01/cannoncini-alla-crema-pasticcera/' rel='external nofollow' class='url'>Cannoncini, Italian Pastries, Pastry Cream Recipe, Italian Desserts | La Mia Vita Dolce</a></cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-22631" title="">June 30th, 2011 at 8:22 am</a> </small>
+
+			<p>[&#8230;] 14th January 2011 by Grace  TweetMy favourite Sweet Indulgence is Italian Pastries especially Cannoli and Cannoncini alla Crema Pasticcera.  If you&#8217;re not familiar with Italian Pastries, [&#8230;]</p>
+
+		</li>
+
+	
+	
+		<li class="alt" id="comment-22637">
+			<cite><a href='http://gracessweetlife.com/2011/06/cannoli-cupcakes-with-marsala-chocolate-whipped-cream-and-mini-cannoli/' rel='external nofollow' class='url'>Gourmet Cupcakes-Vanilla Cupcakes-Cannoli Recipe-Chocolate Whipped Cream | La Mia Vita Dolce</a></cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-22637" title="">June 30th, 2011 at 6:56 pm</a> </small>
+
+			<p>[&#8230;] Whipped Cream.  And the pièce de résistance &#8211; I topped with a crispy mini Cannoli Siciliani.I knew I had a winning cupcake on my hands when all I could hear coming from the visiting group of [&#8230;]</p>
+
+		</li>
+
+	
+	
+		<li id="comment-22994">
+			<cite><a href='http://gracessweetlife.com/2011/07/cannoncini-di-sfoglia-con-crema-pasticcera-al-cioccolato/' rel='external nofollow' class='url'>Italian Pastry-Italian Pastries-Italian Pastry Desserts-Pastry Cream-Sfoglia | La Mia Vita Dolce</a></cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-22994" title="">August 2nd, 2011 at 9:16 am</a> </small>
+
+			<p>[&#8230;] are endless.  For a summer treat &#8211; fill with Gelato (doesn&#8217;t that sound good?).Craving Cannoli? &#8211; But don&#8217;t have the time to make the Cannoli Shells &#8211; fill horns with Marsala [&#8230;]</p>
+
+		</li>
+
+	
+	
+		<li class="alt" id="comment-23089">
+<img alt='' src='http://1.gravatar.com/avatar/417c1a96dcdda2e4f1d0acb21c1568ad?s=30&#038;d=identicon&#038;r=g' srcset='http://1.gravatar.com/avatar/417c1a96dcdda2e4f1d0acb21c1568ad?s=60&amp;d=identicon&amp;r=g 2x' class='avatar avatar-30 photo' height='30' width='30' />			<cite>Sam</cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-23089" title="">August 14th, 2011 at 12:52 pm</a> </small>
+
+			<p>amazing i will be making it next week.  can&#8217;t wait.</p>
+<p>sam</p>
+
+		</li>
+
+	
+	
+		<li id="comment-23220">
+			<cite><a href='http://gracessweetlife.com/2011/07/pizzelle-ferratelle-italian-waffle-cookies/' rel='external nofollow' class='url'>Pizzelles-Cookies Italian-Italian Cookies-Mascarpone Cream | La Mia Vita Dolce</a></cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-23220" title="">September 8th, 2011 at 3:19 pm</a> </small>
+
+			<p>[&#8230;] can believe this, the queen of chocolate (me) has yet to try one.They can be rolled and filled with Cannoli Ricotta Cream or as I&#8217;ve prepared them today with a Mascarpone Cream and a trio of fresh berries (frutti di [&#8230;]</p>
+
+		</li>
+
+	
+	
+		<li class="alt" id="comment-23223">
+<img alt='' src='http://0.gravatar.com/avatar/974667600a99430e4badca388e876810?s=30&#038;d=identicon&#038;r=g' srcset='http://0.gravatar.com/avatar/974667600a99430e4badca388e876810?s=60&amp;d=identicon&amp;r=g 2x' class='avatar avatar-30 photo' height='30' width='30' />			<cite>Natalie</cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-23223" title="">September 9th, 2011 at 9:04 am</a> </small>
+
+			<p>Is there a way to print your recipes without all the other information?</p>
+
+		</li>
+
+	
+	
+		<li id="comment-23225">
+<img alt='' src='http://1.gravatar.com/avatar/a2194110aac13b2f1e7462d3aff9e237?s=30&#038;d=identicon&#038;r=g' srcset='http://1.gravatar.com/avatar/a2194110aac13b2f1e7462d3aff9e237?s=60&amp;d=identicon&amp;r=g 2x' class='avatar avatar-30 photo' height='30' width='30' />			<cite>Grace</cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-23225" title="">September 9th, 2011 at 10:30 am</a> </small>
+
+			<p>Natalie I&#8217;ve recently added the print feature but I have yet to go back to each recipe to add the format, is there a particular one you are interested in?  I will go in and add the feature to the respective recipes for you.</p>
+
+		</li>
+
+	
+	
+		<li class="alt" id="comment-23802">
+<img alt='' src='http://1.gravatar.com/avatar/a530fbcf5f2be24a2e34fa40e96ea51f?s=30&#038;d=identicon&#038;r=g' srcset='http://1.gravatar.com/avatar/a530fbcf5f2be24a2e34fa40e96ea51f?s=60&amp;d=identicon&amp;r=g 2x' class='avatar avatar-30 photo' height='30' width='30' />			<cite>Dedee Royale</cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-23802" title="">November 21st, 2011 at 7:19 pm</a> </small>
+
+			<p>Perfect crunch on the shells!  Best recipe I found yet.  I used Crisco butter flavored shortening and 7 Tbsp. Marsala wine.  Don&#8217;t be intimidated &#8211; this is no harder than making a pie crust.</p>
+
+		</li>
+
+	
+	
+		<li id="comment-23804">
+<img alt='' src='http://0.gravatar.com/avatar/0e9354a2cc3547fd6a88237ecb75fd6f?s=30&#038;d=identicon&#038;r=g' srcset='http://0.gravatar.com/avatar/0e9354a2cc3547fd6a88237ecb75fd6f?s=60&amp;d=identicon&amp;r=g 2x' class='avatar avatar-30 photo' height='30' width='30' />			<cite>Grace</cite> Says:
+						<br />
+
+			<small class="commentmetadata"><a href="#comment-23804" title="">November 21st, 2011 at 8:30 pm</a> </small>
+
+			<p>So happy you enjoyed Dedee.  A lot of people are intimidated but they really are quite easy to make.</p>
+
+		</li>
+
+	
+	
+	</ol>
+
+ 
+
+
+<h3 id="respond">Leave a Reply</h3>
+
+
+<form action="http://gracessweetlife.com/wp-comments-post.php" method="post" id="commentform">
+
+
+<p><input type="text" name="author" id="author" value="" size="22" tabindex="1" />
+<label for="author"><small>Name (required)</small></label></p>
+
+<p><input type="text" name="email" id="email" value="" size="22" tabindex="2" />
+<label for="email"><small>Mail (will not be published) (required)</small></label></p>
+
+<p><input type="text" name="url" id="url" value="" size="22" tabindex="3" />
+<label for="url"><small>Website</small></label></p>
+
+
+<!--<p><small><strong>XHTML:</strong> You can use these tags: <code>&lt;a href=&quot;&quot; title=&quot;&quot;&gt; &lt;abbr title=&quot;&quot;&gt; &lt;acronym title=&quot;&quot;&gt; &lt;b&gt; &lt;blockquote cite=&quot;&quot;&gt; &lt;cite&gt; &lt;code&gt; &lt;del datetime=&quot;&quot;&gt; &lt;em&gt; &lt;i&gt; &lt;q cite=&quot;&quot;&gt; &lt;s&gt; &lt;strike&gt; &lt;strong&gt; </code></small></p>-->
+
+<p><textarea name="comment" id="comment" cols="50%" rows="10" tabindex="4"></textarea></p>
+
+<p><input name="submit" type="submit" id="submit" tabindex="5" value="Submit Comment" />
+<input type="hidden" name="comment_post_ID" value="985" />
+</p>
+
+<div id="captchaImgDiv">
+
+<div class="captchaSizeDivLarge"><img id="si_image_com" class="si-captcha" src="http://gracessweetlife.com/wp-content/plugins/si-captcha-for-wordpress/captcha/securimage_show.php?si_form_id=com&amp;prefix=EdVwHHVIrhdCSJhM" width="175" height="60" alt="CAPTCHA Image" title="CAPTCHA Image" />
+    <input id="si_code_com" name="si_code_com" type="hidden"  value="EdVwHHVIrhdCSJhM" />
+    <div id="si_refresh_com">
+<a href="#" rel="nofollow" title="Refresh Image" onclick="si_captcha_refresh('si_image_com','com','/wp-content/plugins/si-captcha-for-wordpress/captcha','http://gracessweetlife.com/wp-content/plugins/si-captcha-for-wordpress/captcha/securimage_show.php?si_form_id=com&amp;prefix='); return false;">
+      <img class="captchaImgRefresh" src="http://gracessweetlife.com/wp-content/plugins/si-captcha-for-wordpress/captcha/images/refresh.png" width="22" height="20" alt="Refresh Image" onclick="this.blur();" /></a>
+  </div>
+  </div>
+<div id="captchaInputDiv"><input id="captcha_code" name="captcha_code" type="text" value="" tabindex="4"  />
+ <label id="captcha_code_label" for="captcha_code">Please enter the code above</label><span class="required">*</span>
+ </div>
+</div>
+<p style="display: none;"><input type="hidden" id="akismet_comment_nonce" name="akismet_comment_nonce" value="2081ccf6a7" /></p><p style="display: none;"><input type="hidden" id="ak_js" name="ak_js" value="162"/></p>
+</form>
+
+
+
+</div> <!-- Post content div -->
+
+</div> <!-- Latest article div -->
+
+
+
+
+
+
+
+
+</div> <!-- Content div -->
+
+
+
+<div id="sidebar">
+
+
+
+<div class="sidebar-item"><div class="title">Privacy Policy</div>			<div class="textwidget"><a href="http://gracessweetlife.com/privacy-policy/">Grace's Sweet Life Privacy Policy</a></div>
+		</div><div class="sidebar-item">			<div class="textwidget"><a href="https://monitor9.sucuri.net/verify.php?r=009c8d2993af7e6b89e46852645543cdcb6ce8d324"><img src="http://gracessweetlife.com/wp-content/uploads/2013/07/Sucuri-Verified-Badge-Medium.png" alt= "Sucuri Badge"  height="75" width="200" /></a></div>
+		</div><div class="sidebar-item"><div class="title">Looking for Something?</div>			<div class="execphpwidget"><script type="text/javascript">
+  (function() {
+    var cx = '013929226601758978999:osmwoskx2mo';
+    var gcse = document.createElement('script');
+    gcse.type = 'text/javascript';
+    gcse.async = true;
+    gcse.src = (document.location.protocol == 'https:' ? 'https:' : 'http:') +
+        '//www.google.com/cse/cse.js?cx=' + cx;
+    var s = document.getElementsByTagName('script')[0];
+    s.parentNode.insertBefore(gcse, s);
+  })();
+</script>
+<gcse:searchbox-only></gcse:searchbox-only></div>
+		</div><div class="sidebar-item"><div class="title">Categories</div>		<ul>
+	<li class="cat-item cat-item-11"><a href="http://gracessweetlife.com/category/recipes/baking-pastry/" title="Grace&#039;s Sweet Life Baking and Pastry Recipes category.">Baking &amp; Pastry</a>
+</li>
+	<li class="cat-item cat-item-5"><a href="http://gracessweetlife.com/category/recipes/baking-pastry/baking-mise-en-place/" title=" The Baking Mise en Place category for the Grace&#039;s Sweet Life website.">Baking Mise en Place</a>
+</li>
+	<li class="cat-item cat-item-545"><a href="http://gracessweetlife.com/category/recipes/basics/" title="Find recipes for basic dessert elements in this category. Cookbook Author, Grace Massa Langlois shares tips for dessert making techniques.">Basics</a>
+</li>
+	<li class="cat-item cat-item-573"><a href="http://gracessweetlife.com/category/recipes/bevande-e-cocktail/" title="A list of recipes for Drinks and Cocktails {Bevande e Cocktail}.">Bevande e Cocktail</a>
+</li>
+	<li class="cat-item cat-item-572"><a href="http://gracessweetlife.com/category/recipes/beverages-and-cocktails/" title="A compilation of Drink and Cocktail recipes for the Grace&#039;s Sweet Life website shared by Cookbook Author, Grace Massa Langlois.">Beverages and Cocktails</a>
+</li>
+	<li class="cat-item cat-item-551"><a href="http://gracessweetlife.com/category/recipes/biscotti/" title="Biscotti {Cookies} category for the Grace&#039;s Sweet Life website.">Biscotti</a>
+</li>
+	<li class="cat-item cat-item-546"><a href="http://gracessweetlife.com/category/recipes/cakes-cheesecakes/" title="Recipes for Cakes and Cheesecakes from Cookbook Author, Grace Massa Langlois categorized under one umbrella.">Cakes &amp; Cheesecakes</a>
+</li>
+	<li class="cat-item cat-item-420"><a href="http://gracessweetlife.com/category/recipes/chocolates-confections/" title=" Grace&#039;s Sweet Life Recipe Category for Chocolate and Confections. ">Chocolates &amp; Confections</a>
+</li>
+	<li class="cat-item cat-item-547"><a href="http://gracessweetlife.com/category/recipes/cioccolatini-e-bonbon/" title="A category listing all recipes shared by Author, Grace Massa Langlois for Cioccolatini e Bonbon {Chocolates and Bonbons}.">Cioccolatini e Bonbon</a>
+</li>
+	<li class="cat-item cat-item-570"><a href="http://gracessweetlife.com/category/recipes/cookies/" title="A selection of Cookie Recipes by Cookbook Author, Grace Massa Langlois. Find everything from Italian Cookies to kid friendly cookie recipes.">Cookies</a>
+</li>
+	<li class="cat-item cat-item-563"><a href="http://gracessweetlife.com/category/recipes/crostate/" title="Recipes for Crostate {Pies and Tarts} from Author, Grace Massa Langlois arranged in one category to make recipes easy to find.">Crostate</a>
+</li>
+	<li class="cat-item cat-item-6"><a href="http://gracessweetlife.com/category/recipes/baking-pastry/custards-creams-mousses/" title="A compilation of Grace&#039;s Sweet Life recipes for custards, creams and mousses.">Custards, Creams &amp; Mousses</a>
+</li>
+	<li class="cat-item cat-item-565"><a href="http://gracessweetlife.com/category/recipes/dolci-al-cucchiaio/" title="Grace&#039;s Sweet Life&#039;s recipe category for Dolci al Cucchiaio {Spoon Desserts} recipes.">Dolci al Cucchiaio</a>
+</li>
+	<li class="cat-item cat-item-557"><a href="http://gracessweetlife.com/category/recipes/dolci-alla-frutta/" title="The Grace&#039;s Sweet Life website&#039;s category, Dolci alla Frutta, a compilation of all recipes for Fruit Desserts.">Dolci alla Frutta</a>
+</li>
+	<li class="cat-item cat-item-553"><a href="http://gracessweetlife.com/category/recipes/dolci-fritti/" title="The Grace&#039;s Sweet Life website&#039;s category for Dolci Fritti, recipes for Fried Desserts.">Dolci Fritti</a>
+</li>
+	<li class="cat-item cat-item-35"><a href="http://gracessweetlife.com/category/recipes/eggs/" title=" A listing of all recipes shared on the Grace&#039;s Sweet Life website that incorporate Eggs.">Eggs</a>
+</li>
+	<li class="cat-item cat-item-12"><a href="http://gracessweetlife.com/category/recipes/baking-pastry/fillings-frostings-dessert-sauces/" title=" A listing of Grace&#039;s Sweet Life recipes for dessert fillings, frostings and dessert sauces.">Fillings, Frostings &amp; Dessert Sauces</a>
+</li>
+	<li class="cat-item cat-item-552"><a href="http://gracessweetlife.com/category/recipes/fried-desserts/" title="Find recipes for Fried Desserts like Italian Honey Balls or Doughnuts from Cookbook Author, Grace Massa Langlois.">Fried Desserts</a>
+</li>
+	<li class="cat-item cat-item-574"><a href="http://gracessweetlife.com/category/recipes/frozen-desserts/" title="A listing of recipes for Frozen Desserts from Cookbook Author, Grace Massa Langlois.">Frozen Desserts</a>
+</li>
+	<li class="cat-item cat-item-575"><a href="http://gracessweetlife.com/category/recipes/fruit-desserts/" title="Find recipes for Fruit Desserts like crumble or pies from Author, Grace Massa Langlois.">Fruit Desserts</a>
+</li>
+	<li class="cat-item cat-item-555"><a href="http://gracessweetlife.com/category/recipes/gelati-sorbetti-e-semifreddi/" title="A listing of all recipes for Gelati, Sorbetti e Semifreddi.">Gelati, Sorbetti e Semifreddi</a>
+</li>
+	<li class="cat-item cat-item-577"><a href="http://gracessweetlife.com/category/recipes/mini-desserts/" title="Mini Desserts category for the Grace&#039;s Sweet Life website. Find recipes for mini cupcakes, mini cakes, mini tarts and other dessert recipes in this section.">Mini Desserts</a>
+</li>
+	<li class="cat-item cat-item-42"><a href="http://gracessweetlife.com/category/miscellaneous/" title="Miscellaneous Category is a catch all for all posts that do not include a recipe from Cookbook Author, Grace Massa Langlois.">Miscellaneous</a>
+</li>
+	<li class="cat-item cat-item-792"><a href="http://gracessweetlife.com/category/recipes/baking-pastry/muffins-quick-breads/" title="Grace&#039;s Sweet Life recipes for Muffins and Quick Breads.">Muffins &amp; Quick Breads</a>
+</li>
+	<li class="cat-item cat-item-561"><a href="http://gracessweetlife.com/category/recipes/pasticcini/" title="A listing of all Pasticcini {Pastries} recipes for the Grace&#039;s Sweet Life website.  ">Pasticcini</a>
+</li>
+	<li class="cat-item cat-item-576"><a href="http://gracessweetlife.com/category/recipes/pastries/" title="Find recipes for Pastries like Cannoli, Cannoncini and other pastry recipes compiled in one category making them easy to find.">Pastries</a>
+</li>
+	<li class="cat-item cat-item-4"><a href="http://gracessweetlife.com/category/recipes/baking-pastry/pastry-doughs-batter/" title=" A list of Pastry Doughs and Batter recipes for the Grace&#039;s Sweet Life website.">Pastry Doughs &amp; Batter</a>
+</li>
+	<li class="cat-item cat-item-559"><a href="http://gracessweetlife.com/category/recipes/piccola-pasticceria/" title="Find Grace&#039;s Sweet Life recipes for Piccola Pasticceria {Mini Desserts} in this category.">Piccola Pasticceria</a>
+</li>
+	<li class="cat-item cat-item-562"><a href="http://gracessweetlife.com/category/recipes/pies-tarts/" title="A compilation of Grace&#039;s Sweet Life recipes for Pies and Tarts.">Pies &amp; Tarts</a>
+</li>
+	<li class="cat-item cat-item-3"><a href="http://gracessweetlife.com/category/recipes/" title="Recipes shared by Author, Grace Massa Langlois sorted by post date with the most recent post appearing first on the list.">Recipes</a>
+</li>
+	<li class="cat-item cat-item-548"><a href="http://gracessweetlife.com/category/recipes/ricette-di-base/" title="Grace&#039;s Sweet Life website&#039;s category for Ricette di Base, a compilation of base dessert elements.">Ricette di Base</a>
+</li>
+	<li class="cat-item cat-item-564"><a href="http://gracessweetlife.com/category/recipes/spoon-desserts/" title="Spoons Dessert Category for the Grace&#039;s Sweet Life recipe. Category includes recipes for Spoon Desserts like custards, mousses, crumbles and other desserts.">Spoon Desserts</a>
+</li>
+	<li class="cat-item cat-item-549"><a href="http://gracessweetlife.com/category/recipes/torte/" title="Cookbook Author, Grace Massa Langlois shares a variety of Cake Recipes {Ricette Torte}.">Torte</a>
+</li>
+	<li class="cat-item cat-item-8"><a href="http://gracessweetlife.com/category/recipes/baking-pastry/yeast-breads-yeast-dough/" title=" Recipes for Yeast Breads and Yeast Dough compiled in one category.">Yeast Breads &amp; Yeast Dough</a>
+</li>
+		</ul>
+</div><div class="sidebar-item"><div class="title">Archives</div>		<label class="screen-reader-text" for="archives-dropdown-3">Archives</label>
+		<select id="archives-dropdown-3" name="archive-dropdown" onchange='document.location.href=this.options[this.selectedIndex].value;'>
+			
+			<option value="">Select Month</option>
+				<option value='http://gracessweetlife.com/2013/10/'> October 2013  (1)</option>
+	<option value='http://gracessweetlife.com/2013/09/'> September 2013  (2)</option>
+	<option value='http://gracessweetlife.com/2013/08/'> August 2013  (3)</option>
+	<option value='http://gracessweetlife.com/2013/07/'> July 2013  (3)</option>
+	<option value='http://gracessweetlife.com/2013/06/'> June 2013  (3)</option>
+	<option value='http://gracessweetlife.com/2013/05/'> May 2013  (3)</option>
+	<option value='http://gracessweetlife.com/2013/04/'> April 2013  (3)</option>
+	<option value='http://gracessweetlife.com/2013/03/'> March 2013  (3)</option>
+	<option value='http://gracessweetlife.com/2013/02/'> February 2013  (4)</option>
+	<option value='http://gracessweetlife.com/2013/01/'> January 2013  (3)</option>
+	<option value='http://gracessweetlife.com/2012/12/'> December 2012  (2)</option>
+	<option value='http://gracessweetlife.com/2012/11/'> November 2012  (5)</option>
+	<option value='http://gracessweetlife.com/2012/10/'> October 2012  (3)</option>
+	<option value='http://gracessweetlife.com/2012/09/'> September 2012  (4)</option>
+	<option value='http://gracessweetlife.com/2012/08/'> August 2012  (2)</option>
+	<option value='http://gracessweetlife.com/2012/07/'> July 2012  (4)</option>
+	<option value='http://gracessweetlife.com/2012/06/'> June 2012  (4)</option>
+	<option value='http://gracessweetlife.com/2012/05/'> May 2012  (3)</option>
+	<option value='http://gracessweetlife.com/2012/04/'> April 2012  (3)</option>
+	<option value='http://gracessweetlife.com/2012/03/'> March 2012  (1)</option>
+	<option value='http://gracessweetlife.com/2012/02/'> February 2012  (5)</option>
+	<option value='http://gracessweetlife.com/2012/01/'> January 2012  (4)</option>
+	<option value='http://gracessweetlife.com/2011/12/'> December 2011  (1)</option>
+	<option value='http://gracessweetlife.com/2011/11/'> November 2011  (1)</option>
+	<option value='http://gracessweetlife.com/2011/10/'> October 2011  (1)</option>
+	<option value='http://gracessweetlife.com/2011/08/'> August 2011  (1)</option>
+	<option value='http://gracessweetlife.com/2011/07/'> July 2011  (6)</option>
+	<option value='http://gracessweetlife.com/2011/06/'> June 2011  (6)</option>
+	<option value='http://gracessweetlife.com/2011/05/'> May 2011  (5)</option>
+	<option value='http://gracessweetlife.com/2011/04/'> April 2011  (8)</option>
+	<option value='http://gracessweetlife.com/2011/03/'> March 2011  (9)</option>
+	<option value='http://gracessweetlife.com/2011/02/'> February 2011  (7)</option>
+	<option value='http://gracessweetlife.com/2011/01/'> January 2011  (6)</option>
+	<option value='http://gracessweetlife.com/2010/12/'> December 2010  (10)</option>
+	<option value='http://gracessweetlife.com/2010/11/'> November 2010  (7)</option>
+	<option value='http://gracessweetlife.com/2010/10/'> October 2010  (6)</option>
+	<option value='http://gracessweetlife.com/2010/09/'> September 2010  (9)</option>
+	<option value='http://gracessweetlife.com/2010/08/'> August 2010  (11)</option>
+	<option value='http://gracessweetlife.com/2010/07/'> July 2010  (13)</option>
+	<option value='http://gracessweetlife.com/2010/06/'> June 2010  (13)</option>
+	<option value='http://gracessweetlife.com/2010/05/'> May 2010  (13)</option>
+	<option value='http://gracessweetlife.com/2010/04/'> April 2010  (10)</option>
+
+		</select>
+		</div><div class="sidebar-item"><div class="title">Stay Connected</div>			<div class="execphpwidget"><ul class="stay-connected">
+<li><a href="https://plus.google.com/+GracesSweetLife/posts" target="_blank"><img src="http://gracessweetlife.com/wp-content/uploads/2013/09/Google+-Social-Media-Icon.png" alt="Google+ Social Media Icon" height="24" width="24"/> Grace's Sweet Life on Google+</a>
+</li>
+<li><a href="https://plus.google.com/+GraceMassaLanglois/posts" target="_blank"><img src="http://gracessweetlife.com/wp-content/uploads/2013/09/Google+-Social-Media-Icon.png" alt="Google+ Social Media Icon" height="24" width="24"/> Google+</a>
+</li>
+<li><a href="https://www.facebook.com/GracesSweetLife" target="_blank"><img src="http://gracessweetlife.com/wp-content/uploads/2013/09/Facebook-Social-Media-Icon.png" alt="Facebook Social Media Icon" height="24" width="24"/> Facebook</a>
+</li>
+<li><a href="https://www.facebook.com/GraceMassaLanglois" target="_blank"><img src="http://gracessweetlife.com/wp-content/uploads/2013/09/Facebook-Social-Media-Icon.png" alt="Facebook Social Media Icon" height="24" width="24"/> Facebook</a>
+</li>
+<li><a href="https://www.flickr.com/people/gracessweetlife/" target="_blank"><img src="http://gracessweetlife.com/wp-content/uploads/2013/09/Flickr-Social-Media-Icon.png" alt="Flickr Social Media Icon" height="24" width="24"/> Flickr</a>
+</li>
+<li><a href="http://www.linkedin.com/in/gracemassalanglois" target="_blank"><img src="http://gracessweetlife.com/wp-content/uploads/2013/09/LinkedIn-Social-Media-Icon.png" alt="LinkedIn Social Media Icon" height="24" width="24"/> LinkedIn</a>
+</li>
+<li><a href="https://www.linkedin.com/company/grace's-sweet-life" target="_blank"><img src="http://gracessweetlife.com/wp-content/uploads/2013/09/LinkedIn-Social-Media-Icon.png" alt="LinkedIn Social Media Icon" height="24" width="24"/> LinkedIn</a>
+</li>
+<li><a href="http://www.pinterest.com/GracesSweetLife/" target="_blank"><img src="http://gracessweetlife.com/wp-content/uploads/2013/09/Pinterest-Social-Media-Icon.png" alt="Pinterest Social Media Icon" height="24" width="24"/> Pinterest</a>
+</li>
+<li><a href="https://twitter.com/gracessweetlife" target="_blank"><img src="http://gracessweetlife.com/wp-content/uploads/2013/09/Twitter-Social-Media-Icon.png" alt="Twitter Social Media Icon" height="24" width="24"/> Twitter</a>
+</li>
+<li><a href="http://feeds.feedburner.com/GracesSweetLife" target="_blank"><img src="http://gracessweetlife.com/wp-content/uploads/2013/09/RSS-Social-Media-Icon.png" alt="RSS Social Media Icon" height="24" width="24"/> Subscribe</a>
+</li>
+<li><a href="http://www.stumbleupon.com/stumbler/GracesSweetLife/comments" target="_blank"><img src="http://gracessweetlife.com/wp-content/uploads/2013/09/StumbleUpon-Social-Media-Icon.png" alt="StumbleUpon Social Media Icon" height="24" width="24"/> StumbleUpon</a>
+</li>
+</ul></div>
+		</div><div class="sidebar-item"><div class="title">Now Available &#8211; My New Book!</div>			<div class="textwidget"><div style="padding:  15px 0 15px 30px;">
+<a href="http://gracessweetlife.com/my-book/"><img title="Grace's Sweet Life Cookbook Cover" alt="The Grace's Sweet Life Cookbook cover image." height="210" width="170" src="http://gracessweetlife.com/wp-content/uploads/2013/11/Graces-Sweet-Life-Cookbook-Cover.jpg" /></a></div></div>
+		</div><div class="sidebar-item">			<div class="textwidget"><a href="http://www.marthastewart.com/1067936/marthas-circle"><img style="padding-left: 35px;" alt="martha's circle" height="144" width="160" src="http://gracessweetlife.com/wp-content/uploads/2013/09/Marthas-Circle-Badge.png" /></a></div>
+		</div><div class="sidebar-item">			<div class="textwidget"><script type="text/javascript" async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
+<!-- Google Adsense 2 -->
+<ins class="adsbygoogle"
+     style="display:inline-block;width:160px;height:600px"
+     data-ad-client="ca-pub-5237424322278708"
+     data-ad-slot="4679644268"></ins>
+<script type="text/javascript"> 
+(adsbygoogle = window.adsbygoogle || []).push({});
+</script></div>
+		</div><div class="sidebar-item"><div class="title">Recently Added</div>			<div class="execphpwidget"><div class='recentthumbs'><a href='http://gracessweetlife.com/2013/10/pear-and-walnut-bread/' title='Pear and Walnut Bread'><img width="150" height="150" src="http://gracessweetlife.com/wp-content/uploads/2013/10/Graces-Sweet-Life-Pear-and-Walnut-Bread-150x150.jpg" class="attachment-thumbnail size-thumbnail wp-post-image" alt="Pear and Walnut Bread displayed on white ruffled edge cake stand." /></a><a href='http://gracessweetlife.com/2013/09/blackberry-and-almond-shortbread-cake/' title='Blackberry and Almond Shortbread Cake'><img width="150" height="150" src="http://gracessweetlife.com/wp-content/uploads/2013/09/Blackberry-and-Almond-Shortbread-Cake-from-Graces-Sweet-Life-150x150.jpg" class="attachment-thumbnail size-thumbnail wp-post-image" alt="Photo of Blackberry and Almond Shortbread Cake displayed on white ruffled edge cake stand with pink and white striped cloth napkin and antique cake server." /></a><a href='http://gracessweetlife.com/2013/09/nutella-cookies-farfallette-con-la-nutella/' title='Nutella Cookies {Farfallette con la Nutella}'><img width="150" height="150" src="http://gracessweetlife.com/wp-content/uploads/2013/09/Graces-Sweet-Life-Nutella-Cookies-150x150.jpg" class="attachment-thumbnail size-thumbnail wp-post-image" alt="Nutella cookies stacked on white and pink striped cloth napkin lined with parchment paper." /></a><a href='http://gracessweetlife.com/2013/08/blackberry-hand-pies/' title='Blackberry Hand Pies'><img width="150" height="150" src="http://gracessweetlife.com/wp-content/uploads/2013/08/Graces-Sweet-Life-Blackberry-Hand-Pies-150x150.jpg" class="attachment-thumbnail size-thumbnail wp-post-image" alt="Blackberry Hand Pies displayed in a row on rectangle-shaped, white textured serving dish." /></a><a href='http://gracessweetlife.com/2013/08/mini-triple-chocolate-mousse-cakes-with-grand-marnier-cherry-sauce/' title='Mini Triple Chocolate Mousse Cakes with Grand Marnier Cherry Sauce'><img width="150" height="150" src="http://gracessweetlife.com/wp-content/uploads/2013/08/Graces-Sweet-Life-Mini-Triple-Chocolate-Mousse-Cakes-150x150.jpg" class="attachment-thumbnail size-thumbnail wp-post-image" alt="Mini Triple Chocolate Mousse Cakes decorated with Crispearls, Chocolate Disc, Caramel Dipped Cherries and Edible Flowers displayed on black slate board." /></a><a href='http://gracessweetlife.com/2013/08/caramel-mousse-and-dulce-de-leche-cheesecake-mini-cakes/' title='Caramel Mousse and Dulce de Leche Cheesecake Mini Cakes'><img width="150" height="150" src="http://gracessweetlife.com/wp-content/uploads/2013/08/Dulce-de-Leche-Cheesecakes-with-Caramel-Mousse-from-Graces-Sweet-Life-150x150.jpg" class="attachment-thumbnail size-thumbnail wp-post-image" alt="Cropped and close up photo of Dulce de Leche Cheesecake with layer of Caramel Mousse on white cake stand." /></a><div style='clear:both;'></div></div></div>
+		</div>
+
+
+</div> <!-- Sidebar div -->
+</div> <!-- Main content div -->
+
+
+<div id="footer">
+<div id="copyright">Copyright 2016 Grace Massa Langlois, <a href="http://gracessweetlife.com">Grace&#039;s Sweet Life</a>. (519) 878-3294</div>
+
+<div id="links"><a href="http://gracessweetlife.com/wp-admin/">Login</a></div>
+
+
+</div> <!-- Footer div -->
+
+</div> <!-- Wrapper div -->
+<!-- ngg_resource_manager_marker --><script type='text/javascript' src='http://gracessweetlife.com/wp-includes/js/wp-embed.min.js?ver=4.5.3'></script>
+<script type='text/javascript' src='http://gracessweetlife.com/wp-content/plugins/si-captcha-for-wordpress/captcha/si_captcha.js?ver=1.0'></script>
+<script type="text/javascript">
+//<![CDATA[
+var si_captcha_styles = "\
+<!-- begin SI CAPTCHA Anti-Spam - comment form style -->\
+<style type='text/css'>\
+div#captchaImgDiv { display:block; }\
+.captchaSizeDivSmall { width:175px; height:45px; padding-top:10px; }\
+.captchaSizeDivLarge { width:250px; height:60px; padding-top:10px; }\
+img#si_image_com,#si_image_reg,#si_image_log,#si_image_side_login { border-style:none; margin:0; padding-right:5px; float:left; }\
+.captchaImgRefresh { border-style:none; margin:0; vertical-align:bottom; }\
+div#captchaInputDiv { display:block; padding-top:15px; padding-bottom:5px; }\
+label#captcha_code_label { margin:0; }\
+input#captcha_code { width:65px; }\
+</style>\
+<!-- end SI CAPTCHA Anti-Spam - comment form style -->\
+";
+jQuery(document).ready(function($) {
+$('head').append(si_captcha_styles);
+});
+//]]>
+</script>
+<script type='text/javascript' src='http://gracessweetlife.com/wp-content/plugins/akismet/_inc/form.js?ver=3.1.11'></script>
+
+
+</body>
+
+</html> 
+<!-- Performance optimized by W3 Total Cache. Learn more: http://www.w3-edge.com/wordpress-plugins/
+
+Page Caching using disk: enhanced
+
+ Served from: gracessweetlife.com @ 2016-07-05 12:18:00 by W3 Total Cache -->

--- a/tests/data/sweetpaulmag_com_tomato_tart_with_basil_oil_and_curl.html
+++ b/tests/data/sweetpaulmag_com_tomato_tart_with_basil_oil_and_curl.html
@@ -1,0 +1,594 @@
+<!--
+ONETSP_URL: http://www.sweetpaulmag.com/food/tomato-tart-with-basil-oil-and-almond-amp-pepper-crust
+ONETSP_USER_AGENT: curl
+ONETSP_TIME: Tue, 05 Jul 2016 17:04:34 +0000
+-->
+
+<!DOCTYPE HTML>
+
+<!-- STRIPPED CONDITIONAL COMMENT -->
+    <!-- STRIPPED CONDITIONAL COMMENT -->
+        <!-- STRIPPED CONDITIONAL COMMENT -->
+            <!-- STRIPPED CONDITIONAL COMMENT -->
+                <!-- STRIPPED CONDITIONAL COMMENT -->
+                    
+                    <!-- BC_OBNW -->
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+<title>Tomato Tart with Basil Oil and Almond &amp; Pepper Crust  | Sweet Paul Magazine </title>
+<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+<link rel="author" href="https://plus.google.com/112095940219950915119/posts" />
+<link rel="publisher" href="https://plus.google.com/112095940219950915119" />
+<link rel="apple-touch-icon" sizes="57x57" href="/apple-touch-icon-57x57.png" />
+<link rel="apple-touch-icon" sizes="114x114" href="/apple-touch-icon-114x114.png" />
+<link rel="apple-touch-icon" sizes="72x72" href="/apple-touch-icon-72x72.png" />
+<link rel="apple-touch-icon" sizes="144x144" href="/apple-touch-icon-144x144.png" />
+<link rel="apple-touch-icon" sizes="60x60" href="/apple-touch-icon-60x60.png" />
+<link rel="apple-touch-icon" sizes="120x120" href="/apple-touch-icon-120x120.png" />
+<link rel="apple-touch-icon" sizes="76x76" href="/apple-touch-icon-76x76.png" />
+<link rel="apple-touch-icon" sizes="152x152" href="/apple-touch-icon-152x152.png" />
+<link rel="icon" type="image/png" href="/favicon-196x196.png" sizes="196x196" />
+<link rel="icon" type="image/png" href="/favicon-160x160.png" sizes="160x160" />
+<link rel="icon" type="image/png" href="/favicon-96x96.png" sizes="96x96" />
+<link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16" />
+<link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32" />
+<link rel="stylesheet" href="/assets/css/main.css" />
+<script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+<script type="text/javascript" src="//use.typekit.net/otz0bju.js"></script>
+<script type="text/javascript">
+                            try {
+                                Typekit.load();
+                            } catch (e) {}
+                        </script>
+<link rel="canonical" href="http://www.sweetpaulmag.com/food/tomato-tart-with-basil-oil-and-almond-amp-pepper-crust" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+<!-- Google Authorship and Publisher Markup -->
+<meta name="msapplication-TileColor" content="#da532c" />
+<meta name="msapplication-TileImage" content="/mstile-144x144.png" />
+<!-- STRIPPED CONDITIONAL COMMENT -->
+<!-- TYPEKIT BEGIN -->
+<meta name="description" content="Tomato Tart with Basil Oil and Almond Pepper Crust" />
+<meta property="og:title" content="Tomato Tart with Basil Oil and Almond &amp; Pepper Crust | Sweet Paul Magazine" />
+<meta property="og:type" content="article" />
+<meta property="og:url" content="http://www.sweetpaulmag.com/food/tomato-tart-with-basil-oil-and-almond-amp-pepper-crust" />
+<meta property="og:image" content="http://www.sweetpaulmag.com/1EatContent/images/2014/4625980_281271_tomtart1.jpg" />
+<meta property="og:image:secure_url" content="https://sweetpaul.worldsecuresystems.com/1EatContent/images/2014/4625980_281271_tomtart1.jpg" />
+<meta property="og:image:type" content="image/jpeg" />
+<meta property="og:image:width" content="512" />
+<meta property="og:image:height" content="640" />
+<meta property="og:site_name" content="Sweet Paul" />
+<meta property="fb:admins" content="514779030" />
+<meta property="og:description" content="Tomato Tart with Basil Oil and Almond Pepper Crust" />
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:site" content="sweetpaul" />
+<meta name="twitter:title" content="Tomato Tart with Basil Oil and Almond &amp; Pepper Crust" />
+<meta name="twitter:description" content="Tomato Tart with Basil Oil and Almond Pepper Crust" />
+<meta name="twitter:creator" content="sweetpaul" />
+<meta name="twitter:image:src" content="http://www.sweetpaulmag.com/1EatContent/images/2014/4625980_281271_tomtart1.jpg" />
+<meta name="twitter:domain" content="sweetpaulmag.com" />
+</head>
+<body>
+
+                    
+                    
+                        <!-- Ads -->
+                        <div class="container">
+                            <div class="row">
+                                <div class="col-sm-16 col-sm-offset-4"><div class="ad-blocks">
+  <!-- ADS -->
+  
+  <div id="deskads">
+  <a target="_Blank" href="/BannerProcess.aspx?ID=18185&amp;URL=http%3a%2f%2fwww.muirglen.com%2f"><img alt="MuirGlen" src="/advertisting/960x120ads/MuirGlenBig.png"   border="0" /></a>
+  </div>
+  <div id="mobileads">
+  <a target="_blank" href="/BannerProcess.aspx?ID=16815&amp;URL=http%3a%2f%2fwww.ritstudio.com%2f%3futm_source%3dSweetPaul%26utm_medium%3dbanner%26utm_campaign%3dBrilliant"><img alt="RIT" src="/advertisting/320x40ads/rit_banner_ad_SP_320x40.jpg"   border="0" /></a>
+  </div>
+  </div></div>
+                            </div>
+                        </div>
+                        <!-- Header --><header >
+<div class="container hidden-xs">
+<div class="row social-header">
+<div class="col-md-16 col-lg-12 pull-right">
+<div>
+<a herf="/"><img class="ipad-logo visible-sm" src="/assets/images/SweetPaul-logo-green.png" alt="Sweet Paul Magazine"></a>
+<!-- Begin MailChimp Signup Form -->
+<form action="http://typepad.us1.list-manage.com/subscribe/post?u=76c630fcc622fc2a2220c35be&amp;id=bc982c5e21" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter-form" role="form" target="_blank">
+    <div class="mc-field-group form-group">
+    <label for="mce-EMAIL" class="sr-only">Email Address</label>
+    <div class="input-group margin-bottom-sm">
+    <span class="input-group-addon"><em class="fa fa-envelope-o fa-fw"></em>
+    </span>
+    <input type="email" id="mce-EMAIL" name="EMAIL" class="required email form-control input-sm" placeholder="enter your email to subscribe to our newsletter" />
+    </div>
+    </div>
+    <div id="mce-responses" class="clear">
+    <div class="response" id="mce-error-response" style="display: none;"></div>
+    <div class="response" id="mce-success-response" style="display: none;"></div>
+    </div>
+    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+    <div style="position: absolute; left: -5000px;">
+    <input type="text" name="b_76c630fcc622fc2a2220c35be_bc982c5e21" tabindex="-1" />
+    </div>
+    <input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button btn btn-default hidden" />
+</form>
+<!--End mc_embed_signup-->
+<div class="social-icons">
+<a href="http://www.facebook.com/sweetpaulmagazine" title="Sweet Paul on Facebook" target="_blank">
+<em class="fa fa-facebook-square"></em>
+</a>
+<a href="http://www.twitter.com/sweetpaul" title="Sweet Paul on Twitter" target="_blank">
+<em class="fa fa-twitter-square"></em>
+</a>
+<a href="http://www.pinterest.com/SweetPaul/" class="pre-etsy" title="Sweet Paul in Pinterest" target="_blank">
+<em class="fa fa-pinterest-square"></em>
+</a>
+<a href="https://www.etsy.com/pages/sweetpaulmagazine/?eref=sweetpaulmagazine" title="Sweet Paul Etsy Pages" target="_blank" id="etsy">
+</a>
+<a href="/rss" target="_self" title="Sweet Paul RSS Feed">
+<em class="fa fa-rss-square"></em>
+</a>
+</div>
+</div>
+</div>
+</div>
+</div>
+<!-- MENU -->
+
+<nav class="navbar navbar-default navbar-static-top" role="navigation" id="slide-nav" itemscope=
+"itemscope" itemtype="http://schema.org/SiteNavigationElement">
+<div class="container"><div class="navbar-header">
+    <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-main-collapse">
+     <span class="sr-only">Toggle navigation</span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+      <span class="icon-bar"></span>
+    </button>
+    <a href="/" class="navbar-brand hidden-sm"><img src="/assets/images/SweetPaul-logo-green.png" alt="Sweet Paul Magazine"></a>
+    </div>
+     
+<div id="slidemenu">
+
+  <!-- Everything you want hidden at 940px or less, place within here -->
+  <div class="navbar-collapse  navbar-main-collapse">
+    <ul class="nav navbar-nav"><li  class="eat-menu-item single-item" itemprop="url"><a href="/eat" title="Amazing recipes from the Sweet Paul archives" itemprop="name">EAT</a></li><li  class="make-menu-item single-item" itemprop="url"><a href="/make" title="Crafts and ideas for the home" itemprop="name">MAKE</a></li><li  class="kids-menu-item single-item" itemprop="url"><a href="/kids" title="Kids projects that are so fun!" itemprop="name">KIDS</a></li><li  class="blog-menu-item single-item" itemprop="url"><a href="/blog" title="Sweet Paul's personal blog" itemprop="name">BLOG</a></li><li  class="single-item" itemprop="url"><a href="http://sweetpaul.bigcartel.com/" title="" itemprop="name">SHOP</a></li><li  class="magazine-menu-item single-item" itemprop="url"><a href="/magazine" title="Sweet Paul Magazine" itemprop="name">MAGAZINE</a></li><li  class="news-menu-item single-item" itemprop="url"><a href="/news" title="" itemprop="name">NEWS</a></li><li  class="dropdown" itemprop="url"><a href="#" title="" itemprop="name">MORE</a><ul class="nav navbar-nav"><li   itemprop="url"><a href="/about" title="" itemprop="name">About Paul</a></li><li   itemprop="url"><a href="/contact" title="" itemprop="name">Contact Paul</a></li><li   itemprop="url"><a href="/RSS" title="" itemprop="name">RSS Feed</a></li><li   itemprop="url"><a href="/newsletter" title="Subscribe to our newsletter today!" itemprop="name">Newsletter</a></li><li   itemprop="url"><a href="/stockists" title="" itemprop="name">Stockists</a></li><li   itemprop="url"><a href="/advertising" title="" itemprop="name">Advertising</a></li>
+</ul></li><li  class="show-box" itemprop="url"><a href="#" title="" itemprop="name"><i class="fa fa-search"></i></a></li>
+</ul>
+          
+                  </div>
+
+                  <div class="clearfix"></div>
+      <div class="search-box">
+    <div class="row">
+    <div class="col-sm-16 col-lg-10 pull-right">
+            <form class="form-inline"  name="catsearchform92406" method="post" action="/Default.aspx?SiteSearchID=2422&amp;PageID=13043079" role="form">
+            <div class="form-group col-sm-20">
+             <div class="input-group">
+          <span class="input-group-addon"><i class="fa fa-search fa-fw"></i></span>
+          <input type="text" class="form-control" id="inputIcon2" placeholder="search..." name="CAT_Search" />
+
+
+        </div>
+        </div>
+        <button type="submit" class="btn btn-default">Find it!</button>
+              
+            
+        </form>
+    </div>
+    </div>
+</div>
+                  <div class="visible-xs">
+<!-- Begin MailChimp Signup Form -->
+<form action="http://typepad.us1.list-manage.com/subscribe/post?u=76c630fcc622fc2a2220c35be&amp;id=bc982c5e21" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate newsletter-form" role="form" target="_blank">
+    <div class="mc-field-group form-group">
+    <label for="mce-EMAIL" class="sr-only">Email Address</label>
+    <div class="input-group margin-bottom-sm">
+    <span class="input-group-addon"><em class="fa fa-envelope-o fa-fw"></em>
+    </span>
+    <input type="email" id="mce-EMAIL" name="EMAIL" class="required email form-control input-sm" placeholder="enter your email to subscribe to our newsletter" />
+    </div>
+    </div>
+    <div id="mce-responses" class="clear">
+    <div class="response" id="mce-error-response" style="display: none;"></div>
+    <div class="response" id="mce-success-response" style="display: none;"></div>
+    </div>
+    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+    <div style="position: absolute; left: -5000px;">
+    <input type="text" name="b_76c630fcc622fc2a2220c35be_bc982c5e21" tabindex="-1" />
+    </div>
+    <input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button btn btn-default hidden" />
+</form>
+<div class="clearfix"></div>
+<!--End mc_embed_signup-->
+<div class="social-icons">
+<a href="http://www.facebook.com/sweetpaulmagazine" title="Sweet Paul on Facebook" target="_blank">
+<em class="fa fa-facebook-square"></em>
+</a>
+<a href="http://www.twitter.com/sweetpaul" title="Sweet Paul on Twitter" target="_blank">
+<em class="fa fa-twitter-square"></em>
+</a>
+<a href="http://www.pinterest.com/SweetPaul/" class="pre-etsy" title="Sweet Paul in Pinterest" target="_blank">
+<em class="fa fa-pinterest-square"></em>
+</a>
+<a href="https://www.etsy.com/pages/sweetpaulmagazine/?eref=sweetpaulmagazine" title="Sweet Paul Etsy Pages" target="_blank" id="etsy">
+</a>
+<a href="/rss" target="_self" title="Sweet Paul RSS Feed">
+<em class="fa fa-rss-square"></em>
+</a>
+</div>
+</div>
+
+</div>
+       </div>
+ 
+</nav>
+
+       
+
+
+</header>
+                        <div id="page-content">
+
+<div id="main-detail" class="container hrecipe" >
+   <br>
+<section>
+<div class="row">
+    <div class="col-sm-16">
+     <h1 class="bordered fn">Tomato Tart with Basil Oil and Almond &amp; Pepper Crust</h1>
+</div>
+</div>
+    <div class="row">
+            <div class="col-sm-12">
+
+
+     <div class="main-content">
+                <div class="lead summary no-print" >
+                 <p>This tart is an instant classic, the crust is an amazing combination of the flavors from both almonds and ground pepper.</p><br/></div>
+<div class="main-description summary no-print">
+</div>
+
+<p class="yield"><strong>Makes 1 Tart</strong></p>
+         <div class="ingredients ingredient">
+
+           <p><strong>Almond and Pepper Crust:</strong><br /><br/>1 cup all­purpose flour<br /><br/>1/4 cup almond flour<br /><br/>1/2 teaspoon salt<br /><br/>1/4 teaspoon freshly ground pepper (I like my coarse)<br /><br/>1 stick cold butter, in pieces<br /><br/>ice cold water</p><br/><br/><p><br /><br/><strong>Filling:</strong><br /><br/>1 cup fresh ricotta<br /><br/>1/3 cup torn basil leafs<br /><br/>salt and pepper<br /><br/>sliced heirloom tomatoes<br /><br/>1/2 cup basil stalks and all<br /><br/>1/2 garlic clove<br /><br/>1/3 cup olive oil</p><br/>
+         </div>
+
+
+              <ol class="instructions" >
+   
+              <li> For the crust, place regular flour, almond flour, salt, pepper and butter in a large bowl.</li>
+              
+                
+              <li>Use your hands and work the butter into the flour, the mixture should be crumbly and grainy.</li>
+                     
+                
+              <li>Add ice water,just a little at a time until the dough holds together.</li>
+                     
+                
+              <li>Wrap in plastic and let it rest in the fridge for 1 hour. (You can make it a few days beforehand if you want)</li>
+                     
+                
+              <li>Roll it out between two sheets of parchment paper and cover a well greased tart pan.</li>
+                     
+                
+              <li>Prick the bottom with a fork and freeze for 15 minutes.</li>
+                     
+                
+              <li>Bake at 380F for about 15 minutes or until golden.</li>
+                     
+                
+              <li>Cool on a wire rack.</li>
+                     
+                
+              <li>For the filling, in a bowl mix ricotta and basil, season with salt and pepper and spread on top of the tart crust.</li>
+                     
+                
+              <li>Add the tomatoes on top.</li>
+                     
+                
+              <li>In a blender, blend together basil, garlic and oil, and salt to taste.</li>
+                     
+                
+              <li>Drizzle the oil over the tart and serve.</li>
+                     
+                
+                
+                
+                
+                
+                
+                
+                
+                
+                
+                
+                
+                
+          </ol>
+         <div class="tip">
+                     <h3 class="field">
+                         <strong>TIP:</strong>
+                     </h3>
+                     <div class="itemtxt"><p>In season, I love to use heirloom tomatos.  You can make this year-round, but it's best when the tomatos are at their sweetest!</p><br/></div>
+                 </div>
+              <div class="no-print">
+                    
+<script src="//www.chicoryapp.com/widget_v2/?
+location=below-recipe"></script>
+    
+                  <span class="field">
+                             <strong>Photography by</strong>
+                         </span>
+                         <span class="itemtxt">Paul "Sweet Paul" Lowe</span>
+
+                 <br> <br>
+                              <p class="lead brand-color comments"><em class="fa fa-comments-o"></em> Made it? Tell us about it– </p>
+                      <div class="disqus-comments">  <div id="disqus_thread"></div>
+</div>
+              </div>
+     </div>
+
+</div>
+
+        <div class="col-sm-10 col-sm-offset-1 no-print">
+
+            <div id="basic-gallery">
+            <div class="item">
+<div class="pin-wrapper">
+    <a class="pinit-button" href="http://www.pinterest.com/pin/create/button/
+           ?url=http://www.sweetpaulmag.com/food/tomato-tart-with-basil-oil-and-almond-amp-pepper-crust&media=https://sweetpaul.worldsecuresystems.com/1EatContent/images/2014/4625980_281271_tomtart1.jpg&description=Tomato Tart with Basil Oil and Almond &amp; Pepper Crust - http://www.sweetpaulmag.com/food/tomato-tart-with-basil-oil-and-almond-amp-pepper-crust %23sweetpaul"
+           data-pin-do="buttonPin" data-pin-config="none" data-pin-color="white"><img src="//assets.pinterest.com/images/pidgets/pinit_fg_en_rect_white_20.png" /></a>
+</div>
+            <img  class="photo" src="/1EatContent/images/2014/4625980_281271_tomtart1.jpg?Action=thumbnail&Width=512&Height=640&algorithm=fill_proportional" alt="Tomato Tart with Basil Oil and Almond &amp; Pepper Crust" alt="Tomato Tart with Basil Oil and Almond &amp; Pepper Crust"></div>
+<div class="item">
+<div class="pin-wrapper">
+    <a class="pinit-button" href="http://www.pinterest.com/pin/create/button/
+           ?url=http://www.sweetpaulmag.com/food/tomato-tart-with-basil-oil-and-almond-amp-pepper-crust&media=https://sweetpaul.worldsecuresystems.com/1EatContent/images/2014/4625980_281272_tomtart2.jpg&description=Tomato Tart with Basil Oil and Almond &amp; Pepper Crust - http://www.sweetpaulmag.com/food/tomato-tart-with-basil-oil-and-almond-amp-pepper-crust %23sweetpaul"
+           data-pin-do="buttonPin" data-pin-config="none" data-pin-color="white"><img src="//assets.pinterest.com/images/pidgets/pinit_fg_en_rect_white_20.png" /></a>
+</div>
+<img src="/1EatContent/images/2014/4625980_281272_tomtart2.jpg?Action=thumbnail&Width=512&Height=640&algorithm=fill_proportional" alt="Tomato Tart with Basil Oil and Almond &amp; Pepper Crust"></div>
+<div class="item">
+<div class="pin-wrapper">
+    <a class="pinit-button" href="http://www.pinterest.com/pin/create/button/
+           ?url=http://www.sweetpaulmag.com/food/tomato-tart-with-basil-oil-and-almond-amp-pepper-crust&media=https://sweetpaul.worldsecuresystems.com/1EatContent/images/2014/4625980_281273_tomtart3.jpg&description=Tomato Tart with Basil Oil and Almond &amp; Pepper Crust - http://www.sweetpaulmag.com/food/tomato-tart-with-basil-oil-and-almond-amp-pepper-crust %23sweetpaul"
+           data-pin-do="buttonPin" data-pin-config="none" data-pin-color="white"><img src="//assets.pinterest.com/images/pidgets/pinit_fg_en_rect_white_20.png" /></a>
+</div><img  src="/1EatContent/images/2014/4625980_281273_tomtart3.jpg?Action=thumbnail&Width=512&Height=640&algorithm=fill_proportional" alt="Tomato Tart with Basil Oil and Almond &amp; Pepper Crust"></div>
+<div class="item">
+<div class="pin-wrapper">
+    <a class="pinit-button" href="http://www.pinterest.com/pin/create/button/
+           ?url=http://www.sweetpaulmag.com/food/tomato-tart-with-basil-oil-and-almond-amp-pepper-crust&media=https://sweetpaul.worldsecuresystems.com&description=Tomato Tart with Basil Oil and Almond &amp; Pepper Crust - http://www.sweetpaulmag.com/food/tomato-tart-with-basil-oil-and-almond-amp-pepper-crust %23sweetpaul"
+           data-pin-do="buttonPin" data-pin-config="none" data-pin-color="white"><img src="//assets.pinterest.com/images/pidgets/pinit_fg_en_rect_white_20.png" /></a>
+</div>
+<img  src="?Action=thumbnail&Width=512&Height=640&algorithm=fill_proportional" alt="Tomato Tart with Basil Oil and Almond &amp; Pepper Crust">
+</div>
+<div class="item">
+<div class="pin-wrapper">
+    <a class="pinit-button"  href="http://www.pinterest.com/pin/create/button/
+           ?url=http://www.sweetpaulmag.com/food/tomato-tart-with-basil-oil-and-almond-amp-pepper-crust&media=https://sweetpaul.worldsecuresystems.com&description=Tomato Tart with Basil Oil and Almond &amp; Pepper Crust - http://www.sweetpaulmag.com/food/tomato-tart-with-basil-oil-and-almond-amp-pepper-crust %23sweetpaul"
+           data-pin-do="buttonPin" data-pin-config="none" data-pin-color="white"><img src="//assets.pinterest.com/images/pidgets/pinit_fg_en_rect_white_20.png" /></a>
+</div>
+<img src="?Action=thumbnail&Width=512&Height=640&algorithm=fill_proportional" alt="Tomato Tart with Basil Oil and Almond &amp; Pepper Crust"></div>
+            </div>
+
+
+<div class="row">
+  <div class="col-sm-24">
+  <br>
+         <hr>
+      <h4> You May Also Like: </h4> <div class="row multi-columns-row"><div class="col-xs-12 col-sm-12 col-md-12 col-lg-8">
+  <a href="http://www.sweetpaulmag.com/food/quick-tomato-puff-pastry-pizza"><img alt="Quick Tomato Puff Pastry Pizza" src="/1EatContent/images/2014/4998984_281271_Puff1.jpg?Action=thumbnail&Width=214&Height=267&algorithm=fill_proportional" /> </a>
+  <p><a href="/food/quick-tomato-puff-pastry-pizza" class="data-txt" data-len="60">Quick Tomato Puff Pastry Pizza</a></p>
+</div><div class="col-xs-12 col-sm-12 col-md-12 col-lg-8">
+  <a href="http://www.sweetpaulmag.com/food/bishop-s-weed-quiche"><img alt="Bishop’s Weed Quiche" src="/1EatContent/images/2014/4998408_281271_Quiche_01.jpg?Action=thumbnail&Width=214&Height=267&algorithm=fill_proportional" /> </a>
+  <p><a href="/food/bishop-s-weed-quiche" class="data-txt" data-len="60">Bishop’s Weed Quiche</a></p>
+</div><div class="col-xs-12 col-sm-12 col-md-12 col-lg-8">
+  <a href="http://www.sweetpaulmag.com/food/mushroom-amp-ramp-tart-with-asiago"><img alt="Mushroom &amp; Ramp Tart with Asiago" src="/1EatContent/images/2014/4990509_281271_Tart_01.jpg?Action=thumbnail&Width=214&Height=267&algorithm=fill_proportional" /> </a>
+  <p><a href="/food/mushroom-amp-ramp-tart-with-asiago" class="data-txt" data-len="60">Mushroom &amp; Ramp Tart with Asiago</a></p>
+</div><div class="col-xs-12 col-sm-12 col-md-12 col-lg-8">
+  <a href="http://www.sweetpaulmag.com/food/breakfast-bread-pudding-amp-fiesta-cofee"><img alt="Breakfast Bread Pudding &amp; Fiesta Coffee" src="/1EatContent/images/2014/4983884_281271_Fiesta2.jpg?Action=thumbnail&Width=214&Height=267&algorithm=fill_proportional" /> </a>
+  <p><a href="/food/breakfast-bread-pudding-amp-fiesta-cofee" class="data-txt" data-len="60">Breakfast Bread Pudding &amp; Fiesta Coffee</a></p>
+</div><div class="col-xs-12 col-sm-12 col-md-12 col-lg-8">
+  <a href="http://www.sweetpaulmag.com/food/savory-bread-pudding-with-delicata-squash-kale-amp-sausage"><img alt="Savory Bread Pudding with Delicata Squash, Kale, &amp; Sausage" src="/1EatContent/images/2014/4695633_281271_breadpu1.jpg?Action=thumbnail&Width=214&Height=267&algorithm=fill_proportional" /> </a>
+  <p><a href="/food/savory-bread-pudding-with-delicata-squash-kale-amp-sausage" class="data-txt" data-len="60">Savory Bread Pudding with Delicata Squash, Kale, &amp; Sausage</a></p>
+</div><div class="col-xs-12 col-sm-12 col-md-12 col-lg-8">
+  <a href="http://www.sweetpaulmag.com/food/tomato-tart-with-basil-oil-and-almond-amp-pepper-crust"><img alt="Tomato Tart with Basil Oil and Almond &amp; Pepper Crust" src="/1EatContent/images/2014/4625980_281271_tomtart1.jpg?Action=thumbnail&Width=214&Height=267&algorithm=fill_proportional" /> </a>
+  <p><a href="/food/tomato-tart-with-basil-oil-and-almond-amp-pepper-crust" class="data-txt" data-len="60">Tomato Tart with Basil Oil and Almond &amp; Pepper Crust</a></p>
+</div><div class="col-xs-12 col-sm-12 col-md-12 col-lg-8">
+  <a href="http://www.sweetpaulmag.com/food/asparagus-cheese-tarts-with-honey"><img alt="Asparagus &amp; Cheese Tarts with Honey" src="/1EatContent/images/2014/4606161_281271_AspT1.jpg?Action=thumbnail&Width=214&Height=267&algorithm=fill_proportional" /> </a>
+  <p><a href="/food/asparagus-cheese-tarts-with-honey" class="data-txt" data-len="60">Asparagus &amp; Cheese Tarts with Honey</a></p>
+</div><div class="col-xs-12 col-sm-12 col-md-12 col-lg-8">
+  <a href="http://www.sweetpaulmag.com/food/asparagus-amp-lemon-ricotta-tartlets"><img alt="Asparagus &amp; Lemon Ricotta Tartlets" src="/1EatContent/images/2012/4605528_281271_tartlet1.jpg?Action=thumbnail&Width=214&Height=267&algorithm=fill_proportional" /> </a>
+  <p><a href="/food/asparagus-amp-lemon-ricotta-tartlets" class="data-txt" data-len="60">Asparagus &amp; Lemon Ricotta Tartlets</a></p>
+</div><div class="col-xs-12 col-sm-12 col-md-12 col-lg-8">
+  <a href="http://www.sweetpaulmag.com/food/egg-amp-potato-pot-pie"><img alt="Egg &amp; Potato Pot Pie" src="/1EatContent/images/2012/4541222_281271_Pie1.jpg?Action=thumbnail&Width=214&Height=267&algorithm=fill_proportional" /> </a>
+  <p><a href="/food/egg-amp-potato-pot-pie" class="data-txt" data-len="60">Egg &amp; Potato Pot Pie</a></p>
+</div><ul id="webapp16929pagination" class="pagination webapp">
+<li class="pag-current">1</li>
+<li class="pag-number"><a href="/food/tomato-tart-with-basil-oil-and-almond-amp-pepper-crust?A=WebApp&amp;CCID=16929&amp;Page=2&amp;Items=9">2</a></li>
+<li class="pag-number"><a href="/food/tomato-tart-with-basil-oil-and-almond-amp-pepper-crust?A=WebApp&amp;CCID=16929&amp;Page=3&amp;Items=9">3</a></li>
+<li class="pag-next"><a href="/food/tomato-tart-with-basil-oil-and-almond-amp-pepper-crust?A=WebApp&amp;CCID=16929&amp;Page=2&amp;Items=9">Next</a></li>
+</ul>
+ </div>
+              <br>
+         <hr>
+  </div>
+</div>
+
+</div>
+
+    </div>
+
+</section>
+</div>
+
+<script type="application/ld+json">
+{
+  "@context": "http://schema.org",
+  "@type": "Recipe",
+  "author": "Sweet Paul",
+  "datePublished": "2014-07-01",
+  "description": "
+",
+  "image": "/1EatContent/images/2014/4625980_281271_tomtart1.jpg",
+    "name": "Tomato Tart with Basil Oil and Almond &amp; Pepper Crust",
+  "ingredients": [
+      "Almond and Pepper Crust","1 cup all­purpose flour","1/4 cup almond flour","1/2 teaspoon salt","1/4 teaspoon freshly ground pepper (I like my coarse)","1 stick cold butter, in pieces","ice cold water" ,"","Filling","1 cup fresh ricotta","1/3 cup torn basil leafs","salt and pepper","sliced heirloom tomatoes","1/2 cup basil stalks and all","1/2 garlic clove","1/3 cup olive oil" , ""
+  ],
+"recipeInstructions": "For the crust, place regular flour, almond flour, salt, pepper and butter in a large bowl. Use your hands and work the butter into the flour, the mixture should be crumbly and grainy.   Add ice water,just a little at a time until the dough holds together.   Wrap in plastic and let it rest in the fridge for 1 hour. (You can make it a few days beforehand if you want)   Roll it out between two sheets of parchment paper and cover a well greased tart pan.   Prick the bottom with a fork and freeze for 15 minutes.   Bake at 380F for about 15 minutes or until golden.    Cool on a wire rack.    For the filling, in a bowl mix ricotta and basil, season with salt and pepper and spread on top of the tart crust.   Add the tomatoes on top.   In a blender, blend together basil, garlic and oil, and salt to taste.   Drizzle the oil over the tart and serve.                 ",
+ "recipeYield": "Makes 1 Tart"
+}
+</script>
+<script type="text/javascript" src="//s7.addthis.com/js/300/addthis_widget.js#pubid=ra-5356b73e74b81a5a"></script>
+
+                            <!-- Footer --><footer>
+<div class="container">
+<div class="row">
+    <div class="col-sm-6"><img src="/assets/images/sweetpaul-logo-grey.png" data-pin-no-hover="true" alt="Sweet Paul Magazine" /></div>
+</div>
+<div class="row">
+<div class="col-sm-6">
+<h3> Subscribe</h3>
+<!-- Begin MailChimp Signup Form -->
+<form action="http://typepad.us1.list-manage.com/subscribe/post?u=76c630fcc622fc2a2220c35be&amp;id=bc982c5e21" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" role="form" target="_blank">
+    <div class="mc-field-group form-group">
+    <label for="mce-EMAIL" class="sr-only">Email</label>
+
+    <input type="email" id="mce-EMAIL" name="EMAIL" class="required email form-control input-sm" placeholder="Enter your email" />
+    </div>
+    <div id="mce-responses" class="clear">
+    <div class="response" id="mce-error-response" style="display: none;"></div>
+    <div class="response" id="mce-success-response" style="display: none;"></div>
+    </div>
+    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+    <div style="position: absolute; left: -5000px;">
+    <input type="text" name="b_76c630fcc622fc2a2220c35be_bc982c5e21" tabindex="-1" />
+    </div>
+    <input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button btn btn-default btn-sm" />
+</form>
+<!--End mc_embed_signup-->
+<h3>Follow Paul </h3>
+<div class="follow-icons">
+    
+<a href="http://www.facebook.com/sweetpaulmagazine" target="_blank" title="Sweet Paul on Facebook"><img src="/assets/images/social-square-facebook.png" alt="Sweet Paul on Facebook" data-pin-no-hover="true" /></a>
+    <a href="http://www.twitter.com/sweetpaul" target="_blank" data-pin-no-hover="true" title="Sweet Paul on Twitter"><img src="/assets/images/social-square-twitter.png" data-pin-no-hover="true" alt="Sweet Paul on Twitter"></a>
+    <a href="http://www.pinterest.com/sweetpaul" target="_blank" title="Sweet Paul on Pinterest"><img src="/assets/images/social-square-pinterest.png" alt="Sweet Paul on Pinterest"></a>
+    <a href="https://plus.google.com/112095940219950915119/posts" target="_blank" title="Sweet Paul on Google+"><img src="/assets/images/social-square-google.png" data-pin-no-hover="true" alt="Sweet Paul on Google Plus"></a>
+    <a href="http://instagram.com/sweetpaulmagazine" target="_blank" title="Sweet Paul on Instagram"><img src="/assets/images/social-square-instagram.png" alt="Sweet Paul on Instagram"></a>
+    <a href="https://www.etsy.com/pages/sweetpaulmagazine" target="_blank" title="Sweet Paul on Etsy"><img src="/assets/images/social-square-etsy.png" alt="Sweet Paul on Etsy"></a>
+</div>
+</div>
+<div class="col-sm-10">
+<h3>About Paul</h3>
+<p>Paul “Sweet Paul” Lowe is guided by his grandmother, Mormor’s, motto: “fullkommenhet er kjedelig” -- “perfection is boring”. Born in Oslo, his Mormor and Great Auntie Gunnvor instilled in him a love for cooking and crafting that carried over to his career in New York as a food and props stylist, and eventually the creative guru behind the quarterly Sweet Paul Magazine. Flipping through the pages of his eponymous magazine, you’ll be riveted by beautiful culinary and crafting ideas that remain humble and accessible -- but never boring!
+</p>
+<h3>About the Magazine</h3>
+<p>Sweet Paul Magazine is a lifestyle magazine for anyone
+looking to make simple, elegant meals and stylishly easy
+crafts for the home. We're about homemade and handmade, and we're
+helping our readers create a one-of-a-kind style for life&rsquo;s
+every day occasions.</p>
+
+<p>
+    &copy;
+    <script type="text/javascript">
+                    var cur = 2014;
+                    var year = new Date();
+                    if (cur == year.getFullYear()) year = year.getFullYear();
+                    else year = cur + ' - ' + year.getFullYear();
+                    document.write(year);
+                    </script>
+    Sweet Paul Magazine <br>
+    website by
+    <a target="_blank" style="color: #897975 !important;" href="http://www.tinymill.com">tinymill.com</a>
+</p>
+</div>
+<div class="col-sm-6 col-lg-offset-1">
+<nav itemscope="itemscope" itemtype="http://schema.org/SiteNavigationElement">
+    <ul class="list-unstyled">
+        <li itemprop="url">
+        <a itemprop="name" href="/">Home </a>
+        </li>
+        <li itemprop="url"> <a itemprop="name" href="/eat"> Eat </a>
+        </li>
+        <li itemprop="url"><a itemprop="name" href="/make">Make</a></li>
+        <li itemprop="url"><a itemprop="name" href="/kids">Kids</a></li>
+        <li itemprop="url"><a itemprop="name" href="/blog">Blog</a></li>
+        <li itemprop="url">
+        <a itemprop="name" href="/news">News </a>
+        </li>
+        <li itemprop="url">
+        <a itemprop="name" href="/issues"> Magazine</a>
+        </li>
+        <li itemprop="url">
+        <a itemprop="name" target="_blank" href="http://sweetpaul.bigcartel.com/">
+        Shop
+        </a>
+        </li>
+      
+    </ul>
+<ul class="list-unstyled">
+      <li itemprop="url">
+        <a itemprop="name" href="/about">    About Paul    </a>
+        </li>
+        <li itemprop="url">
+        <a itemprop="name" href="/contact">
+        Contact Paul
+        </a>
+        </li>
+        <li itemprop="url">
+        <a itemprop="name" href="/RSS">    RSS </a>
+        </li>
+        <li itemprop="url">
+        <a itemprop="name" href="/stockists">    Stockists </a>
+        </li>
+        <li itemprop="url">
+        <a itemprop="name" href="/advertising">    Advertising </a>
+        </li>
+        
+        <li itemprop="url"> <a itemprop="name" href="/privacy-policy"> Privacy Policy </a>
+        </li>
+       <!--  <li> <a itemprop="name" href="#"> Sitemap </a>
+        </li> -->
+</ul>
+</nav>
+</div>
+</div>
+</div>
+</footer></div>
+                        <script src="/assets/js/main-ck.js">
+                            
+                        </script>
+                        <script type="text/javascript" src="//assets.pinterest.com/js/pinit.js"></script>
+                        <script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-35665137-3', 'sweetpaulmag.com');
+ga('require', 'displayfeatures');
+ga('require', 'linkid', 'linkid.js');
+  ga('send', 'pageview');
+
+</script>
+
+                        <script type="text/javascript">
+                            /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
+                            var disqus_shortname = 'sweetpaulcomments'; // required: replace example with your forum shortname
+
+                            /* * * DON'T EDIT BELOW THIS LINE * * */ (function() {
+                                var dsq = document.createElement('script');
+                                dsq.type = 'text/javascript';
+                                dsq.async = true;
+                                dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+                                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+                            })();
+                        </script>
+                        <script type="text/javascript" src="http://wms.assoc-amazon.com/20070822/US/js/autotagger.js?tag=swepaumag-20&locale=US&overwrite=Y">
+</script> 
+                    
+
+                    
+                    
+</body>
+</html>


### PR DESCRIPTION
# Change Summary
1. Added new parser for recipes using JSON-LD formatting in the context of schema.org
2. Changed the cleaning of html so as not to remove scripts (which we need). Note that we probably _could_ have done something slightly more sophisticated, like only excluding JSON-LD scripts from cleaning. However, this would have added considerable work, and the benefits at this time are not obvious, since the only reason stated (by OneTsp) for stripping scripts in the first place is `they don't accidentally get executed if we ever display clipped content to end-users`. I think this is OK for now.
3. Added support for ISO_8601 duration formatting (to help us pick up cook/prep times)

# Release Notes
1. We need to make sure that when the scraper gets redeployed, it picks up these changes.
2. Sweet Paul needs all his recipes deleted; broken recipes came in because we didn't pick up JSON-LD.

# Testing
1. Tested with three fake recipes:
    - One with an JSON-LD script provided by Google
    - One with an JSON-LD script provided by Brecht
    - One with a recipe not containing a JSON-LD script