### PR TITLE
Core 1855: Fix realsimple.com scraper

### DIFF
--- a/lib/RecipeParser/Parser/MicrodataJsonLd.php
+++ b/lib/RecipeParser/Parser/MicrodataJsonLd.php
@@ -59,7 +59,6 @@ class RecipeParser_Parser_MicrodataJsonLd {
         if (!$ingredients) {
             $ingredients = property_exists($data, "ingredients") ? $data->ingredients : [];
         }
-        
         foreach ($ingredients as $ingredient) {
             $ingredient = RecipeParser_Text::formatAsOneLine($ingredient);
             if (empty($ingredient)) {
@@ -80,16 +79,13 @@ class RecipeParser_Parser_MicrodataJsonLd {
         // Photo
         if (property_exists($data, "image")) {
             $photo_url = $data->image;
+
             if (is_array($photo_url)) {
                 $first_element = array_values($photo_url)[0];
-                if ($first_element) {
-                    if (property_exists($first_element, "url")) {
-                        $photo_url = $first_element->url;
-                    }
-                }
+                $photo_url = $first_element;
             }
             if (is_object($photo_url)) {
-                $photo_url = $data->image->url;
+                $photo_url = $photo_url->url;
             }
             $recipe->photo_url = RecipeParser_Text::relativeToAbsolute($photo_url, $url);
         }

--- a/lib/RecipeParser/Parser/MicrodataJsonLd.php
+++ b/lib/RecipeParser/Parser/MicrodataJsonLd.php
@@ -80,6 +80,15 @@ class RecipeParser_Parser_MicrodataJsonLd {
         // Photo
         if (property_exists($data, "image")) {
             $photo_url = $data->image;
+            if (is_object($photo_url)) {
+                $photo_url = $data->image->url;
+            }
+            if (is_array($photo_url)) {
+                $first_element = array_values($photo_url)[0];
+                if ($first_element) {
+                    $photo_url = $first_element->url;
+                }
+            }
             $recipe->photo_url = RecipeParser_Text::relativeToAbsolute($photo_url, $url);
         }
     

--- a/lib/RecipeParser/Parser/MicrodataJsonLd.php
+++ b/lib/RecipeParser/Parser/MicrodataJsonLd.php
@@ -80,14 +80,16 @@ class RecipeParser_Parser_MicrodataJsonLd {
         // Photo
         if (property_exists($data, "image")) {
             $photo_url = $data->image;
-            if (is_object($photo_url)) {
-                $photo_url = $data->image->url;
-            }
             if (is_array($photo_url)) {
                 $first_element = array_values($photo_url)[0];
                 if ($first_element) {
-                    $photo_url = $first_element->url;
+                    if (property_exists($first_element, "url")) {
+                        $photo_url = $first_element->url;
+                    }
                 }
+            }
+            if (is_object($photo_url)) {
+                $photo_url = $data->image->url;
             }
             $recipe->photo_url = RecipeParser_Text::relativeToAbsolute($photo_url, $url);
         }

--- a/lib/RecipeParser/Parser/parsers.ini
+++ b/lib/RecipeParser/Parser/parsers.ini
@@ -114,10 +114,6 @@ parser = "Nytimescom"
 pattern = "pillsbury.com"
 parser = "Pillsburycom"
 
-[Real Simple]
-pattern = "realsimple.com"
-parser = "Realsimplecom"
-
 [Recipe.com]
 pattern = "recipe.com"
 parser = "Recipecom"

--- a/lib/RecipeParser/Parser/parsers.ini
+++ b/lib/RecipeParser/Parser/parsers.ini
@@ -102,10 +102,6 @@ parser = "Kingarthurflourcom"
 pattern = "marthastewart.com"
 parser = "Marthastewartcom"
 
-[MyRecipes.com]
-pattern = "myrecipes.com"
-parser = "Myrecipescom"
-
 [New York Times]
 pattern = "nytimes.com"
 parser = "Nytimescom"


### PR DESCRIPTION
## Change Summary
For the JSON-LD format, if we run into images that are of Array type, we now attempt to access the first element of the array and extract the 'url' attribute.

## Release Notes
None.

## Testing
We need to make sure that we can scrape www.cookinglight.com recipes successfully.