### PR TITLE
CORE-1855: Fix realsimple.com scraper

### DIFF
--- a/lib/RecipeParser/Parser/parsers.ini
+++ b/lib/RecipeParser/Parser/parsers.ini
@@ -114,10 +114,6 @@ parser = "Nytimescom"
 pattern = "pillsbury.com"
 parser = "Pillsburycom"
 
-[Real Simple]
-pattern = "realsimple.com"
-parser = "Realsimplecom"
-
 [Recipe.com]
 pattern = "recipe.com"
 parser = "Recipecom"


### PR DESCRIPTION
## Change Summary
The custom scrape logic for the publisher RealSimple was removed from configuration. However, the actual code still remains in the repository.

## Release Notes
None. These are non breaking changes.

## Testing
We need to make sure that the parser is able to find and parse the recipes on realsimple.com.