### PR TITLE
CORE-1818: Parsing Image Objects for JSON LD Format

### DIFF
--- a/lib/RecipeParser/Parser/MicrodataJsonLd.php
+++ b/lib/RecipeParser/Parser/MicrodataJsonLd.php
@@ -80,6 +80,9 @@ class RecipeParser_Parser_MicrodataJsonLd {
         // Photo
         if (property_exists($data, "image")) {
             $photo_url = $data->image;
+            if (is_object($photo_url)) {
+                $photo_url = $data->image->url;
+            }
             $recipe->photo_url = RecipeParser_Text::relativeToAbsolute($photo_url, $url);
         }
     


### PR DESCRIPTION
## Change Summary
The parser was failing to read the Micro format JSON LD since the image were provided as an object. We now check to see if an image is an object and if it is, we attempt to get the URL attribute of that object.

## Release Notes
None.

## Testing

We should now be able to scrape recipes on HappyFoods Tubes. Tested with https://www.happyfoodstube.com/baked-curry-chicken-wings-with-mango-chutney/. One can use the  QA recipe parser to verify this at http://qa-scraper.chicoryapp.com.