### PR TITLE
CORE-1849: Custom Scraper for Time Inc. Sites

### DIFF
--- a/lib/RecipeParser/Parser/MicrodataJsonLd.php
+++ b/lib/RecipeParser/Parser/MicrodataJsonLd.php
@@ -7,7 +7,17 @@ class RecipeParser_Parser_MicrodataJsonLd {
         $xpath = new DOMXPath($doc);
         
         $jsonScripts = $xpath->query('//script[@type="application/ld+json"]');
-        $json = trim( $jsonScripts->item(0)->nodeValue );
+        // we iterate over all ld+json script elements to find the correct one containing a Recipe object.
+        if ($jsonScripts->length > 1) {
+            foreach ($jsonScripts as $script) {
+                $json = trim( $script->nodeValue );
+                if (!preg_match('/["|\']@type["|\']:["|\']Recipe["|\']/', $json) and !preg_match('/["|\']type["|\']:["|\']Recipe["|\']/', $json)) {
+                    continue;
+                }
+            }
+        } else {
+            $json = trim( $jsonScripts->item(0)->nodeValue );
+        }
         $json = RecipeParser_Text::cleanJson($json);
         $data = json_decode( $json );
         

--- a/lib/RecipeParser/Text.php
+++ b/lib/RecipeParser/Text.php
@@ -97,6 +97,7 @@ ONETSP_TIME: $time
     static public function cleanupClippedRecipeHtmlWithScripts($html) {
         $html = self::normalize($html);
         $html = RecipeParser_Text::stripConditionalComments($html);
+        $html = RecipeParser_Text::cleanupSVGs($html);
         return $html;
     }
     
@@ -112,8 +113,6 @@ ONETSP_TIME: $time
      * @return string HTML
      */
     static public function cleanupSVGs($html) {
-        $html = self::normalize($html);
-
         // Strip out SVG tags so they don't accidentally get executed if we ever display
         // clipped content to end-users.
         $html = RecipeParser_Text::stripTagAndContents('svg', $html);


### PR DESCRIPTION
## Change Summary
The Micro format JSON LD was attempting to find a <script> element with content of a JSON feed content-type application/ld+json but neglected to verify that the JSON object has a @type attribute of a Recipe. We now attempt to find all scripts objects on the page with a ld+json content-type and if we find more than 1, we iterate over the objects searching for one that contains a type of 'Recipe'. 

## Release Notes
This release should fix the southernliving.com recipe scrape.

## Testing
We need to make sure that by adding this feature, we did not break anything. We should test the scraper capability on sites formatting using json-ld Recipe format.