### PR TITLE
CORE-1863: Daily Meal Not Scraping

### DIFF
--- a/lib/RecipeParser/Parser/parsers.ini
+++ b/lib/RecipeParser/Parser/parsers.ini
@@ -138,10 +138,6 @@ parser = "Sparkpeoplecom"
 pattern = "tasteofhome.com"
 parser = "Tasteofhomecom"
 
-[The Daily Meal]
-pattern = "thedailymeal.com"
-parser = "Thedailymealcom"
-
 [The Kitchn]
 pattern = "thekitchn.com"
 parser = "Thekitchencom"


### PR DESCRIPTION
## Change Summary
We have removed the TheDailyMeal custom scraper and are now allowing the system to scrape them using the JSON-LD scraper.

## Release Notes
This should not  break any processes and does not require additional actions.

## Testing
We need to make sure that we can scrape recipes on TheDailyMeal. The change in this ticket is already pushed to QA and so we can use the QA scraper to make sure that we can scrape their recipes - http://qa-scraper.chicoryapp.com/